### PR TITLE
[DEVELOP] #95 매치업 상세 추정/보강 메타 계약 확장

### DIFF
--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -105,6 +105,8 @@ class MatchupOut(BaseModel):
     date_resolution: str | None = None
     date_inference_mode: str | None = None
     date_inference_confidence: float | None = None
+    nesdc_enriched: bool = False
+    needs_manual_review: bool = False
     poll_fingerprint: str | None = None
     source_channel: Literal["article", "nesdc"] | None = None
     source_channels: list[Literal["article", "nesdc"]] | None = None

--- a/data/inference_enrichment_matchup_sample_v1.json
+++ b/data/inference_enrichment_matchup_sample_v1.json
@@ -1,0 +1,44 @@
+{
+  "matchup_id": "20260603|광역자치단체장|11-000",
+  "region_code": "11-000",
+  "office_type": "광역자치단체장",
+  "title": "서울시장 가상대결",
+  "pollster": "KBS",
+  "survey_start_date": "2026-02-15",
+  "survey_end_date": "2026-02-18",
+  "confidence_level": 95.0,
+  "sample_size": 1000,
+  "response_rate": 12.3,
+  "margin_of_error": 3.1,
+  "source_grade": "B",
+  "audience_scope": "regional",
+  "audience_region_code": "11-000",
+  "sampling_population_text": "서울시 거주 만 18세 이상",
+  "legal_completeness_score": 0.86,
+  "legal_filled_count": 6,
+  "legal_required_count": 7,
+  "date_resolution": "exact",
+  "date_inference_mode": "relative_published_at",
+  "date_inference_confidence": 0.92,
+  "nesdc_enriched": true,
+  "needs_manual_review": true,
+  "poll_fingerprint": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "source_channel": "article",
+  "source_channels": [
+    "article",
+    "nesdc"
+  ],
+  "verified": true,
+  "options": [
+    {
+      "option_name": "정원오",
+      "value_mid": 44.0,
+      "value_raw": "44%"
+    },
+    {
+      "option_name": "오세훈",
+      "value_mid": 42.0,
+      "value_raw": "42%"
+    }
+  ]
+}

--- a/develop_report/2026-02-19_inference_enrichment_api_contract_report.md
+++ b/develop_report/2026-02-19_inference_enrichment_api_contract_report.md
@@ -1,0 +1,59 @@
+# 2026-02-19 Inference/Enrichment API Contract Report
+
+## 1. 작업 목표
+- Issue: #95 `[DEVELOP] 추정/보강 메타 API 계약 확장(date_inference/enriched/review)`
+- 대상 API: `GET /api/v1/matchups/{matchup_id}`
+- 목표: 아래 필드를 계약/조회/문서/샘플에 일관 반영
+  - `date_inference_mode`
+  - `date_inference_confidence`
+  - `nesdc_enriched`
+  - `needs_manual_review`
+
+## 2. 구현 내용
+1. API 응답 스키마 확장
+- `app/models/schemas.py`
+  - `MatchupOut`에 `nesdc_enriched: bool = False`
+  - `MatchupOut`에 `needs_manual_review: bool = False`
+
+2. 저장소 조회 로직 확장
+- `app/services/repository.py` (`get_matchup`)
+  - `nesdc_enriched` 계산:
+    - `source_channel='nesdc'` 또는 `source_channels`에 `nesdc` 포함 시 `true`
+  - `needs_manual_review` 계산:
+    - `review_queue`에서 동일 `observation_key` 기준
+    - `entity_type IN ('poll_observation', 'ingest_record')`
+    - `status IN ('pending', 'in_progress')`
+    - 존재 시 `true`
+
+3. 계약 테스트 보강
+- `tests/test_api_routes.py`
+  - `matchup` 응답에 `nesdc_enriched`, `needs_manual_review` 검증 추가
+- `tests/test_repository_matchup_legal_metadata.py`
+  - repository 반환값에 `nesdc_enriched`, `needs_manual_review` 검증 추가
+
+4. 문서 동기화
+- `docs/03_UI_UX_SPEC.md`
+  - 매치업 상세 필수 필드에 `nesdc_enriched`, `needs_manual_review` 반영
+  - `needs_manual_review`의 `review_queue` 연계 규칙 명시
+
+5. 샘플 응답 추가
+- `data/inference_enrichment_matchup_sample_v1.json`
+  - 확장 필드 포함 샘플 1건 추가
+
+## 3. 검증 결과
+1. 타겟 테스트
+- 명령: `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q tests/test_repository_matchup_legal_metadata.py tests/test_api_routes.py`
+- 결과: `7 passed`
+
+2. 전체 테스트
+- 명령: `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q`
+- 결과: `67 passed`
+
+## 4. DoD 점검
+1. 계약 테스트 PASS: 완료
+2. 샘플 응답 + 보고서 제출: 완료
+3. 문서 필드 동기화: 완료
+
+## 5. 산출물 경로
+- `develop_report/2026-02-19_inference_enrichment_api_contract_report.md`
+- `data/inference_enrichment_matchup_sample_v1.json`

--- a/docs/03_UI_UX_SPEC.md
+++ b/docs/03_UI_UX_SPEC.md
@@ -63,7 +63,7 @@
 | 빅매치 카드 | `GET /api/v1/dashboard/big-matches` | `matchups`, `poll_observations` | `matchup_id`, `title`, `survey_end_date`, `value_mid`, `source_channel`, `source_channels` |
 | 지역 검색 | `GET /api/v1/regions/search` | `regions` | `region_code`, `sido_name`, `sigungu_name` |
 | 지역별 선거 탭 | `GET /api/v1/regions/{region_code}/elections` | `matchups` | `region_code`, `office_type`, `is_active` |
-| 매치업 상세 | `GET /api/v1/matchups/{matchup_id}` | `poll_observations`, `poll_options` | `matchup_id`, `pollster`, `survey_start_date`, `survey_end_date`, `confidence_level`, `sample_size`, `response_rate`, `margin_of_error`, `date_inference_mode`, `date_inference_confidence`, `value_mid`, `source_grade`, `audience_scope`, `audience_region_code`, `legal_completeness_score`, `legal_filled_count`, `legal_required_count`, `source_channel`, `source_channels`, `poll_fingerprint` |
+| 매치업 상세 | `GET /api/v1/matchups/{matchup_id}` | `poll_observations`, `poll_options`, `review_queue` | `matchup_id`, `pollster`, `survey_start_date`, `survey_end_date`, `confidence_level`, `sample_size`, `response_rate`, `margin_of_error`, `date_inference_mode`, `date_inference_confidence`, `nesdc_enriched`, `needs_manual_review`, `value_mid`, `source_grade`, `audience_scope`, `audience_region_code`, `legal_completeness_score`, `legal_filled_count`, `legal_required_count`, `source_channel`, `source_channels`, `poll_fingerprint` |
 | 후보자 상세 | `GET /api/v1/candidates/{candidate_id}` | `candidates`, `candidate_profiles` | `candidate_id`, `name_ko`, `party_name`, `career_summary` |
 
 ## 5. API-UI 필드명 일치 규칙
@@ -75,3 +75,5 @@
 6. 매치업 상세는 조사 스코프(`audience_scope`)와 법정 completeness(`legal_*`)를 함께 노출
 7. 대시보드 계열 API의 `source_channels`는 null 대신 빈 배열(`[]`)을 기본값으로 노출
 8. 매치업 상세의 법정메타 결측값은 `null`로 유지한다(숫자/날짜 모두 동일)
+9. 매치업 상세의 `nesdc_enriched`는 `source_channels`에 `nesdc`가 포함되면 `true`다.
+10. 매치업 상세의 `needs_manual_review`는 연결된 `review_queue`가 `pending` 또는 `in_progress`이면 `true`다.

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -109,6 +109,8 @@ class FakeApiRepo:
             "date_resolution": "exact",
             "date_inference_mode": "relative_published_at",
             "date_inference_confidence": 0.92,
+            "nesdc_enriched": True,
+            "needs_manual_review": True,
             "poll_fingerprint": "f" * 64,
             "source_channel": "article",
             "source_channels": ["article", "nesdc"],
@@ -348,6 +350,8 @@ def test_api_contract_fields():
     assert matchup.json()["legal_required_count"] == 7
     assert matchup.json()["date_inference_mode"] == "relative_published_at"
     assert matchup.json()["date_inference_confidence"] == 0.92
+    assert matchup.json()["nesdc_enriched"] is True
+    assert matchup.json()["needs_manual_review"] is True
     assert matchup.json()["source_channel"] == "article"
     assert matchup.json()["source_channels"] == ["article", "nesdc"]
 

--- a/tests/test_repository_matchup_legal_metadata.py
+++ b/tests/test_repository_matchup_legal_metadata.py
@@ -42,6 +42,8 @@ class _Cursor:
                 "date_resolution": "exact",
                 "date_inference_mode": "relative_published_at",
                 "date_inference_confidence": 0.92,
+                "nesdc_enriched": True,
+                "needs_manual_review": True,
                 "poll_fingerprint": "f" * 64,
                 "source_channel": "article",
                 "source_channels": ["article", "nesdc"],
@@ -74,3 +76,5 @@ def test_get_matchup_returns_legal_metadata_fields():
     assert out["audience_scope"] == "regional"
     assert out["date_inference_mode"] == "relative_published_at"
     assert out["date_inference_confidence"] == 0.92
+    assert out["nesdc_enriched"] is True
+    assert out["needs_manual_review"] is True


### PR DESCRIPTION
## 작업 요약
- `GET /api/v1/matchups/{matchup_id}` 응답에 `nesdc_enriched`, `needs_manual_review` 추가
- repository 조회에서 `review_queue` 연계 수동검수 필요 여부 계산 추가
- API/repository 계약 테스트 보강 및 문서 동기화
- 샘플 응답 JSON/개발 보고서 제출

## 변경 파일
- `app/models/schemas.py`
- `app/services/repository.py`
- `tests/test_api_routes.py`
- `tests/test_repository_matchup_legal_metadata.py`
- `docs/03_UI_UX_SPEC.md`
- `data/inference_enrichment_matchup_sample_v1.json`
- `develop_report/2026-02-19_inference_enrichment_api_contract_report.md`

## 검증
- `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q tests/test_repository_matchup_legal_metadata.py tests/test_api_routes.py`
- `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q`

Closes #95

Report-Path: develop_report/2026-02-19_inference_enrichment_api_contract_report.md
