### PR TITLE
feat(develop): legal metadata schema/api extension for #86

### DIFF
--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -89,7 +89,11 @@ class MatchupOut(BaseModel):
     office_type: str
     title: str
     pollster: str | None = None
+    survey_start_date: date | None = None
     survey_end_date: date | None = None
+    confidence_level: float | None = None
+    sample_size: int | None = None
+    response_rate: float | None = None
     margin_of_error: float | None = None
     source_grade: str | None = None
     audience_scope: Literal["national", "regional", "local"] | None = None
@@ -246,6 +250,7 @@ class PollObservationInput(BaseModel):
     pollster: str
     survey_start_date: date | None = None
     survey_end_date: date | None = None
+    confidence_level: float | None = None
     sample_size: int | None = None
     response_rate: float | None = None
     margin_of_error: float | None = None

--- a/app/services/fingerprint.py
+++ b/app/services/fingerprint.py
@@ -86,6 +86,7 @@ def merge_observation_by_priority(existing: dict, incoming: dict) -> dict:
         "sponsor",
         "survey_start_date",
         "survey_end_date",
+        "confidence_level",
         "sample_size",
         "response_rate",
         "margin_of_error",

--- a/app/services/repository.py
+++ b/app/services/repository.py
@@ -110,7 +110,7 @@ class PostgresRepository:
                 """
                 SELECT
                     id, observation_key, article_id, survey_name, pollster, sponsor,
-                    survey_start_date, survey_end_date, sample_size, response_rate,
+                    survey_start_date, survey_end_date, confidence_level, sample_size, response_rate,
                     margin_of_error, method, region_code, office_type, matchup_id,
                     audience_scope, audience_region_code, sampling_population_text,
                     legal_completeness_score, legal_filled_count, legal_required_count,
@@ -132,6 +132,7 @@ class PostgresRepository:
         payload.setdefault("audience_scope", None)
         payload.setdefault("audience_region_code", None)
         payload.setdefault("sampling_population_text", None)
+        payload.setdefault("confidence_level", None)
         payload.setdefault("legal_completeness_score", None)
         payload.setdefault("legal_filled_count", None)
         payload.setdefault("legal_required_count", None)
@@ -158,7 +159,7 @@ class PostgresRepository:
                 """
                 INSERT INTO poll_observations (
                     observation_key, article_id, survey_name, pollster,
-                    survey_start_date, survey_end_date, sample_size,
+                    survey_start_date, survey_end_date, confidence_level, sample_size,
                     response_rate, margin_of_error, sponsor, method, region_code,
                     office_type, matchup_id, audience_scope, audience_region_code,
                     sampling_population_text, legal_completeness_score,
@@ -169,7 +170,7 @@ class PostgresRepository:
                 )
                 VALUES (
                     %(observation_key)s, %(article_id)s, %(survey_name)s, %(pollster)s,
-                    %(survey_start_date)s, %(survey_end_date)s, %(sample_size)s,
+                    %(survey_start_date)s, %(survey_end_date)s, %(confidence_level)s, %(sample_size)s,
                     %(response_rate)s, %(margin_of_error)s, %(sponsor)s, %(method)s, %(region_code)s,
                     %(office_type)s, %(matchup_id)s, %(audience_scope)s, %(audience_region_code)s,
                     %(sampling_population_text)s, %(legal_completeness_score)s,
@@ -184,6 +185,7 @@ class PostgresRepository:
                     pollster=EXCLUDED.pollster,
                     survey_start_date=EXCLUDED.survey_start_date,
                     survey_end_date=EXCLUDED.survey_end_date,
+                    confidence_level=EXCLUDED.confidence_level,
                     sample_size=EXCLUDED.sample_size,
                     response_rate=EXCLUDED.response_rate,
                     margin_of_error=EXCLUDED.margin_of_error,
@@ -521,7 +523,11 @@ class PostgresRepository:
                     o.office_type,
                     COALESCE(m.title, o.matchup_id) AS title,
                     o.pollster,
+                    o.survey_start_date,
                     o.survey_end_date,
+                    o.confidence_level,
+                    o.sample_size,
+                    o.response_rate,
                     o.margin_of_error,
                     o.source_grade,
                     o.audience_scope,
@@ -565,7 +571,11 @@ class PostgresRepository:
             "office_type": row["office_type"],
             "title": row["title"],
             "pollster": row["pollster"],
+            "survey_start_date": row["survey_start_date"],
             "survey_end_date": row["survey_end_date"],
+            "confidence_level": row["confidence_level"],
+            "sample_size": row["sample_size"],
+            "response_rate": row["response_rate"],
             "margin_of_error": row["margin_of_error"],
             "source_grade": row["source_grade"],
             "audience_scope": row["audience_scope"],

--- a/data/legal_metadata_matchup_sample_v1.json
+++ b/data/legal_metadata_matchup_sample_v1.json
@@ -1,0 +1,37 @@
+{
+  "matchup_id": "20260603|광역자치단체장|11-000",
+  "region_code": "11-000",
+  "office_type": "광역자치단체장",
+  "title": "서울시장 가상대결",
+  "pollster": "KBS",
+  "survey_start_date": "2026-02-15",
+  "survey_end_date": "2026-02-18",
+  "confidence_level": 95.0,
+  "sample_size": 1000,
+  "response_rate": 12.3,
+  "margin_of_error": 3.1,
+  "source_grade": "B",
+  "audience_scope": "regional",
+  "audience_region_code": "11-000",
+  "sampling_population_text": "서울시 거주 만 18세 이상",
+  "legal_completeness_score": 0.86,
+  "legal_filled_count": 6,
+  "legal_required_count": 7,
+  "date_resolution": "exact",
+  "poll_fingerprint": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "source_channel": "article",
+  "source_channels": ["article", "nesdc"],
+  "verified": true,
+  "options": [
+    {
+      "option_name": "정원오",
+      "value_mid": 44.0,
+      "value_raw": "44%"
+    },
+    {
+      "option_name": "오세훈",
+      "value_mid": 42.0,
+      "value_raw": "42%"
+    }
+  ]
+}

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -63,6 +63,7 @@ CREATE TABLE IF NOT EXISTS poll_observations (
     pollster TEXT NOT NULL,
     survey_start_date DATE NULL,
     survey_end_date DATE NULL,
+    confidence_level FLOAT NULL,
     sample_size INT NULL,
     response_rate FLOAT NULL,
     margin_of_error FLOAT NULL,
@@ -89,6 +90,7 @@ CREATE TABLE IF NOT EXISTS poll_observations (
 );
 
 ALTER TABLE poll_observations
+    ADD COLUMN IF NOT EXISTS confidence_level FLOAT NULL,
     ADD COLUMN IF NOT EXISTS sponsor TEXT NULL,
     ADD COLUMN IF NOT EXISTS method TEXT NULL,
     ADD COLUMN IF NOT EXISTS audience_scope TEXT NULL,

--- a/develop_report/2026-02-19_legal_metadata_schema_api_extension_report.md
+++ b/develop_report/2026-02-19_legal_metadata_schema_api_extension_report.md
@@ -1,0 +1,68 @@
+# 2026-02-19 Legal Metadata Schema/API Extension Report (Issue #86)
+
+## 1. 작업 개요
+- 이슈: [#86](https://github.com/iAmSomething/2026-/issues/86)
+- 목표: 기사 법정메타 v2 수집 결과를 저장/조회 가능한 스키마/API 계약으로 확장
+- 브랜치: `codex/issue86-legal-metadata-extension`
+
+## 2. 구현 내용
+### 2.1 저장 계층 확장
+- 파일: `db/schema.sql`
+- `poll_observations` 확장:
+  - `confidence_level FLOAT NULL` 추가
+  - 기존 법정메타 필드(`survey_start_date`, `survey_end_date`, `margin_of_error`, `response_rate`, `sample_size`, `audience_scope`, `audience_region_code`)와 함께 v2 저장 범위 정렬
+- 마이그레이션 호환:
+  - `ALTER TABLE ... ADD COLUMN IF NOT EXISTS confidence_level FLOAT NULL`
+
+### 2.2 API 계약 확장
+- 파일: `app/models/schemas.py`
+- `MatchupOut`에 법정메타 필드 명시 노출:
+  - `survey_start_date`, `survey_end_date`
+  - `confidence_level`, `margin_of_error`
+  - `response_rate`, `sample_size`
+  - `audience_scope`, `audience_region_code`
+- `PollObservationInput`에도 `confidence_level` 입력 필드 추가
+
+- 파일: `app/services/repository.py`
+  - upsert/조회 쿼리에 `confidence_level` 반영
+  - `get_matchup` 응답 딕셔너리에 법정메타 필드 일관 노출
+
+- 파일: `app/services/fingerprint.py`
+  - 병합 메타 필드에 `confidence_level` 포함
+
+### 2.3 문서 동기화
+- 파일: `docs/02_DATA_MODEL_AND_NORMALIZATION.md`
+  - `confidence_level` 포함 및 법정메타 null/결측 정책 명시
+- 파일: `docs/03_UI_UX_SPEC.md`
+  - `GET /api/v1/matchups/{matchup_id}` 필수 필드 목록에 법정메타 확장 반영
+
+### 2.4 샘플 응답
+- 파일: `data/legal_metadata_matchup_sample_v1.json`
+- 매치업 상세 법정메타 필드 전체 포함 예시 1세트 제공
+
+## 3. 테스트/검증
+### 3.1 추가/수정 테스트
+- 신규: `tests/test_schema_legal_metadata.py`
+  - schema에 legal metadata/migration 구문 존재 검증
+- 신규: `tests/test_repository_matchup_legal_metadata.py`
+  - repository `get_matchup` 반환 필드 검증
+- 수정:
+  - `tests/test_api_routes.py` (matchup 계약 검증 강화)
+  - `tests/test_ingest_service.py` (ingest 저장 경로 검증)
+  - `tests/test_poll_fingerprint.py` (병합 필드 반영)
+
+### 3.2 실행 결과
+- `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q tests/test_schema_legal_metadata.py tests/test_repository_matchup_legal_metadata.py tests/test_api_routes.py tests/test_ingest_service.py tests/test_poll_fingerprint.py`
+  - 결과: PASS
+- `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q`
+  - 결과: PASS
+
+## 4. null/결측 정책
+- 법정메타 필드 결측 시 DB는 `null` 저장
+- API는 결측을 `null`로 그대로 노출
+- 배열형 provenance 필드는 기존 정책대로 `[]` fallback 유지
+
+## 5. DoD 충족 여부
+1. 테스트 PASS: 완료
+2. 문서 계약 동기화: 완료
+3. 보고서 + 샘플 응답 제출: 완료

--- a/docs/02_DATA_MODEL_AND_NORMALIZATION.md
+++ b/docs/02_DATA_MODEL_AND_NORMALIZATION.md
@@ -18,7 +18,7 @@
 - 목적: 조사 메타 정보 저장
 - 주요 컬럼:
 - `id`, `survey_name`, `pollster`, `survey_start_date`, `survey_end_date`
-- `sample_size`, `response_rate`, `margin_of_error`
+- `confidence_level`, `sample_size`, `response_rate`, `margin_of_error`
 - `sponsor`, `method`
 - `region_code`, `office_type`, `matchup_id`, `verified`, `source_grade`, `ingestion_run_id`
 - `audience_scope`(`national|regional|local`), `audience_region_code`, `sampling_population_text`
@@ -111,3 +111,8 @@
 2. 신규 `source_channels`는 채널 집합(`article`, `nesdc`)을 누적 저장한다.
 3. 병합 후 `source_channel`은 기존 규칙(`nesdc` 존재 시 `nesdc`)으로 유지하고, 상세 provenance는 `source_channels`로 조회한다.
 4. 기존 레거시 데이터는 마이그레이션 시 `source_channels = [source_channel]`로 백필한다.
+
+## 9. 법정메타 null/결측 정책
+1. 수집기에서 값이 없거나 추론 불가인 경우 `survey_start_date`, `survey_end_date`, `confidence_level`, `margin_of_error`, `response_rate`, `sample_size`는 `null` 저장한다.
+2. `audience_scope`, `audience_region_code`도 불명확하면 `null` 저장한다.
+3. API는 DB 값을 그대로 노출하며, 결측은 `null`로 유지한다.

--- a/docs/03_UI_UX_SPEC.md
+++ b/docs/03_UI_UX_SPEC.md
@@ -63,7 +63,7 @@
 | 빅매치 카드 | `GET /api/v1/dashboard/big-matches` | `matchups`, `poll_observations` | `matchup_id`, `title`, `survey_end_date`, `value_mid`, `source_channel`, `source_channels` |
 | 지역 검색 | `GET /api/v1/regions/search` | `regions` | `region_code`, `sido_name`, `sigungu_name` |
 | 지역별 선거 탭 | `GET /api/v1/regions/{region_code}/elections` | `matchups` | `region_code`, `office_type`, `is_active` |
-| 매치업 상세 | `GET /api/v1/matchups/{matchup_id}` | `poll_observations`, `poll_options` | `matchup_id`, `pollster`, `margin_of_error`, `value_mid`, `source_grade`, `audience_scope`, `legal_completeness_score`, `legal_filled_count`, `legal_required_count`, `source_channel`, `source_channels`, `poll_fingerprint` |
+| 매치업 상세 | `GET /api/v1/matchups/{matchup_id}` | `poll_observations`, `poll_options` | `matchup_id`, `pollster`, `survey_start_date`, `survey_end_date`, `confidence_level`, `sample_size`, `response_rate`, `margin_of_error`, `value_mid`, `source_grade`, `audience_scope`, `audience_region_code`, `legal_completeness_score`, `legal_filled_count`, `legal_required_count`, `source_channel`, `source_channels`, `poll_fingerprint` |
 | 후보자 상세 | `GET /api/v1/candidates/{candidate_id}` | `candidates`, `candidate_profiles` | `candidate_id`, `name_ko`, `party_name`, `career_summary` |
 
 ## 5. API-UI 필드명 일치 규칙
@@ -74,3 +74,4 @@
 5. 대시보드 요약 카드는 `audience_scope='national'`로 스코프 분리된 데이터만 사용
 6. 매치업 상세는 조사 스코프(`audience_scope`)와 법정 completeness(`legal_*`)를 함께 노출
 7. 대시보드 계열 API의 `source_channels`는 null 대신 빈 배열(`[]`)을 기본값으로 노출
+8. 매치업 상세의 법정메타 결측값은 `null`로 유지한다(숫자/날짜 모두 동일)

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -93,7 +93,11 @@ class FakeApiRepo:
             "office_type": "광역자치단체장",
             "title": "서울시장 가상대결",
             "pollster": "KBS",
+            "survey_start_date": date(2026, 2, 15),
             "survey_end_date": date(2026, 2, 18),
+            "confidence_level": 95.0,
+            "sample_size": 1000,
+            "response_rate": 12.3,
             "margin_of_error": 3.1,
             "source_grade": "B",
             "audience_scope": "regional",
@@ -332,7 +336,11 @@ def test_api_contract_fields():
     matchup = client.get("/api/v1/matchups/20260603|광역자치단체장|11-000")
     assert matchup.status_code == 200
     assert matchup.json()["options"][0]["option_name"] == "정원오"
+    assert matchup.json()["survey_start_date"] == "2026-02-15"
     assert matchup.json()["audience_scope"] == "regional"
+    assert matchup.json()["confidence_level"] == 95.0
+    assert matchup.json()["sample_size"] == 1000
+    assert matchup.json()["response_rate"] == 12.3
     assert matchup.json()["legal_required_count"] == 7
     assert matchup.json()["source_channel"] == "article"
     assert matchup.json()["source_channels"] == ["article", "nesdc"]

--- a/tests/test_ingest_service.py
+++ b/tests/test_ingest_service.py
@@ -64,6 +64,7 @@ PAYLOAD = {
                 "observation_key": "obs-1",
                 "survey_name": "survey",
                 "pollster": "MBC",
+                "confidence_level": 95.0,
                 "sponsor": "서울일보",
                 "method": "전화면접",
                 "region_code": "11-000",
@@ -100,6 +101,7 @@ def test_idempotent_ingest_no_duplicate_records():
     assert repo.observations["obs-1"]["legal_filled_count"] == 6
     assert len(repo.observations["obs-1"]["poll_fingerprint"]) == 64
     assert repo.observations["obs-1"]["source_channels"] == ["article"]
+    assert repo.observations["obs-1"]["confidence_level"] == 95.0
 
 
 def test_ingest_error_pushes_review_queue():

--- a/tests/test_poll_fingerprint.py
+++ b/tests/test_poll_fingerprint.py
@@ -33,6 +33,7 @@ def test_merge_prefers_nesdc_metadata_and_keeps_article_context():
         "sponsor": None,
         "survey_start_date": "2026-02-10",
         "survey_end_date": "2026-02-12",
+        "confidence_level": None,
         "sample_size": 1000,
         "response_rate": None,
         "margin_of_error": 3.1,
@@ -55,6 +56,7 @@ def test_merge_prefers_nesdc_metadata_and_keeps_article_context():
         "sponsor": "중앙선거여론조사심의위",
         "survey_start_date": "2026-02-10",
         "survey_end_date": "2026-02-12",
+        "confidence_level": 95.0,
         "sample_size": 1000,
         "response_rate": 11.2,
         "margin_of_error": 3.1,
@@ -75,6 +77,7 @@ def test_merge_prefers_nesdc_metadata_and_keeps_article_context():
     assert merged["source_channel"] == "nesdc"
     assert merged["source_channels"] == ["article", "nesdc"]
     assert merged["pollster"] == "KBS"
+    assert merged["confidence_level"] == 95.0
     assert merged["method"] == "전화면접"
     assert merged["survey_name"] == "기사 제목 기반 조사"
     assert merged["article_id"] == 101

--- a/tests/test_repository_matchup_legal_metadata.py
+++ b/tests/test_repository_matchup_legal_metadata.py
@@ -1,0 +1,73 @@
+from datetime import date
+
+from app.services.repository import PostgresRepository
+
+
+class _Cursor:
+    def __init__(self):
+        self.execs: list[str] = []
+        self._step = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):  # noqa: ANN001
+        return False
+
+    def execute(self, query, params=None):  # noqa: ARG002
+        self.execs.append(query)
+
+    def fetchone(self):
+        if self._step == 0:
+            self._step += 1
+            return {
+                "matchup_id": "m1",
+                "region_code": "11-000",
+                "office_type": "광역자치단체장",
+                "title": "서울시장 가상대결",
+                "pollster": "KBS",
+                "survey_start_date": date(2026, 2, 15),
+                "survey_end_date": date(2026, 2, 18),
+                "confidence_level": 95.0,
+                "sample_size": 1000,
+                "response_rate": 12.3,
+                "margin_of_error": 3.1,
+                "source_grade": "B",
+                "audience_scope": "regional",
+                "audience_region_code": "11-000",
+                "sampling_population_text": "서울시 거주 만 18세 이상",
+                "legal_completeness_score": 0.86,
+                "legal_filled_count": 6,
+                "legal_required_count": 7,
+                "date_resolution": "exact",
+                "poll_fingerprint": "f" * 64,
+                "source_channel": "article",
+                "source_channels": ["article", "nesdc"],
+                "verified": True,
+                "observation_id": 101,
+            }
+        return None
+
+    def fetchall(self):
+        return [{"option_name": "정원오", "value_mid": 44.0, "value_raw": "44%"}]
+
+
+class _Conn:
+    def __init__(self):
+        self.cur = _Cursor()
+
+    def cursor(self):
+        return self.cur
+
+
+def test_get_matchup_returns_legal_metadata_fields():
+    repo = PostgresRepository(_Conn())
+    out = repo.get_matchup("m1")
+
+    assert out is not None
+    assert out["survey_start_date"] == date(2026, 2, 15)
+    assert out["confidence_level"] == 95.0
+    assert out["sample_size"] == 1000
+    assert out["response_rate"] == 12.3
+    assert out["audience_scope"] == "regional"
+

--- a/tests/test_schema_legal_metadata.py
+++ b/tests/test_schema_legal_metadata.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+
+def test_schema_contains_legal_metadata_columns_and_backfill():
+    sql = Path("db/schema.sql").read_text(encoding="utf-8")
+    assert "confidence_level FLOAT NULL" in sql
+    assert "audience_scope TEXT NULL" in sql
+    assert "audience_region_code TEXT NULL" in sql
+    assert "source_channels TEXT[] NULL" in sql
+    assert "UPDATE poll_observations" in sql
+    assert "SET source_channels = ARRAY[source_channel]" in sql


### PR DESCRIPTION
## Summary
- `poll_observations`에 법정메타 v2 확장을 반영(`confidence_level` 포함)
- `GET /api/v1/matchups/{matchup_id}`에 법정메타 필드 노출 일관성 강화
- null/결측 정책 문서화 및 법정메타 샘플 응답 1세트 추가
- migration/contract/repository 테스트 보강

## Linked Issue
- Closes #86

## Report-Path
Report-Path: develop_report/2026-02-19_legal_metadata_schema_api_extension_report.md

## Checklist
- [x] docs 계약(필드/API/용어)과 일치
- [x] 테스트 또는 검증 로그 첨부
- [x] 보안 정보(key/secret) 미포함 확인
- [x] Report-Path 파일이 이번 PR에 포함됨

## Validation
- `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q tests/test_schema_legal_metadata.py tests/test_repository_matchup_legal_metadata.py tests/test_api_routes.py tests/test_ingest_service.py tests/test_poll_fingerprint.py` -> 14 passed
- `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q` -> 63 passed
