### PR TITLE
[DEVELOP] #92 Vercel Preview CI 배포 경로 확정

### DIFF
--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -1,0 +1,133 @@
+name: Vercel Preview
+
+on:
+  workflow_dispatch:
+    inputs:
+      root_dir:
+        description: "Web root directory"
+        required: true
+        default: "apps/staging-web"
+        type: choice
+        options:
+          - apps/staging-web
+          - apps/web
+      issue_number:
+        description: "Issue number to post preview URL"
+        required: true
+        default: "92"
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    env:
+      ROOT_DIR: ${{ inputs.root_dir }}
+      ISSUE_NUMBER: ${{ inputs.issue_number }}
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_SCOPE: ${{ secrets.VERCEL_SCOPE }}
+      VERCEL_PROJECT_NAME: ${{ secrets.VERCEL_PROJECT_NAME }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Preflight required Vercel secrets
+        run: |
+          missing=()
+          [ -z "${VERCEL_TOKEN:-}" ] && missing+=("VERCEL_TOKEN")
+          [ -z "${VERCEL_SCOPE:-}" ] && missing+=("VERCEL_SCOPE")
+          [ -z "${VERCEL_PROJECT_NAME:-}" ] && missing+=("VERCEL_PROJECT_NAME")
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "::error::Missing required repository secrets: ${missing[*]}"
+            exit 1
+          fi
+
+      - name: Validate root directory
+        run: |
+          if [ ! -d "$ROOT_DIR" ]; then
+            echo "::error::Root directory not found: $ROOT_DIR"
+            exit 1
+          fi
+          if [ ! -f "$ROOT_DIR/package.json" ]; then
+            echo "::error::package.json not found under root directory: $ROOT_DIR"
+            exit 1
+          fi
+
+      - name: Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: ${{ inputs.root_dir }}/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: ${{ inputs.root_dir }}
+
+      - name: Build web app
+        run: npm run build
+        working-directory: ${{ inputs.root_dir }}
+
+      - name: Deploy preview to Vercel
+        id: deploy
+        working-directory: ${{ inputs.root_dir }}
+        run: |
+          set -o pipefail
+          DEPLOY_LOG=/tmp/vercel-preview-deploy.log
+          npx vercel@latest deploy \
+            --yes \
+            --token "$VERCEL_TOKEN" \
+            --scope "$VERCEL_SCOPE" \
+            --name "$VERCEL_PROJECT_NAME" \
+            2>&1 | tee "$DEPLOY_LOG"
+
+          PREVIEW_URL=$(grep -Eo 'https://[^ ]+' "$DEPLOY_LOG" | grep 'vercel.app' | tail -n 1)
+          if [ -z "$PREVIEW_URL" ]; then
+            echo "::error::Preview URL was not found in deploy log"
+            exit 1
+          fi
+
+          echo "preview_url=$PREVIEW_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Verify preview URL accessibility
+        id: verify
+        run: |
+          PREVIEW_URL="${{ steps.deploy.outputs.preview_url }}"
+          curl -fsSL "$PREVIEW_URL" -o /tmp/vercel-preview-home.html
+          echo "verified=true" >> "$GITHUB_OUTPUT"
+
+      - name: Comment preview URL to issue
+        if: ${{ success() && env.ISSUE_NUMBER != '' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issueNumber = Number(process.env.ISSUE_NUMBER);
+            const previewUrl = "${{ steps.deploy.outputs.preview_url }}";
+            const rootDir = process.env.ROOT_DIR;
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              body: [
+                "[DEVELOP] Vercel preview URL issued via CI.",
+                "",
+                `- root_dir: ${rootDir}`,
+                `- preview_url: ${previewUrl}`,
+                `- action_run: ${runUrl}`,
+                "",
+                "Access verification: curl success"
+              ].join("\n")
+            });
+
+      - name: Upload deploy artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: vercel-preview-${{ github.run_id }}
+          path: |
+            /tmp/vercel-preview-deploy.log
+            /tmp/vercel-preview-home.html

--- a/develop_report/2026-02-19_preview_url_publish_report.md
+++ b/develop_report/2026-02-19_preview_url_publish_report.md
@@ -1,0 +1,56 @@
+# 2026-02-19 Preview URL Publish Report
+
+## 1. 목적
+- Issue #92 `[DEVELOP] 외부 프리뷰 URL 발급(비차단 병렬트랙)` 대응
+- 배포 타깃 `Vercel`, 배포 방식 `CI`, 토큰은 GitHub Secrets로만 주입
+
+## 2. 구현 결과
+1. Preview 배포 워크플로 추가
+- 파일: `.github/workflows/vercel-preview.yml`
+- 트리거: `workflow_dispatch`
+- 입력값:
+  - `root_dir` (`apps/staging-web` | `apps/web`)
+  - `issue_number` (기본값 `92`)
+
+2. 보안/운영 강제
+- 필수 Secret 미주입 시 fail-fast:
+  - `VERCEL_TOKEN`
+  - `VERCEL_SCOPE` (team slug)
+  - `VERCEL_PROJECT_NAME`
+- 민감값 출력 금지(Secret 원문 로그 미출력)
+
+3. 자동화 동작
+- 웹 빌드 성공 후 `vercel deploy` 실행
+- 배포 로그에서 Preview URL 추출
+- `curl` 접근 확인 수행
+- 액션 artifact 업로드:
+  - `/tmp/vercel-preview-deploy.log`
+  - `/tmp/vercel-preview-home.html`
+- 성공 시 지정 이슈에 URL 자동 코멘트
+
+4. 문서 동기화
+- 파일: `docs/04_DEPLOYMENT_AND_ENVIRONMENT.md`
+- 섹션 추가: `12. Vercel Preview CI (Issue #92)`
+
+## 3. 로컬 검증
+1. 명령
+- `npm --prefix apps/staging-web ci`
+- `npm --prefix apps/staging-web run build`
+2. 결과
+- build 성공
+
+## 4. 현재 상태
+- CI 파이프라인 준비 완료
+- 실제 외부 Preview URL 발급은 아래 Secret 값 주입 후 `workflow_dispatch` 실행 시 완료
+
+## 5. 오너 입력 필요(의사결정)
+1. `VERCEL_SCOPE` 실제 값 확정 (`<team_slug>` 대체)
+2. `VERCEL_PROJECT_NAME` 실제 값 확정 (`<project_name>` 대체)
+3. 기본 root_dir 확정 권고:
+- 현재 main 기준 빌드 가능한 경로는 `apps/staging-web`
+- `apps/web`는 `package.json` 부재로 현재 배포 불가
+
+## 6. 후속 액션(DEVELOP)
+1. Secret 주입 확인
+2. `Vercel Preview` 워크플로 실행 (`root_dir=apps/staging-web`, `issue_number=92`)
+3. 발급 URL/접근 검증 로그를 이슈 #92 코멘트 및 본 보고서에 최종 반영

--- a/docs/04_DEPLOYMENT_AND_ENVIRONMENT.md
+++ b/docs/04_DEPLOYMENT_AND_ENVIRONMENT.md
@@ -152,3 +152,20 @@ scripts/qa/smoke_staging.sh --api-base "$API_BASE" --web-base "$WEB_BASE"
 4. 동작:
 - 누락 secret 발견 시 fail-fast
 - 형식 오류(`SUPABASE_URL`, `DATABASE_URL`, `INTERNAL_JOB_TOKEN`)에 대해 즉시 가이드 출력
+
+## 12. Vercel Preview CI (Issue #92)
+1. Workflow:
+- `.github/workflows/vercel-preview.yml` (`workflow_dispatch`)
+2. 배포 원칙:
+- 배포 타깃은 `Vercel`
+- 토큰은 GitHub Repository Secret으로만 주입
+3. 필수 Secrets:
+- `VERCEL_TOKEN`
+- `VERCEL_SCOPE` (team slug)
+- `VERCEL_PROJECT_NAME`
+4. Dispatch 입력:
+- `root_dir`: `apps/staging-web` 또는 `apps/web`
+- `issue_number`: URL 코멘트를 남길 이슈 번호(기본 `92`)
+5. 실행 결과:
+- Preview URL 추출 후 `issue_number`에 코멘트 자동 작성
+- 접근 검증(`curl`) 로그와 배포 로그를 artifact로 업로드


### PR DESCRIPTION
## 작업 요약
- Vercel Preview CI 워크플로 추가
- root 디렉토리를 dispatch 입력으로 강제(`apps/staging-web` 또는 `apps/web`)
- Vercel Secret preflight(fail-fast) 및 이슈 코멘트 자동등록 추가
- 배포/접근검증 로그 artifact 업로드 추가
- 배포 문서/개발 보고서 동기화

## 변경 파일
- `.github/workflows/vercel-preview.yml`
- `docs/04_DEPLOYMENT_AND_ENVIRONMENT.md`
- `develop_report/2026-02-19_preview_url_publish_report.md`

## 검증
- `npm --prefix apps/staging-web ci`
- `npm --prefix apps/staging-web run build`

## 비고
- 현재 저장소 Secret에는 `VERCEL_TOKEN/VERCEL_SCOPE/VERCEL_PROJECT_NAME`가 없어서 실제 URL 발급 전 단계까지 구현 완료 상태입니다.
- 값 주입 후 `Vercel Preview` workflow_dispatch 실행 시 URL이 이슈 #92에 자동 코멘트됩니다.

Related #92

Report-Path: develop_report/2026-02-19_preview_url_publish_report.md
