### PR TITLE
feat(develop): extend dashboard APIs with source_channels for #82

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -49,6 +49,8 @@ def get_dashboard_summary(
             value_mid=row["value_mid"],
             pollster=row["pollster"],
             survey_end_date=row["survey_end_date"],
+            source_channel=row.get("source_channel"),
+            source_channels=row.get("source_channels") or [],
             verified=row["verified"],
         )
         if row["option_type"] == "party_support":

--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -27,6 +27,8 @@ class SummaryPoint(BaseModel):
     value_mid: float | None = None
     pollster: str | None = None
     survey_end_date: date | None = None
+    source_channel: Literal["article", "nesdc"] | None = None
+    source_channels: list[Literal["article", "nesdc"]] = Field(default_factory=list)
     verified: bool
 
 
@@ -43,6 +45,8 @@ class MapLatestPoint(BaseModel):
     value_mid: float | None = None
     survey_end_date: date | None = None
     option_name: str | None = None
+    source_channel: Literal["article", "nesdc"] | None = None
+    source_channels: list[Literal["article", "nesdc"]] = Field(default_factory=list)
 
 
 class DashboardMapLatestOut(BaseModel):
@@ -56,6 +60,8 @@ class BigMatchPoint(BaseModel):
     survey_end_date: date | None = None
     value_mid: float | None = None
     spread: float | None = None
+    source_channel: Literal["article", "nesdc"] | None = None
+    source_channels: list[Literal["article", "nesdc"]] = Field(default_factory=list)
 
 
 class DashboardBigMatchesOut(BaseModel):

--- a/data/dashboard_source_channels_samples_v1.json
+++ b/data/dashboard_source_channels_samples_v1.json
@@ -1,0 +1,60 @@
+{
+  "dashboard_summary": {
+    "as_of": "2026-02-19",
+    "party_support": [
+      {
+        "option_name": "더불어민주당",
+        "value_mid": 42.0,
+        "pollster": "KBS",
+        "survey_end_date": "2026-02-18",
+        "source_channel": "nesdc",
+        "source_channels": ["article", "nesdc"],
+        "verified": true
+      }
+    ],
+    "presidential_approval": [
+      {
+        "option_name": "국정안정론",
+        "value_mid": 54.0,
+        "pollster": "KBS",
+        "survey_end_date": "2026-02-18",
+        "source_channel": "article",
+        "source_channels": ["article"],
+        "verified": true
+      }
+    ]
+  },
+  "dashboard_map_latest": {
+    "as_of": "2026-02-19",
+    "items": [
+      {
+        "region_code": "11-000",
+        "office_type": "광역자치단체장",
+        "title": "서울시장 가상대결",
+        "value_mid": 44.0,
+        "survey_end_date": "2026-02-18",
+        "option_name": "정원오",
+        "source_channel": "nesdc",
+        "source_channels": ["article", "nesdc"]
+      }
+    ]
+  },
+  "dashboard_big_matches": {
+    "as_of": "2026-02-19",
+    "items": [
+      {
+        "matchup_id": "20260603|광역자치단체장|11-000",
+        "title": "서울시장 가상대결",
+        "survey_end_date": "2026-02-18",
+        "value_mid": 44.0,
+        "spread": 2.0,
+        "source_channel": "nesdc",
+        "source_channels": ["article", "nesdc"]
+      }
+    ]
+  },
+  "null_policy": {
+    "source_channels": "always array",
+    "fallback": "[]"
+  }
+}

--- a/develop_report/2026-02-19_dashboard_source_channels_api_extension_report.md
+++ b/develop_report/2026-02-19_dashboard_source_channels_api_extension_report.md
@@ -1,0 +1,59 @@
+# 2026-02-19 Dashboard Source Channels API Extension Report (Issue #82)
+
+## 1. 작업 개요
+- 이슈: [#82](https://github.com/iAmSomething/2026-/issues/82)
+- 목표: 대시보드 계열 API(`summary/map-latest/big-matches`)에 `source_channels`를 일관 노출
+- 브랜치: `codex/issue82-dashboard-source-channels`
+
+## 2. 구현 내용
+### 2.1 API 응답 모델 확장
+- 파일: `app/models/schemas.py`
+- 확장 대상:
+  - `SummaryPoint`
+  - `MapLatestPoint`
+  - `BigMatchPoint`
+- 추가 필드:
+  - `source_channel` (legacy 호환)
+  - `source_channels` (`string[]`, 기본값 `[]`)
+
+### 2.2 라우트/쿼리 반영
+- 파일: `app/api/routes.py`
+  - summary 응답 매핑 시 `source_channels` 누락/null을 `[]`로 보정
+- 파일: `app/services/repository.py`
+  - `fetch_dashboard_summary`
+  - `fetch_dashboard_map_latest`
+  - `fetch_dashboard_big_matches`
+- SQL에서 `source_channels` fallback 규칙 반영:
+  - `COALESCE(o.source_channels, CASE WHEN o.source_channel IS NULL THEN ARRAY[]::text[] ELSE ARRAY[o.source_channel] END)`
+
+### 2.3 문서 동기화
+- 파일: `docs/03_UI_UX_SPEC.md`
+- 반영 항목:
+  - 3개 대상 엔드포인트 필수 필드에 `source_channel`, `source_channels` 명시
+  - null 정책: `source_channels`는 null 대신 `[]` 노출
+
+### 2.4 UIUX 소비용 샘플 응답
+- 파일: `data/dashboard_source_channels_samples_v1.json`
+- 포함 내용:
+  - `dashboard_summary`, `dashboard_map_latest`, `dashboard_big_matches` 예시
+  - null/empty array 정책 명시
+
+## 3. 테스트/검증
+### 3.1 계약 테스트
+- 파일: `tests/test_api_routes.py`
+- 검증 항목:
+  - `GET /api/v1/dashboard/summary`
+  - `GET /api/v1/dashboard/map-latest`
+  - `GET /api/v1/dashboard/big-matches`
+  - 각 응답에서 `source_channels` 필드 존재 및 배열 형태 확인
+
+### 3.2 실행 결과
+- `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q tests/test_api_routes.py tests/test_repository_dashboard_summary_scope.py tests/test_poll_fingerprint.py tests/test_repository_source_channels.py`
+  - 결과: `13 passed`
+- `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q`
+  - 결과: `61 passed`
+
+## 4. DoD 충족 여부
+1. 3개 엔드포인트 계약 테스트 PASS: 완료
+2. 문서 필드 동기화: 완료 (`docs/03_UI_UX_SPEC.md`)
+3. 보고서 + 샘플 응답 첨부: 완료

--- a/docs/03_UI_UX_SPEC.md
+++ b/docs/03_UI_UX_SPEC.md
@@ -58,9 +58,9 @@
 
 | 화면 기능 | 사용 API | 핵심 테이블 | 필수 필드 |
 |---|---|---|---|
-| 최신 정당/대통령 요약 | `GET /api/v1/dashboard/summary` | `poll_observations`, `poll_options` | `pollster`, `survey_end_date`, `option_name`, `value_mid`, `verified`, `audience_scope`(national only) |
-| 지도 Hover 최신값 | `GET /api/v1/dashboard/map-latest` | `regions`, `matchups`, `poll_options` | `region_code`, `office_type`, `title`, `value_mid` |
-| 빅매치 카드 | `GET /api/v1/dashboard/big-matches` | `matchups`, `poll_observations` | `matchup_id`, `title`, `survey_end_date`, `value_mid` |
+| 최신 정당/대통령 요약 | `GET /api/v1/dashboard/summary` | `poll_observations`, `poll_options` | `pollster`, `survey_end_date`, `option_name`, `value_mid`, `verified`, `audience_scope`(national only), `source_channel`, `source_channels` |
+| 지도 Hover 최신값 | `GET /api/v1/dashboard/map-latest` | `regions`, `matchups`, `poll_options` | `region_code`, `office_type`, `title`, `value_mid`, `source_channel`, `source_channels` |
+| 빅매치 카드 | `GET /api/v1/dashboard/big-matches` | `matchups`, `poll_observations` | `matchup_id`, `title`, `survey_end_date`, `value_mid`, `source_channel`, `source_channels` |
 | 지역 검색 | `GET /api/v1/regions/search` | `regions` | `region_code`, `sido_name`, `sigungu_name` |
 | 지역별 선거 탭 | `GET /api/v1/regions/{region_code}/elections` | `matchups` | `region_code`, `office_type`, `is_active` |
 | 매치업 상세 | `GET /api/v1/matchups/{matchup_id}` | `poll_observations`, `poll_options` | `matchup_id`, `pollster`, `margin_of_error`, `value_mid`, `source_grade`, `audience_scope`, `legal_completeness_score`, `legal_filled_count`, `legal_required_count`, `source_channel`, `source_channels`, `poll_fingerprint` |
@@ -73,3 +73,4 @@
 4. 지역 선택의 기준 키는 `region_code` 단일 사용
 5. 대시보드 요약 카드는 `audience_scope='national'`로 스코프 분리된 데이터만 사용
 6. 매치업 상세는 조사 스코프(`audience_scope`)와 법정 completeness(`legal_*`)를 함께 노출
+7. 대시보드 계열 API의 `source_channels`는 null 대신 빈 배열(`[]`)을 기본값으로 노출

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -20,6 +20,8 @@ class FakeApiRepo:
                 "value_mid": 42.0,
                 "pollster": "KBS",
                 "survey_end_date": date(2026, 2, 18),
+                "source_channel": "nesdc",
+                "source_channels": ["article", "nesdc"],
                 "verified": True,
             },
             {
@@ -28,6 +30,8 @@ class FakeApiRepo:
                 "value_mid": 54.0,
                 "pollster": "KBS",
                 "survey_end_date": date(2026, 2, 18),
+                "source_channel": "article",
+                "source_channels": ["article"],
                 "verified": True,
             },
         ]
@@ -51,6 +55,8 @@ class FakeApiRepo:
                 "value_mid": 44.0,
                 "survey_end_date": date(2026, 2, 18),
                 "option_name": "정원오",
+                "source_channel": "nesdc",
+                "source_channels": ["article", "nesdc"],
             }
         ]
 
@@ -62,6 +68,8 @@ class FakeApiRepo:
                 "survey_end_date": date(2026, 2, 18),
                 "value_mid": 44.0,
                 "spread": 2.0,
+                "source_channel": "nesdc",
+                "source_channels": ["article", "nesdc"],
             }
         ]
 
@@ -300,6 +308,8 @@ def test_api_contract_fields():
     assert "presidential_approval" in body
     assert "option_name" in body["party_support"][0]
     assert "value_mid" in body["party_support"][0]
+    assert "source_channels" in body["party_support"][0]
+    assert body["party_support"][0]["source_channels"] == ["article", "nesdc"]
 
     regions = client.get("/api/v1/regions/search", params={"q": "서울"})
     assert regions.status_code == 200
@@ -308,10 +318,12 @@ def test_api_contract_fields():
     map_latest = client.get("/api/v1/dashboard/map-latest")
     assert map_latest.status_code == 200
     assert map_latest.json()["items"][0]["region_code"] == "11-000"
+    assert map_latest.json()["items"][0]["source_channels"] == ["article", "nesdc"]
 
     big_matches = client.get("/api/v1/dashboard/big-matches")
     assert big_matches.status_code == 200
     assert big_matches.json()["items"][0]["matchup_id"] == "20260603|광역자치단체장|11-000"
+    assert big_matches.json()["items"][0]["source_channels"] == ["article", "nesdc"]
 
     region_elections = client.get("/api/v1/regions/11-000/elections")
     assert region_elections.status_code == 200


### PR DESCRIPTION
## Summary
- 대시보드 3개 API(summary/map-latest/big-matches)에 `source_channels` 계약을 확장
- legacy 호환을 위해 `source_channel` 필드도 병행 유지
- DB 조회 쿼리에서 `source_channels` null fallback을 `[]`로 보정
- UIUX 소비용 샘플 응답(`data/dashboard_source_channels_samples_v1.json`) 추가
- API 계약 테스트 및 문서 동기화 반영

## Linked Issue
- Closes #82

## Report-Path
Report-Path: develop_report/2026-02-19_dashboard_source_channels_api_extension_report.md

## Checklist
- [x] docs 계약(필드/API/용어)과 일치
- [x] 테스트 또는 검증 로그 첨부
- [x] 보안 정보(key/secret) 미포함 확인
- [x] Report-Path 파일이 이번 PR에 포함됨

## Validation
- `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q tests/test_api_routes.py tests/test_repository_dashboard_summary_scope.py tests/test_poll_fingerprint.py tests/test_repository_source_channels.py` -> 13 passed
- `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q` -> 61 passed
