### PR TITLE
feat(develop): relative date policy + review routing for #91

### DIFF
--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -103,6 +103,8 @@ class MatchupOut(BaseModel):
     legal_filled_count: int | None = None
     legal_required_count: int | None = None
     date_resolution: str | None = None
+    date_inference_mode: str | None = None
+    date_inference_confidence: float | None = None
     poll_fingerprint: str | None = None
     source_channel: Literal["article", "nesdc"] | None = None
     source_channels: list[Literal["article", "nesdc"]] | None = None
@@ -124,6 +126,8 @@ class OpsIngestionMetricsOut(BaseModel):
     failed_runs: int
     total_processed_count: int
     total_error_count: int
+    date_inference_failed_count: int = 0
+    date_inference_estimated_count: int = 0
     fetch_fail_rate: float
 
 
@@ -266,6 +270,8 @@ class PollObservationInput(BaseModel):
     legal_filled_count: int | None = None
     legal_required_count: int | None = None
     date_resolution: str | None = None
+    date_inference_mode: str | None = None
+    date_inference_confidence: float | None = None
     poll_fingerprint: str | None = None
     source_channel: Literal["article", "nesdc"] = "article"
     source_channels: list[Literal["article", "nesdc"]] | None = None

--- a/app/services/fingerprint.py
+++ b/app/services/fingerprint.py
@@ -100,6 +100,8 @@ def merge_observation_by_priority(existing: dict, incoming: dict) -> dict:
         "legal_filled_count",
         "legal_required_count",
         "date_resolution",
+        "date_inference_mode",
+        "date_inference_confidence",
         "method",
     )
     for field in meta_fields:

--- a/data/legal_metadata_matchup_sample_v1.json
+++ b/data/legal_metadata_matchup_sample_v1.json
@@ -18,6 +18,8 @@
   "legal_filled_count": 6,
   "legal_required_count": 7,
   "date_resolution": "exact",
+  "date_inference_mode": "relative_published_at",
+  "date_inference_confidence": 0.92,
   "poll_fingerprint": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
   "source_channel": "article",
   "source_channels": ["article", "nesdc"],

--- a/data/relative_date_policy_comparison_v1.json
+++ b/data/relative_date_policy_comparison_v1.json
@@ -1,0 +1,26 @@
+{
+  "scenario": "relative_date_policy_comparison_v1",
+  "generated_at": "2026-02-19T08:10:00Z",
+  "policies": {
+    "strict_fail": {
+      "article_published_at_missing": {
+        "survey_end_date": null,
+        "date_inference_mode": "strict_fail_blocked",
+        "date_inference_confidence": 0.0,
+        "review_queue_error_code": "RELATIVE_DATE_STRICT_FAIL"
+      }
+    },
+    "allow_estimated_timestamp": {
+      "article_published_at_missing": {
+        "survey_end_date": "2026-02-18",
+        "date_inference_mode": "estimated_timestamp",
+        "date_inference_confidence": 0.35,
+        "review_queue_error_code": "RELATIVE_DATE_ESTIMATED"
+      }
+    }
+  },
+  "ingestion_run_counters": {
+    "date_inference_failed_count": 1,
+    "date_inference_estimated_count": 1
+  }
+}

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -51,9 +51,15 @@ CREATE TABLE IF NOT EXISTS ingestion_runs (
     llm_model TEXT NULL,
     processed_count INT NOT NULL DEFAULT 0,
     error_count INT NOT NULL DEFAULT 0,
+    date_inference_failed_count INT NOT NULL DEFAULT 0,
+    date_inference_estimated_count INT NOT NULL DEFAULT 0,
     started_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     ended_at TIMESTAMPTZ NULL
 );
+
+ALTER TABLE ingestion_runs
+    ADD COLUMN IF NOT EXISTS date_inference_failed_count INT NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS date_inference_estimated_count INT NOT NULL DEFAULT 0;
 
 CREATE TABLE IF NOT EXISTS poll_observations (
     id BIGSERIAL PRIMARY KEY,
@@ -79,6 +85,8 @@ CREATE TABLE IF NOT EXISTS poll_observations (
     legal_filled_count INT NULL,
     legal_required_count INT NULL,
     date_resolution TEXT NULL,
+    date_inference_mode TEXT NULL,
+    date_inference_confidence FLOAT NULL,
     poll_fingerprint TEXT NULL,
     source_channel TEXT NULL,
     source_channels TEXT[] NULL,
@@ -100,6 +108,8 @@ ALTER TABLE poll_observations
     ADD COLUMN IF NOT EXISTS legal_filled_count INT NULL,
     ADD COLUMN IF NOT EXISTS legal_required_count INT NULL,
     ADD COLUMN IF NOT EXISTS date_resolution TEXT NULL,
+    ADD COLUMN IF NOT EXISTS date_inference_mode TEXT NULL,
+    ADD COLUMN IF NOT EXISTS date_inference_confidence FLOAT NULL,
     ADD COLUMN IF NOT EXISTS poll_fingerprint TEXT NULL,
     ADD COLUMN IF NOT EXISTS source_channel TEXT NULL,
     ADD COLUMN IF NOT EXISTS source_channels TEXT[] NULL;

--- a/develop_report/2026-02-19_relative_date_policy_and_review_routing_report.md
+++ b/develop_report/2026-02-19_relative_date_policy_and_review_routing_report.md
@@ -1,0 +1,90 @@
+# 2026-02-19 Relative Date Policy and Review Routing Report (Issue #91)
+
+## 1. 작업 개요
+- 이슈: [#91](https://github.com/iAmSomething/2026-/issues/91)
+- 목표: 상대시점 변환 정책화 + 불확실성/실패 review_queue 라우팅 + 정책 카운트 운영 추적
+- 브랜치: `codex/issue91-relative-date-policy`
+
+## 2. 구현 내용
+### 2.1 변환 정책 플래그 도입
+- 파일: `src/pipeline/collector.py`
+- 정책:
+  - `strict_fail` (기본)
+  - `allow_estimated_timestamp`
+- 동작:
+  - 상대시점 문구(어제/그제/오늘/지난주/최근) 감지
+  - `published_at` 기준 변환 우선
+  - `published_at` 결측 시
+    - `strict_fail`: `date_inference_mode=strict_fail_blocked`, `survey_end_date=null`, review_queue 라우팅
+    - `allow_estimated_timestamp`: `collected_at` fallback 추정, `date_inference_mode=estimated_timestamp`, review_queue 라우팅
+
+### 2.2 데이터 모델 확장
+- 파일: `db/schema.sql`
+  - `poll_observations` 신규 컬럼:
+    - `date_inference_mode`
+    - `date_inference_confidence`
+  - `ingestion_runs` 신규 컬럼:
+    - `date_inference_failed_count`
+    - `date_inference_estimated_count`
+- 파일: `app/models/schemas.py`
+  - `PollObservationInput`, `MatchupOut`에 `date_inference_mode`, `date_inference_confidence` 반영
+- 파일: `src/pipeline/contracts.py`, `src/pipeline/ingest_adapter.py`
+  - collector->ingest 계약에 inference 필드 반영
+
+### 2.3 운영 라우팅 + 카운트
+- 파일: `src/pipeline/collector.py`
+  - 불확실/실패 건 자동 review_queue 라우팅 (`extract_error` + 세부 error_code)
+    - `RELATIVE_DATE_UNCERTAIN`
+    - `RELATIVE_DATE_ESTIMATED`
+    - `RELATIVE_DATE_STRICT_FAIL`
+- 파일: `app/services/ingest_service.py`
+  - `date_inference_mode/confidence` 기준으로 불확실 건 review_queue 라우팅
+  - 실행 종료 시 정책 카운트 저장
+- 파일: `app/services/repository.py`
+  - `update_ingestion_policy_counters(...)` 추가
+  - `fetch_ops_ingestion_metrics`에 정책 카운트 집계 포함
+
+### 2.4 API/문서/샘플
+- 파일: `app/services/repository.py`
+  - `GET /api/v1/matchups/{matchup_id}` 응답에 inference 필드 노출
+- 파일: `docs/01_DATA_PIPELINE_STRATEGY.md`
+  - 상대시점 정책 섹션 추가
+- 파일: `docs/02_DATA_MODEL_AND_NORMALIZATION.md`
+  - `date_inference_*` 필드/정책 반영
+- 파일: `docs/03_UI_UX_SPEC.md`
+  - matchup 상세 필수 필드에 inference 항목 반영
+- 파일: `docs/04_DEPLOYMENT_AND_ENVIRONMENT.md`
+  - 선택 환경변수 `RELATIVE_DATE_POLICY` 반영
+- 파일: `docs/05_RUNBOOK_AND_OPERATIONS.md`
+  - 운영 규칙/지표 항목 업데이트
+- 샘플/비교:
+  - `data/legal_metadata_matchup_sample_v1.json`
+  - `data/relative_date_policy_comparison_v1.json`
+
+## 3. 테스트/검증
+### 3.1 정책/라우팅 테스트
+- `tests/test_collector_extract.py`
+  - strict_fail 라우팅
+  - allow_estimated_timestamp fallback
+  - 저신뢰(`confidence < 0.8`) 라우팅
+- `tests/test_ingest_service.py`
+  - 불확실 inference review_queue 라우팅 + ingestion_runs 정책 카운트 업데이트 검증
+
+### 3.2 계약/저장 테스트
+- `tests/test_schema_legal_metadata.py`
+  - 스키마/마이그레이션 구문 검증
+- `tests/test_repository_matchup_legal_metadata.py`
+  - matchup 조회 필드 검증
+- `tests/test_api_routes.py`, `tests/test_ingest_adapter.py`, `tests/test_poll_fingerprint.py`
+  - 계약/전파/병합 회귀 검증
+
+### 3.3 실행 결과
+- `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q tests/test_collector_extract.py tests/test_ingest_service.py tests/test_repository_matchup_legal_metadata.py tests/test_schema_legal_metadata.py tests/test_api_routes.py tests/test_ingest_adapter.py tests/test_poll_fingerprint.py`
+  - 결과: `28 passed`
+- `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q`
+  - 결과: `67 passed`
+
+## 4. DoD 충족 여부
+1. 정책 플래그 + 저장 필드 + 라우팅 테스트 PASS: 완료
+2. 정책별 결과 비교 샘플 제출: 완료 (`data/relative_date_policy_comparison_v1.json`)
+3. 운영 문서 업데이트: 완료 (`docs/05_RUNBOOK_AND_OPERATIONS.md` 포함)

--- a/docs/01_DATA_PIPELINE_STRATEGY.md
+++ b/docs/01_DATA_PIPELINE_STRATEGY.md
@@ -1,7 +1,7 @@
 # 데이터 파이프라인 전략
 
 - 문서 버전: v0.2
-- 최종 수정일: 2026-02-18
+- 최종 수정일: 2026-02-19
 - 수정자: Codex
 
 ## 1. End-to-End 흐름
@@ -71,6 +71,13 @@
 3. 코드 매핑 실패: `mapping_error` 상태로 검수 큐 이동
 4. 중복 적재 시도: idempotency key로 upsert
 5. robots/약관 위반 가능 URL: 영구 제외 목록 등록
+
+## 6.1 상대시점 변환 정책
+1. 기본 정책 `strict_fail`:
+- 상대시점 문구(예: 어제/지난주) + `article.published_at` 결측이면 변환 실패(`date_inference_mode=strict_fail_blocked`)로 기록하고 검수 큐 라우팅
+2. 선택 정책 `allow_estimated_timestamp`:
+- `article.collected_at`를 fallback 기준시각으로 사용해 추정 변환(`date_inference_mode=estimated_timestamp`)
+3. 저신뢰 추론(`date_inference_confidence < 0.8`)은 정책과 무관하게 검수 큐 라우팅
 
 ## 7. 배치 주기
 - 기본: 2시간 간격

--- a/docs/02_DATA_MODEL_AND_NORMALIZATION.md
+++ b/docs/02_DATA_MODEL_AND_NORMALIZATION.md
@@ -23,6 +23,7 @@
 - `region_code`, `office_type`, `matchup_id`, `verified`, `source_grade`, `ingestion_run_id`
 - `audience_scope`(`national|regional|local`), `audience_region_code`, `sampling_population_text`
 - `legal_completeness_score`, `legal_filled_count`, `legal_required_count`, `date_resolution`
+- `date_inference_mode`, `date_inference_confidence`
 - `poll_fingerprint`, `source_channel`(`article|nesdc`), `source_channels`(다중 provenance)
 
 ## 1.4 `poll_options`
@@ -116,3 +117,4 @@
 1. 수집기에서 값이 없거나 추론 불가인 경우 `survey_start_date`, `survey_end_date`, `confidence_level`, `margin_of_error`, `response_rate`, `sample_size`는 `null` 저장한다.
 2. `audience_scope`, `audience_region_code`도 불명확하면 `null` 저장한다.
 3. API는 DB 값을 그대로 노출하며, 결측은 `null`로 유지한다.
+4. 상대시점 추론 결과는 `date_inference_mode`, `date_inference_confidence`에 저장한다.

--- a/docs/03_UI_UX_SPEC.md
+++ b/docs/03_UI_UX_SPEC.md
@@ -63,7 +63,7 @@
 | 빅매치 카드 | `GET /api/v1/dashboard/big-matches` | `matchups`, `poll_observations` | `matchup_id`, `title`, `survey_end_date`, `value_mid`, `source_channel`, `source_channels` |
 | 지역 검색 | `GET /api/v1/regions/search` | `regions` | `region_code`, `sido_name`, `sigungu_name` |
 | 지역별 선거 탭 | `GET /api/v1/regions/{region_code}/elections` | `matchups` | `region_code`, `office_type`, `is_active` |
-| 매치업 상세 | `GET /api/v1/matchups/{matchup_id}` | `poll_observations`, `poll_options` | `matchup_id`, `pollster`, `survey_start_date`, `survey_end_date`, `confidence_level`, `sample_size`, `response_rate`, `margin_of_error`, `value_mid`, `source_grade`, `audience_scope`, `audience_region_code`, `legal_completeness_score`, `legal_filled_count`, `legal_required_count`, `source_channel`, `source_channels`, `poll_fingerprint` |
+| 매치업 상세 | `GET /api/v1/matchups/{matchup_id}` | `poll_observations`, `poll_options` | `matchup_id`, `pollster`, `survey_start_date`, `survey_end_date`, `confidence_level`, `sample_size`, `response_rate`, `margin_of_error`, `date_inference_mode`, `date_inference_confidence`, `value_mid`, `source_grade`, `audience_scope`, `audience_region_code`, `legal_completeness_score`, `legal_filled_count`, `legal_required_count`, `source_channel`, `source_channels`, `poll_fingerprint` |
 | 후보자 상세 | `GET /api/v1/candidates/{candidate_id}` | `candidates`, `candidate_profiles` | `candidate_id`, `name_ko`, `party_name`, `career_summary` |
 
 ## 5. API-UI 필드명 일치 규칙

--- a/docs/04_DEPLOYMENT_AND_ENVIRONMENT.md
+++ b/docs/04_DEPLOYMENT_AND_ENVIRONMENT.md
@@ -1,7 +1,7 @@
 # 배포 및 개발 환경 명세
 
 - 문서 버전: v0.2
-- 최종 수정일: 2026-02-18
+- 최종 수정일: 2026-02-19
 - 수정자: Codex
 
 ## 1. 최종 배포 아키텍처
@@ -99,6 +99,8 @@ PYTHONPATH=. .venv/bin/python scripts/sync_common_codes.py \
 - `DATA_GO_KR_KEY`
 - `DATABASE_URL`
 - `INTERNAL_JOB_TOKEN`
+4. 선택 환경변수:
+- `RELATIVE_DATE_POLICY` (`strict_fail` 기본, `allow_estimated_timestamp` 선택)
 4. CI 부트스트랩 전략:
 - `DATABASE_URL` secret가 비어 있으면 workflow service postgres(`postgresql://postgres:postgres@127.0.0.1:5432/app`)로 자동 fallback
 - secret preflight는 fallback 반영 후 실행되어 DB URL 누락 원인을 즉시 표시

--- a/docs/05_RUNBOOK_AND_OPERATIONS.md
+++ b/docs/05_RUNBOOK_AND_OPERATIONS.md
@@ -1,7 +1,7 @@
 # 운영 런북 및 체크리스트
 
 - 문서 버전: v0.2
-- 최종 수정일: 2026-02-18
+- 최종 수정일: 2026-02-19
 - 수정자: Codex
 
 ## 1. 운영 목표
@@ -30,6 +30,8 @@
 - `DATA_GO_KR_KEY`
 - `DATABASE_URL`
 - `INTERNAL_JOB_TOKEN`
+5. 상대시점 정책 플래그:
+- `RELATIVE_DATE_POLICY` (`strict_fail` 기본, `allow_estimated_timestamp` 선택)
 
 ## 3. 수동/자동 경계
 ### 자동 처리
@@ -73,6 +75,14 @@
 - 헬스체크
 - 직전 배포 버전 롤백
 
+## 6.2 상대시점 변환 운영 규칙
+1. 기본 정책 `strict_fail`:
+- 기사에 상대시점(예: 어제/지난주)이 있고 `article.published_at`가 없으면 `survey_end_date`를 비워두고 review_queue 라우팅
+2. 선택 정책 `allow_estimated_timestamp`:
+- `article.published_at` 결측 시 `article.collected_at` 기반 추정값 허용
+- `date_inference_mode='estimated_timestamp'` 저장, review_queue 라우팅
+3. 불확실 추론(`date_inference_confidence < 0.8`)은 정책과 무관하게 review_queue 라우팅
+
 ## 6.1 재시도 운영 규칙
 1. 내부 배치 호출 실패(네트워크/5xx/partial_success) 시 최대 2회 재시도
 2. 재시도 간 backoff: 1초, 2초
@@ -104,6 +114,8 @@
 2. 확인 항목:
 - `ingestion.total_runs/success_runs/failed_runs`
 - `ingestion.fetch_fail_rate`
+- `ingestion.date_inference_failed_count`
+- `ingestion.date_inference_estimated_count`
 - `review_queue.pending_over_24h_count`
 - `failure_distribution` 상위 `issue_type`
 3. `GET /api/v1/ops/coverage/summary` 호출

--- a/src/pipeline/contracts.py
+++ b/src/pipeline/contracts.py
@@ -87,6 +87,8 @@ POLL_OBSERVATION_SCHEMA: dict[str, Any] = {
         "legal_filled_count": {"type": ["integer", "null"]},
         "legal_required_count": {"type": ["integer", "null"]},
         "date_resolution": {"type": ["string", "null"]},
+        "date_inference_mode": {"type": ["string", "null"]},
+        "date_inference_confidence": {"type": ["number", "null"]},
         "poll_fingerprint": {"type": ["string", "null"]},
         "source_channel": {"type": ["string", "null"], "enum": ["article", "nesdc", None]},
         "source_channels": {
@@ -217,6 +219,8 @@ class PollObservation:
     legal_filled_count: int | None = None
     legal_required_count: int | None = None
     date_resolution: str | None = None
+    date_inference_mode: str | None = None
+    date_inference_confidence: float | None = None
     poll_fingerprint: str | None = None
     source_channel: str | None = None
     source_channels: list[str] | None = None

--- a/src/pipeline/ingest_adapter.py
+++ b/src/pipeline/ingest_adapter.py
@@ -97,6 +97,8 @@ def collector_output_to_ingest_payload(
                     "legal_filled_count": getattr(observation, "legal_filled_count", None),
                     "legal_required_count": getattr(observation, "legal_required_count", None),
                     "date_resolution": getattr(observation, "date_resolution", None),
+                    "date_inference_mode": getattr(observation, "date_inference_mode", None),
+                    "date_inference_confidence": getattr(observation, "date_inference_confidence", None),
                     "poll_fingerprint": getattr(observation, "poll_fingerprint", None),
                     "source_channel": getattr(observation, "source_channel", "article"),
                     "source_channels": getattr(observation, "source_channels", None),

--- a/src/pipeline/run_collector.py
+++ b/src/pipeline/run_collector.py
@@ -34,6 +34,12 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--rss-file", help="Path to file with RSS URLs (one per line)")
     parser.add_argument("--election-id", default="2026_local", help="Election id used for matchup_id")
     parser.add_argument("--output", help="Write output JSON to this file")
+    parser.add_argument(
+        "--relative-date-policy",
+        default=None,
+        choices=["strict_fail", "allow_estimated_timestamp"],
+        help="Relative date inference policy when article.published_at is missing",
+    )
     parser.add_argument("--print-contracts", action="store_true", help="Print input/error contract schemas")
     parser.add_argument("--print-query-templates", action="store_true", help="Print discovery query templates")
     return parser
@@ -44,7 +50,7 @@ def main() -> None:
     seeds = [*args.seed, *_load_lines(args.seed_file)]
     rss_feeds = [*args.rss, *_load_lines(args.rss_file)]
 
-    collector = PollCollector(election_id=args.election_id)
+    collector = PollCollector(election_id=args.election_id, relative_date_policy=args.relative_date_policy)
     result = collector.run(seeds=seeds, rss_feeds=rss_feeds)
     payload: dict[str, Any] = result.to_dict()
 

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -107,6 +107,8 @@ class FakeApiRepo:
             "legal_filled_count": 6,
             "legal_required_count": 7,
             "date_resolution": "exact",
+            "date_inference_mode": "relative_published_at",
+            "date_inference_confidence": 0.92,
             "poll_fingerprint": "f" * 64,
             "source_channel": "article",
             "source_channels": ["article", "nesdc"],
@@ -139,6 +141,8 @@ class FakeApiRepo:
             "failed_runs": 1,
             "total_processed_count": 500,
             "total_error_count": 30,
+            "date_inference_failed_count": 2,
+            "date_inference_estimated_count": 5,
             "fetch_fail_rate": 0.0566,
         }
 
@@ -342,6 +346,8 @@ def test_api_contract_fields():
     assert matchup.json()["sample_size"] == 1000
     assert matchup.json()["response_rate"] == 12.3
     assert matchup.json()["legal_required_count"] == 7
+    assert matchup.json()["date_inference_mode"] == "relative_published_at"
+    assert matchup.json()["date_inference_confidence"] == 0.92
     assert matchup.json()["source_channel"] == "article"
     assert matchup.json()["source_channels"] == ["article", "nesdc"]
 

--- a/tests/test_ingest_adapter.py
+++ b/tests/test_ingest_adapter.py
@@ -29,6 +29,8 @@ def test_collector_output_converts_to_ingest_payload():
     obs[0].legal_filled_count = 5
     obs[0].legal_required_count = 7
     obs[0].date_resolution = "exact"
+    obs[0].date_inference_mode = "relative_published_at"
+    obs[0].date_inference_confidence = 0.92
     obs[0].source_channel = "article"
     obs[0].source_channels = ["article"]
     output.poll_observations.extend(obs)
@@ -45,3 +47,4 @@ def test_collector_output_converts_to_ingest_payload():
     assert parsed.records[0].observation.legal_required_count == 7
     assert parsed.records[0].observation.source_channel == "article"
     assert parsed.records[0].observation.source_channels == ["article"]
+    assert parsed.records[0].observation.date_inference_mode == "relative_published_at"

--- a/tests/test_repository_matchup_legal_metadata.py
+++ b/tests/test_repository_matchup_legal_metadata.py
@@ -40,6 +40,8 @@ class _Cursor:
                 "legal_filled_count": 6,
                 "legal_required_count": 7,
                 "date_resolution": "exact",
+                "date_inference_mode": "relative_published_at",
+                "date_inference_confidence": 0.92,
                 "poll_fingerprint": "f" * 64,
                 "source_channel": "article",
                 "source_channels": ["article", "nesdc"],
@@ -70,4 +72,5 @@ def test_get_matchup_returns_legal_metadata_fields():
     assert out["sample_size"] == 1000
     assert out["response_rate"] == 12.3
     assert out["audience_scope"] == "regional"
-
+    assert out["date_inference_mode"] == "relative_published_at"
+    assert out["date_inference_confidence"] == 0.92

--- a/tests/test_schema_legal_metadata.py
+++ b/tests/test_schema_legal_metadata.py
@@ -4,8 +4,12 @@ from pathlib import Path
 def test_schema_contains_legal_metadata_columns_and_backfill():
     sql = Path("db/schema.sql").read_text(encoding="utf-8")
     assert "confidence_level FLOAT NULL" in sql
+    assert "date_inference_mode TEXT NULL" in sql
+    assert "date_inference_confidence FLOAT NULL" in sql
     assert "audience_scope TEXT NULL" in sql
     assert "audience_region_code TEXT NULL" in sql
     assert "source_channels TEXT[] NULL" in sql
+    assert "date_inference_failed_count INT NOT NULL DEFAULT 0" in sql
+    assert "date_inference_estimated_count INT NOT NULL DEFAULT 0" in sql
     assert "UPDATE poll_observations" in sql
     assert "SET source_channels = ARRAY[source_channel]" in sql


### PR DESCRIPTION
## Summary
- 상대시점 변환 정책(`strict_fail`/`allow_estimated_timestamp`) 도입
- `date_inference_mode`, `date_inference_confidence` 저장 필드 확장
- 불확실/실패 상대시점 건 review_queue 자동 라우팅
- `ingestion_runs` 정책 카운트 저장(`date_inference_failed_count`, `date_inference_estimated_count`)
- 운영 문서/샘플 리포트/비교 JSON 반영

## Linked Issue
- Closes #91

## Report-Path
Report-Path: develop_report/2026-02-19_relative_date_policy_and_review_routing_report.md

## Checklist
- [x] docs 계약(필드/API/용어)과 일치
- [x] 테스트 또는 검증 로그 첨부
- [x] 보안 정보(key/secret) 미포함 확인
- [x] Report-Path 파일이 이번 PR에 포함됨

## Validation
- `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q tests/test_collector_extract.py tests/test_ingest_service.py tests/test_repository_matchup_legal_metadata.py tests/test_schema_legal_metadata.py tests/test_api_routes.py tests/test_ingest_adapter.py tests/test_poll_fingerprint.py` -> 28 passed
- `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q` -> 67 passed
