### PR TITLE
[DEVELOP] fix PM Cycle QA PASS detection false positives

### DIFF
--- a/develop_report/2026-02-19_pm_cycle_qapass_detection_fix_report.md
+++ b/develop_report/2026-02-19_pm_cycle_qapass_detection_fix_report.md
@@ -1,0 +1,50 @@
+# 2026-02-19 PM Cycle QA PASS Detection Fix Report
+
+## 1) 이슈
+- 대상: `#46 [DEVELOP] PM Cycle QA PASS 탐지 오탐 방지(엄격 패턴 매칭)`
+- Report-Path: `develop_report/2026-02-19_pm_cycle_qapass_detection_fix_report.md`
+
+## 2) 문제
+- 기존 PM Cycle은 `grep '\[QA PASS\]'` 단순 포함 검색으로 판정함
+- 안내문구/백틱 예시 텍스트의 `[QA PASS]`도 PASS로 오탐 가능
+
+## 3) 수정 내용
+1. 엄격 판정 로직 분리
+- 파일: `scripts/pm/qapass_detection.py` (신규)
+- 규칙: 라인 시작 토큰 `^[QA PASS]`만 유효
+- 입력: `gh issue view --json comments` 결과(JSON)
+
+2. PM Cycle 적용
+- 파일: `scripts/pm/pm_cycle_dry_run.sh`
+- 변경:
+  - `has_qa_pass_comment()` 함수 추가
+  - 기존 `grep` 포함 검색 제거
+  - Python detector 반환코드 기반으로 `MISSING_QA_PASS` 판정
+
+3. 회귀 테스트 추가
+- 파일: `tests/test_pm_cycle_qapass_detection.py`
+- 케이스:
+  - 실제 PASS 코멘트: 인식해야 함
+  - 안내문구 포함 `[QA PASS]`: 인식하면 안 됨
+  - 백틱 텍스트 `` `[QA PASS]` ``: 인식하면 안 됨
+
+4. 운영 문서 반영
+- 파일: `docs/07_GITHUB_CLI_COLLAB_WORKFLOW.md`
+- 추가: `6-1) QA PASS 코멘트 표준 포맷`
+
+## 4) 검증
+1. 정적 검증
+- `python3 -m py_compile scripts/pm/qapass_detection.py` 통과
+- `bash -n scripts/pm/pm_cycle_dry_run.sh` 통과
+
+2. 테스트
+- `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q tests/test_pm_cycle_qapass_detection.py` -> `3 passed`
+- `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q` -> `47 passed`
+
+## 5) DoD 대응
+1. 오탐 재현 케이스에서 PASS 미인식
+- 충족 (안내문구/백틱 케이스)
+2. 실제 QA PASS 코멘트 정상 인식
+- 충족
+3. 보고서 제출
+- 충족 (본 문서)

--- a/docs/07_GITHUB_CLI_COLLAB_WORKFLOW.md
+++ b/docs/07_GITHUB_CLI_COLLAB_WORKFLOW.md
@@ -52,6 +52,17 @@ bash scripts/pm/report_scan.sh --date 2026-02-18
 2. `status/done` 전환 전 필수 조건: QA PASS 코멘트
 3. QA FAIL/WARN이면 원인 진단 기준으로 담당자 재할당 후 `status/in-progress`로 복귀
 
+## 6-1) QA PASS 코멘트 표준 포맷
+1. 자동 판정은 줄 시작 토큰 `\[QA PASS\]`만 유효로 본다.
+2. 허용 예시:
+```text
+[QA PASS]
+- 회귀 테스트 통과
+```
+3. 비허용 예시(오탐 방지):
+- 안내문구 안의 텍스트: `status/done 전에 [QA PASS] 필요`
+- 백틱 예시 텍스트: `` `[QA PASS]` ``
+
 ## 6-1) 작업영역 락 규칙
 1. 상세 규칙은 `docs/10_WORKSPACE_LOCK_POLICY.md`를 기준으로 적용
 2. 공용 잠금 경로(`docs/**`, `.github/**`, `scripts/pm/**`, `README.md`) 수정은 PM 승인 코멘트 필수

--- a/scripts/pm/qapass_detection.py
+++ b/scripts/pm/qapass_detection.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from typing import Any
+
+QA_PASS_LINE_RE = re.compile(r"(?m)^\[QA PASS\](?:\s|$)")
+
+
+def has_qa_pass_comment(comment_bodies: list[str]) -> bool:
+    for body in comment_bodies:
+        if QA_PASS_LINE_RE.search(body):
+            return True
+    return False
+
+
+def _extract_bodies_from_issue_json(payload: dict[str, Any]) -> list[str]:
+    comments = payload.get("comments", [])
+    out: list[str] = []
+    for item in comments:
+        body = item.get("body")
+        if isinstance(body, str):
+            out.append(body)
+    return out
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Strict QA PASS comment detector")
+    parser.add_argument(
+        "--mode",
+        default="issue-json",
+        choices=("issue-json", "comments-array"),
+        help="input payload mode",
+    )
+    args = parser.parse_args()
+
+    raw = sys.stdin.read()
+    if not raw.strip():
+        return 1
+
+    payload = json.loads(raw)
+    if args.mode == "comments-array":
+        if not isinstance(payload, list):
+            raise ValueError("comments-array mode expects JSON string array")
+        bodies = [x for x in payload if isinstance(x, str)]
+    else:
+        if not isinstance(payload, dict):
+            raise ValueError("issue-json mode expects object with comments[].body")
+        bodies = _extract_bodies_from_issue_json(payload)
+
+    return 0 if has_qa_pass_comment(bodies) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_pm_cycle_qapass_detection.py
+++ b/tests/test_pm_cycle_qapass_detection.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "pm" / "qapass_detection.py"
+
+
+def run_detector(issue_json: dict) -> int:
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--mode", "issue-json"],
+        input=json.dumps(issue_json, ensure_ascii=False),
+        text=True,
+        cwd=ROOT,
+        check=False,
+    )
+    return proc.returncode
+
+
+def test_detects_real_qa_pass_comment() -> None:
+    payload = {
+        "comments": [
+            {"body": "중간 점검"},
+            {"body": "[QA PASS]\n- 회귀 테스트 통과"},
+        ]
+    }
+    assert run_detector(payload) == 0
+
+
+def test_ignores_guidance_text_with_qapass_token() -> None:
+    payload = {
+        "comments": [
+            {"body": "안내: status/done 전환 전 [QA PASS] 코멘트를 남겨주세요."},
+        ]
+    }
+    assert run_detector(payload) == 1
+
+
+def test_ignores_backtick_qapass_token() -> None:
+    payload = {
+        "comments": [
+            {"body": "예시 포맷: `[QA PASS]` 를 그대로 복붙하지 마세요."},
+        ]
+    }
+    assert run_detector(payload) == 1


### PR DESCRIPTION
Report-Path: develop_report/2026-02-19_pm_cycle_qapass_detection_fix_report.md

## Summary
- add strict QA PASS detector (line-start token only)
- replace PM cycle grep-based detection with structured detector
- add regression tests for pass/guidance/backtick cases
- document QA PASS comment standard format

## Verification
- python3 -m py_compile scripts/pm/qapass_detection.py
- bash -n scripts/pm/pm_cycle_dry_run.sh
- /Users/gimtaehun/election2026_codex/.venv/bin/pytest -q tests/test_pm_cycle_qapass_detection.py
- /Users/gimtaehun/election2026_codex/.venv/bin/pytest -q

Closes #46