### PR TITLE
feat(develop): introduce multi-source provenance model for #78

### DIFF
--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -95,6 +95,7 @@ class MatchupOut(BaseModel):
     date_resolution: str | None = None
     poll_fingerprint: str | None = None
     source_channel: Literal["article", "nesdc"] | None = None
+    source_channels: list[Literal["article", "nesdc"]] | None = None
     verified: bool
     options: list[MatchupOptionOut]
 
@@ -256,6 +257,7 @@ class PollObservationInput(BaseModel):
     date_resolution: str | None = None
     poll_fingerprint: str | None = None
     source_channel: Literal["article", "nesdc"] = "article"
+    source_channels: list[Literal["article", "nesdc"]] | None = None
     verified: bool = False
     source_grade: str = "C"
 

--- a/data/provenance_migration_validation_v1.json
+++ b/data/provenance_migration_validation_v1.json
@@ -1,0 +1,15 @@
+{
+  "scenario": "provenance_multi_source_migration_v1",
+  "generated_at": "2026-02-19T05:55:00Z",
+  "compatibility": {
+    "source_channel_kept": true,
+    "source_channels_added": true,
+    "legacy_backfill_rule": "source_channels=[source_channel] when source_channels is null"
+  },
+  "merge_validation": {
+    "input_channels": ["article", "nesdc"],
+    "merged_source_channel": "nesdc",
+    "merged_source_channels": ["article", "nesdc"],
+    "duplicate_increase_after_reingest": 0
+  }
+}

--- a/develop_report/2026-02-19_provenance_multi_source_model_v1_report.md
+++ b/develop_report/2026-02-19_provenance_multi_source_model_v1_report.md
@@ -1,0 +1,67 @@
+# 2026-02-19 Provenance Multi Source Model v1 Report (Issue #78)
+
+## 1. 작업 개요
+- 이슈: [#78](https://github.com/iAmSomething/2026-/issues/78)
+- 목표: 하위호환을 유지한 채 다중 provenance(`source_channels`) 도입
+- 브랜치: `codex/issue78-provenance-multi-source`
+
+## 2. 구현 내용
+### 2.1 데이터 모델 확장
+- 파일: `db/schema.sql`
+- `poll_observations`에 `source_channels TEXT[]` 추가
+- 기존 `source_channel` 유지(하위호환)
+- 제약/인덱스:
+  - `poll_observations_source_channels_check`
+  - `idx_poll_observations_source_channels` (GIN)
+- 백필 규칙 반영:
+  - `source_channels IS NULL AND source_channel IS NOT NULL`인 기존 레코드에 대해 `source_channels = ARRAY[source_channel]`
+
+### 2.2 병합 정책 확장
+- 파일: `app/services/fingerprint.py`
+- 병합 시 provenance 집합 누적:
+  - 기존 `source_channels` + 신규 `source_channels` + 단일 `source_channel` 값을 모두 합쳐 dedupe
+  - 정렬된 결과(`article`, `nesdc`)를 `source_channels`에 저장
+- 단일 필드 호환 유지:
+  - `source_channel`은 기존 규칙 유지(`nesdc` 포함 시 `nesdc`)
+
+### 2.3 적재/조회 경로 반영
+- 파일: `app/services/repository.py`
+  - payload 준비 시 `source_channels` 누락이면 `[source_channel]`로 자동 보강
+  - upsert에 `source_channels` 반영
+  - `GET /api/v1/matchups/{matchup_id}` 조회에 `source_channels` 노출
+- 파일: `app/models/schemas.py`
+  - `PollObservationInput`, `MatchupOut`에 `source_channels` 추가
+- 파일: `src/pipeline/contracts.py`, `src/pipeline/ingest_adapter.py`, `src/pipeline/collector.py`
+  - contracts/adapter/collector 전파 경로에 `source_channels` 반영
+
+### 2.4 문서/산출물
+- 문서 반영:
+  - `docs/02_DATA_MODEL_AND_NORMALIZATION.md`
+  - `docs/03_UI_UX_SPEC.md`
+- 검증 산출물:
+  - `data/provenance_migration_validation_v1.json`
+
+## 3. 테스트/검증
+### 3.1 신규/수정 테스트
+- 신규: `tests/test_repository_source_channels.py`
+  - payload 백필(`source_channels=[source_channel]`) 검증
+- 수정: `tests/test_poll_fingerprint.py`
+  - 병합 후 `source_channels=[article, nesdc]` 누적 검증
+- 수정: API/ingest/adapter 테스트
+  - `source_channels` 계약 노출/전파 검증
+
+### 3.2 실행 결과
+- `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q tests/test_poll_fingerprint.py tests/test_repository_source_channels.py tests/test_ingest_service.py tests/test_api_routes.py tests/test_ingest_adapter.py tests/test_repository_dashboard_summary_scope.py`
+  - 결과: `17 passed`
+- `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q`
+  - 결과: `61 passed`
+
+## 4. DoD 충족 여부
+1. 하위호환 깨짐 0건: 완료(`source_channel` 유지)
+2. provenance 병합 정확성 테스트 PASS: 완료
+3. 계약/회귀 테스트 PASS: 완료
+
+## 5. 의사결정 필요사항
+1. `source_channels` 노출 순서 정책 고정 여부
+- 현재: `article`, `nesdc` 순서로 정규화
+- 필요 시 UI 요구에 맞춰 우선순위(예: `nesdc` first) 재정의 가능

--- a/docs/02_DATA_MODEL_AND_NORMALIZATION.md
+++ b/docs/02_DATA_MODEL_AND_NORMALIZATION.md
@@ -23,7 +23,7 @@
 - `region_code`, `office_type`, `matchup_id`, `verified`, `source_grade`, `ingestion_run_id`
 - `audience_scope`(`national|regional|local`), `audience_region_code`, `sampling_population_text`
 - `legal_completeness_score`, `legal_filled_count`, `legal_required_count`, `date_resolution`
-- `poll_fingerprint`, `source_channel`(`article|nesdc`)
+- `poll_fingerprint`, `source_channel`(`article|nesdc`), `source_channels`(다중 provenance)
 
 ## 1.4 `poll_options`
 - 목적: 조사 선택지(후보/문항값) 저장
@@ -105,3 +105,9 @@
 2. 입력 정규화 후 `sha256`으로 `poll_fingerprint` 생성해 저장한다.
 3. 동일 fingerprint 다중 소스 병합 시 메타 필드는 `nesdc` 우선, 문맥(기사 제목 기반 `survey_name`)은 `article` 보강 우선으로 적용한다.
 4. 동일 fingerprint에서 핵심 식별 필드 충돌 시 `review_queue.issue_type='DUPLICATE_CONFLICT'`로 분기한다.
+
+## 8. provenance 다중 출처 규칙
+1. 하위호환을 위해 `source_channel` 단일값은 유지한다.
+2. 신규 `source_channels`는 채널 집합(`article`, `nesdc`)을 누적 저장한다.
+3. 병합 후 `source_channel`은 기존 규칙(`nesdc` 존재 시 `nesdc`)으로 유지하고, 상세 provenance는 `source_channels`로 조회한다.
+4. 기존 레거시 데이터는 마이그레이션 시 `source_channels = [source_channel]`로 백필한다.

--- a/docs/03_UI_UX_SPEC.md
+++ b/docs/03_UI_UX_SPEC.md
@@ -63,7 +63,7 @@
 | 빅매치 카드 | `GET /api/v1/dashboard/big-matches` | `matchups`, `poll_observations` | `matchup_id`, `title`, `survey_end_date`, `value_mid` |
 | 지역 검색 | `GET /api/v1/regions/search` | `regions` | `region_code`, `sido_name`, `sigungu_name` |
 | 지역별 선거 탭 | `GET /api/v1/regions/{region_code}/elections` | `matchups` | `region_code`, `office_type`, `is_active` |
-| 매치업 상세 | `GET /api/v1/matchups/{matchup_id}` | `poll_observations`, `poll_options` | `matchup_id`, `pollster`, `margin_of_error`, `value_mid`, `source_grade`, `audience_scope`, `legal_completeness_score`, `legal_filled_count`, `legal_required_count`, `source_channel`, `poll_fingerprint` |
+| 매치업 상세 | `GET /api/v1/matchups/{matchup_id}` | `poll_observations`, `poll_options` | `matchup_id`, `pollster`, `margin_of_error`, `value_mid`, `source_grade`, `audience_scope`, `legal_completeness_score`, `legal_filled_count`, `legal_required_count`, `source_channel`, `source_channels`, `poll_fingerprint` |
 | 후보자 상세 | `GET /api/v1/candidates/{candidate_id}` | `candidates`, `candidate_profiles` | `candidate_id`, `name_ko`, `party_name`, `career_summary` |
 
 ## 5. API-UI 필드명 일치 규칙

--- a/src/pipeline/collector.py
+++ b/src/pipeline/collector.py
@@ -397,6 +397,7 @@ class PollCollector:
             evidence_text=article.raw_text[:280],
             source_url=article.url,
             source_channel="article",
+            source_channels=["article"],
         )
         observations.append(observation)
 

--- a/src/pipeline/contracts.py
+++ b/src/pipeline/contracts.py
@@ -89,6 +89,10 @@ POLL_OBSERVATION_SCHEMA: dict[str, Any] = {
         "date_resolution": {"type": ["string", "null"]},
         "poll_fingerprint": {"type": ["string", "null"]},
         "source_channel": {"type": ["string", "null"], "enum": ["article", "nesdc", None]},
+        "source_channels": {
+            "type": ["array", "null"],
+            "items": {"type": "string", "enum": ["article", "nesdc"]},
+        },
         "verified": {"type": "boolean"},
         "source_grade": {"type": ["string", "null"]},
         "ingestion_run_id": {"type": ["string", "null"]},
@@ -215,6 +219,7 @@ class PollObservation:
     date_resolution: str | None = None
     poll_fingerprint: str | None = None
     source_channel: str | None = None
+    source_channels: list[str] | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)

--- a/src/pipeline/ingest_adapter.py
+++ b/src/pipeline/ingest_adapter.py
@@ -99,6 +99,7 @@ def collector_output_to_ingest_payload(
                     "date_resolution": getattr(observation, "date_resolution", None),
                     "poll_fingerprint": getattr(observation, "poll_fingerprint", None),
                     "source_channel": getattr(observation, "source_channel", "article"),
+                    "source_channels": getattr(observation, "source_channels", None),
                     "verified": observation.verified,
                     "source_grade": observation.source_grade or "C",
                 },

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -97,6 +97,7 @@ class FakeApiRepo:
             "date_resolution": "exact",
             "poll_fingerprint": "f" * 64,
             "source_channel": "article",
+            "source_channels": ["article", "nesdc"],
             "verified": True,
             "options": [
                 {"option_name": "정원오", "value_mid": 44.0, "value_raw": "44%"},
@@ -322,6 +323,7 @@ def test_api_contract_fields():
     assert matchup.json()["audience_scope"] == "regional"
     assert matchup.json()["legal_required_count"] == 7
     assert matchup.json()["source_channel"] == "article"
+    assert matchup.json()["source_channels"] == ["article", "nesdc"]
 
     candidate = client.get("/api/v1/candidates/cand-jwo")
     assert candidate.status_code == 200

--- a/tests/test_ingest_adapter.py
+++ b/tests/test_ingest_adapter.py
@@ -30,6 +30,7 @@ def test_collector_output_converts_to_ingest_payload():
     obs[0].legal_required_count = 7
     obs[0].date_resolution = "exact"
     obs[0].source_channel = "article"
+    obs[0].source_channels = ["article"]
     output.poll_observations.extend(obs)
     output.poll_options.extend(opts)
     output.review_queue.extend(errs)
@@ -43,3 +44,4 @@ def test_collector_output_converts_to_ingest_payload():
     assert parsed.records[0].observation.audience_scope == "regional"
     assert parsed.records[0].observation.legal_required_count == 7
     assert parsed.records[0].observation.source_channel == "article"
+    assert parsed.records[0].observation.source_channels == ["article"]

--- a/tests/test_ingest_service.py
+++ b/tests/test_ingest_service.py
@@ -76,6 +76,7 @@ PAYLOAD = {
                 "legal_filled_count": 6,
                 "legal_required_count": 7,
                 "date_resolution": "exact",
+                "source_channels": ["article"],
             },
             "options": [
                 {"option_type": "presidential_approval", "option_name": "국정안정론", "value_raw": "53~55%"}
@@ -98,6 +99,7 @@ def test_idempotent_ingest_no_duplicate_records():
     assert repo.observations["obs-1"]["audience_scope"] == "national"
     assert repo.observations["obs-1"]["legal_filled_count"] == 6
     assert len(repo.observations["obs-1"]["poll_fingerprint"]) == 64
+    assert repo.observations["obs-1"]["source_channels"] == ["article"]
 
 
 def test_ingest_error_pushes_review_queue():

--- a/tests/test_poll_fingerprint.py
+++ b/tests/test_poll_fingerprint.py
@@ -42,6 +42,7 @@ def test_merge_prefers_nesdc_metadata_and_keeps_article_context():
         "matchup_id": "20260603|광역자치단체장|11-000",
         "poll_fingerprint": "fp1",
         "source_channel": "article",
+        "source_channels": ["article"],
         "verified": False,
         "source_grade": "C",
         "ingestion_run_id": 1,
@@ -63,6 +64,7 @@ def test_merge_prefers_nesdc_metadata_and_keeps_article_context():
         "matchup_id": "20260603|광역자치단체장|11-000",
         "poll_fingerprint": "fp1",
         "source_channel": "nesdc",
+        "source_channels": ["nesdc"],
         "verified": True,
         "source_grade": "A",
         "ingestion_run_id": 2,
@@ -71,6 +73,7 @@ def test_merge_prefers_nesdc_metadata_and_keeps_article_context():
 
     assert merged["observation_key"] == "obs-article"
     assert merged["source_channel"] == "nesdc"
+    assert merged["source_channels"] == ["article", "nesdc"]
     assert merged["pollster"] == "KBS"
     assert merged["method"] == "전화면접"
     assert merged["survey_name"] == "기사 제목 기반 조사"
@@ -82,6 +85,7 @@ def test_merge_raises_duplicate_conflict_on_core_mismatch():
     existing = {
         "observation_key": "obs-1",
         "source_channel": "article",
+        "source_channels": ["article"],
         "region_code": "11-000",
         "office_type": "광역자치단체장",
         "survey_start_date": "2026-02-10",
@@ -91,6 +95,7 @@ def test_merge_raises_duplicate_conflict_on_core_mismatch():
     incoming = {
         "observation_key": "obs-2",
         "source_channel": "nesdc",
+        "source_channels": ["nesdc"],
         "region_code": "11-000",
         "office_type": "광역자치단체장",
         "survey_start_date": "2026-02-10",
@@ -102,4 +107,3 @@ def test_merge_raises_duplicate_conflict_on_core_mismatch():
         raise AssertionError("expected DuplicateConflictError")
     except DuplicateConflictError as exc:
         assert "DUPLICATE_CONFLICT" in str(exc)
-

--- a/tests/test_repository_source_channels.py
+++ b/tests/test_repository_source_channels.py
@@ -1,0 +1,28 @@
+from app.services.repository import PostgresRepository
+
+
+def test_prepare_observation_payload_backfills_source_channels_from_source_channel():
+    repo = PostgresRepository(conn=None)
+    payload = repo._prepare_observation_payload(  # noqa: SLF001
+        {
+            "observation_key": "obs-1",
+            "source_channel": "article",
+        },
+        article_id=1,
+        ingestion_run_id=1,
+    )
+    assert payload["source_channels"] == ["article"]
+
+
+def test_prepare_observation_payload_keeps_given_source_channels():
+    repo = PostgresRepository(conn=None)
+    payload = repo._prepare_observation_payload(  # noqa: SLF001
+        {
+            "observation_key": "obs-1",
+            "source_channel": "article",
+            "source_channels": ["article", "nesdc"],
+        },
+        article_id=1,
+        ingestion_run_id=1,
+    )
+    assert payload["source_channels"] == ["article", "nesdc"]


### PR DESCRIPTION
## Summary
- `source_channel` 하위호환 유지 + `source_channels` 다중 provenance 모델 도입
- fingerprint 병합 시 provenance 채널 집합 누적(`article`, `nesdc`) 반영
- `poll_observations` 스키마에 `source_channels` 추가 및 legacy backfill 규칙 반영
- `GET /api/v1/matchups/{matchup_id}` 응답에 `source_channels` 노출
- 계약/회귀 테스트 및 검증 산출물/보고서 반영

## Linked Issue
- Closes #78

## Report-Path
Report-Path: develop_report/2026-02-19_provenance_multi_source_model_v1_report.md

## Checklist
- [x] docs 계약(필드/API/용어)과 일치
- [x] 테스트 또는 검증 로그 첨부
- [x] 보안 정보(key/secret) 미포함 확인
- [x] Report-Path 파일이 이번 PR에 포함됨

## Validation
- `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q tests/test_poll_fingerprint.py tests/test_repository_source_channels.py tests/test_ingest_service.py tests/test_api_routes.py tests/test_ingest_adapter.py tests/test_repository_dashboard_summary_scope.py` -> 17 passed
- `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q` -> 61 passed
