### PR TITLE
[DEVELOP] #101 정당 추정 스키마/API/검수 연계 확장

### DIFF
--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -81,6 +81,9 @@ class MatchupOptionOut(BaseModel):
     option_name: str
     value_mid: float | None = None
     value_raw: str | None = None
+    party_inferred: bool = False
+    party_inference_source: str | None = None
+    party_inference_confidence: float | None = None
 
 
 class MatchupOut(BaseModel):
@@ -289,6 +292,9 @@ class PollOptionInput(BaseModel):
     value_max: float | None = None
     value_mid: float | None = None
     is_missing: bool = False
+    party_inferred: bool = False
+    party_inference_source: str | None = None
+    party_inference_confidence: float | None = None
 
 
 class IngestRecordInput(BaseModel):

--- a/data/party_inference_matchup_sample_v1.json
+++ b/data/party_inference_matchup_sample_v1.json
@@ -1,0 +1,50 @@
+{
+  "matchup_id": "20260603|광역자치단체장|11-000",
+  "region_code": "11-000",
+  "office_type": "광역자치단체장",
+  "title": "서울시장 가상대결",
+  "pollster": "KBS",
+  "survey_start_date": "2026-02-15",
+  "survey_end_date": "2026-02-18",
+  "confidence_level": 95.0,
+  "sample_size": 1000,
+  "response_rate": 12.3,
+  "margin_of_error": 3.1,
+  "source_grade": "B",
+  "audience_scope": "regional",
+  "audience_region_code": "11-000",
+  "sampling_population_text": "서울시 거주 만 18세 이상",
+  "legal_completeness_score": 0.86,
+  "legal_filled_count": 6,
+  "legal_required_count": 7,
+  "date_resolution": "exact",
+  "date_inference_mode": "relative_published_at",
+  "date_inference_confidence": 0.92,
+  "nesdc_enriched": true,
+  "needs_manual_review": false,
+  "poll_fingerprint": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "source_channel": "article",
+  "source_channels": [
+    "article",
+    "nesdc"
+  ],
+  "verified": true,
+  "options": [
+    {
+      "option_name": "정원오",
+      "value_mid": 44.0,
+      "value_raw": "44%",
+      "party_inferred": true,
+      "party_inference_source": "name_rule",
+      "party_inference_confidence": 0.86
+    },
+    {
+      "option_name": "오세훈",
+      "value_mid": 42.0,
+      "value_raw": "42%",
+      "party_inferred": false,
+      "party_inference_source": null,
+      "party_inference_confidence": null
+    }
+  ]
+}

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -182,10 +182,18 @@ CREATE TABLE IF NOT EXISTS poll_options (
     value_max FLOAT NULL,
     value_mid FLOAT NULL,
     is_missing BOOLEAN NOT NULL DEFAULT FALSE,
+    party_inferred BOOLEAN NOT NULL DEFAULT FALSE,
+    party_inference_source TEXT NULL,
+    party_inference_confidence FLOAT NULL,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     UNIQUE (observation_id, option_type, option_name)
 );
+
+ALTER TABLE poll_options
+    ADD COLUMN IF NOT EXISTS party_inferred BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS party_inference_source TEXT NULL,
+    ADD COLUMN IF NOT EXISTS party_inference_confidence FLOAT NULL;
 
 CREATE TABLE IF NOT EXISTS review_queue (
     id BIGSERIAL PRIMARY KEY,

--- a/develop_report/2026-02-19_party_inference_schema_api_report.md
+++ b/develop_report/2026-02-19_party_inference_schema_api_report.md
@@ -1,0 +1,63 @@
+# 2026-02-19 Party Inference Schema/API Report
+
+## 1. 작업 목표
+- Issue: #101 `[DEVELOP] 정당 추정 결과 스키마/API/검수 연계 확장`
+- 범위:
+  1. 저장 계층: party inference 필드 추가
+  2. API 확장: matchup 상세 옵션 응답에 추정 필드 노출
+  3. 검수 연계: low confidence 자동 review_queue 라우팅
+
+## 2. 구현 내용
+1. DB 스키마 확장 (`db/schema.sql`)
+- `poll_options` 컬럼 추가
+  - `party_inferred BOOLEAN NOT NULL DEFAULT FALSE`
+  - `party_inference_source TEXT NULL`
+  - `party_inference_confidence FLOAT NULL`
+- 기존 DB 호환용 `ALTER TABLE poll_options ADD COLUMN IF NOT EXISTS ...` 추가
+
+2. 모델/계약 확장 (`app/models/schemas.py`)
+- `PollOptionInput`에 신규 3필드 추가
+- `MatchupOptionOut`에 신규 3필드 추가
+
+3. Repository 반영 (`app/services/repository.py`)
+- `upsert_poll_option` insert/upsert 대상에 신규 3필드 포함
+- `get_matchup` 옵션 조회에 신규 3필드 포함
+
+4. Ingest 검수 라우팅 반영 (`app/services/ingest_service.py`)
+- 임계값: `PARTY_INFERENCE_REVIEW_THRESHOLD = 0.8`
+- 조건:
+  - `party_inferred=true`
+  - `party_inference_confidence < 0.8`
+- 액션:
+  - `review_queue`에 `issue_type='party_inference_low_confidence'`로 적재
+
+5. 문서 동기화
+- `docs/02_DATA_MODEL_AND_NORMALIZATION.md`
+  - `poll_options` 주요 컬럼/정책에 party inference 반영
+- `docs/03_UI_UX_SPEC.md`
+  - `GET /api/v1/matchups/{matchup_id}` 필수 필드에 party inference 반영
+- `docs/05_RUNBOOK_AND_OPERATIONS.md`
+  - low confidence 정당 추론 검수 라우팅 규칙 추가
+
+6. 샘플 응답
+- `data/party_inference_matchup_sample_v1.json` 추가
+
+## 3. 테스트
+1. migration/repository/API/ingest 타깃 테스트
+- 명령:
+  - `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q tests/test_schema_party_inference.py tests/test_repository_matchup_legal_metadata.py tests/test_api_routes.py tests/test_ingest_service.py`
+- 결과: `13 passed`
+
+2. 전체 테스트
+- 명령:
+  - `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q`
+- 결과: `69 passed`
+
+## 4. DoD 점검
+1. migration + repository + API contract 테스트 PASS: 완료
+2. 샘플 응답 + 운영 문서 업데이트: 완료
+3. 보고서 제출: 완료
+
+## 5. 산출물
+- `develop_report/2026-02-19_party_inference_schema_api_report.md`
+- `data/party_inference_matchup_sample_v1.json`

--- a/docs/02_DATA_MODEL_AND_NORMALIZATION.md
+++ b/docs/02_DATA_MODEL_AND_NORMALIZATION.md
@@ -28,7 +28,7 @@
 
 ## 1.4 `poll_options`
 - 목적: 조사 선택지(후보/문항값) 저장
-- 주요 컬럼: `id`, `observation_id`, `option_type`, `option_name`, `value_raw`, `value_min`, `value_max`, `value_mid`, `is_missing`
+- 주요 컬럼: `id`, `observation_id`, `option_type`, `option_name`, `value_raw`, `value_min`, `value_max`, `value_mid`, `is_missing`, `party_inferred`, `party_inference_source`, `party_inference_confidence`
 
 ## 1.5 `regions`
 - 목적: 시도/시군구 코드 사전
@@ -118,3 +118,8 @@
 2. `audience_scope`, `audience_region_code`도 불명확하면 `null` 저장한다.
 3. API는 DB 값을 그대로 노출하며, 결측은 `null`로 유지한다.
 4. 상대시점 추론 결과는 `date_inference_mode`, `date_inference_confidence`에 저장한다.
+
+## 10. 정당 추정 메타 정책
+1. 옵션 단위 정당 추론 결과는 `party_inferred`, `party_inference_source`, `party_inference_confidence`로 저장한다.
+2. `party_inferred=false`면 `party_inference_source`, `party_inference_confidence`는 `null` 허용이다.
+3. `party_inference_confidence < 0.8`이면 `review_queue.issue_type='party_inference_low_confidence'`로 검수 큐에 적재한다.

--- a/docs/03_UI_UX_SPEC.md
+++ b/docs/03_UI_UX_SPEC.md
@@ -63,7 +63,7 @@
 | 빅매치 카드 | `GET /api/v1/dashboard/big-matches` | `matchups`, `poll_observations` | `matchup_id`, `title`, `survey_end_date`, `value_mid`, `source_channel`, `source_channels` |
 | 지역 검색 | `GET /api/v1/regions/search` | `regions` | `region_code`, `sido_name`, `sigungu_name` |
 | 지역별 선거 탭 | `GET /api/v1/regions/{region_code}/elections` | `matchups` | `region_code`, `office_type`, `is_active` |
-| 매치업 상세 | `GET /api/v1/matchups/{matchup_id}` | `poll_observations`, `poll_options`, `review_queue` | `matchup_id`, `pollster`, `survey_start_date`, `survey_end_date`, `confidence_level`, `sample_size`, `response_rate`, `margin_of_error`, `date_inference_mode`, `date_inference_confidence`, `nesdc_enriched`, `needs_manual_review`, `value_mid`, `source_grade`, `audience_scope`, `audience_region_code`, `legal_completeness_score`, `legal_filled_count`, `legal_required_count`, `source_channel`, `source_channels`, `poll_fingerprint` |
+| 매치업 상세 | `GET /api/v1/matchups/{matchup_id}` | `poll_observations`, `poll_options`, `review_queue` | `matchup_id`, `pollster`, `survey_start_date`, `survey_end_date`, `confidence_level`, `sample_size`, `response_rate`, `margin_of_error`, `date_inference_mode`, `date_inference_confidence`, `nesdc_enriched`, `needs_manual_review`, `value_mid`, `party_inferred`, `party_inference_source`, `party_inference_confidence`, `source_grade`, `audience_scope`, `audience_region_code`, `legal_completeness_score`, `legal_filled_count`, `legal_required_count`, `source_channel`, `source_channels`, `poll_fingerprint` |
 | 후보자 상세 | `GET /api/v1/candidates/{candidate_id}` | `candidates`, `candidate_profiles` | `candidate_id`, `name_ko`, `party_name`, `career_summary` |
 
 ## 5. API-UI 필드명 일치 규칙
@@ -77,3 +77,4 @@
 8. 매치업 상세의 법정메타 결측값은 `null`로 유지한다(숫자/날짜 모두 동일)
 9. 매치업 상세의 `nesdc_enriched`는 `source_channels`에 `nesdc`가 포함되면 `true`다.
 10. 매치업 상세의 `needs_manual_review`는 연결된 `review_queue`가 `pending` 또는 `in_progress`이면 `true`다.
+11. 옵션별 `party_inferred=true`이면서 `party_inference_confidence < 0.8`이면 `review_queue` 검수 대상이다.

--- a/docs/05_RUNBOOK_AND_OPERATIONS.md
+++ b/docs/05_RUNBOOK_AND_OPERATIONS.md
@@ -82,6 +82,8 @@
 - `article.published_at` 결측 시 `article.collected_at` 기반 추정값 허용
 - `date_inference_mode='estimated_timestamp'` 저장, review_queue 라우팅
 3. 불확실 추론(`date_inference_confidence < 0.8`)은 정책과 무관하게 review_queue 라우팅
+4. 옵션 정당 추론에서 `party_inferred=true`이면서 `party_inference_confidence < 0.8`이면
+- `review_queue.issue_type='party_inference_low_confidence'`로 라우팅
 
 ## 6.1 재시도 운영 규칙
 1. 내부 배치 호출 실패(네트워크/5xx/partial_success) 시 최대 2회 재시도

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -116,8 +116,22 @@ class FakeApiRepo:
             "source_channels": ["article", "nesdc"],
             "verified": True,
             "options": [
-                {"option_name": "정원오", "value_mid": 44.0, "value_raw": "44%"},
-                {"option_name": "오세훈", "value_mid": 42.0, "value_raw": "42%"},
+                {
+                    "option_name": "정원오",
+                    "value_mid": 44.0,
+                    "value_raw": "44%",
+                    "party_inferred": True,
+                    "party_inference_source": "name_rule",
+                    "party_inference_confidence": 0.86,
+                },
+                {
+                    "option_name": "오세훈",
+                    "value_mid": 42.0,
+                    "value_raw": "42%",
+                    "party_inferred": False,
+                    "party_inference_source": None,
+                    "party_inference_confidence": None,
+                },
             ],
         }
 
@@ -354,6 +368,9 @@ def test_api_contract_fields():
     assert matchup.json()["needs_manual_review"] is True
     assert matchup.json()["source_channel"] == "article"
     assert matchup.json()["source_channels"] == ["article", "nesdc"]
+    assert matchup.json()["options"][0]["party_inferred"] is True
+    assert matchup.json()["options"][0]["party_inference_source"] == "name_rule"
+    assert matchup.json()["options"][0]["party_inference_confidence"] == 0.86
 
     candidate = client.get("/api/v1/candidates/cand-jwo")
     assert candidate.status_code == 200

--- a/tests/test_repository_matchup_legal_metadata.py
+++ b/tests/test_repository_matchup_legal_metadata.py
@@ -53,7 +53,16 @@ class _Cursor:
         return None
 
     def fetchall(self):
-        return [{"option_name": "정원오", "value_mid": 44.0, "value_raw": "44%"}]
+        return [
+            {
+                "option_name": "정원오",
+                "value_mid": 44.0,
+                "value_raw": "44%",
+                "party_inferred": True,
+                "party_inference_source": "name_rule",
+                "party_inference_confidence": 0.84,
+            }
+        ]
 
 
 class _Conn:
@@ -78,3 +87,6 @@ def test_get_matchup_returns_legal_metadata_fields():
     assert out["date_inference_confidence"] == 0.92
     assert out["nesdc_enriched"] is True
     assert out["needs_manual_review"] is True
+    assert out["options"][0]["party_inferred"] is True
+    assert out["options"][0]["party_inference_source"] == "name_rule"
+    assert out["options"][0]["party_inference_confidence"] == 0.84

--- a/tests/test_schema_party_inference.py
+++ b/tests/test_schema_party_inference.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+
+def test_schema_contains_party_inference_columns() -> None:
+    sql = Path("db/schema.sql").read_text(encoding="utf-8")
+    assert "party_inferred BOOLEAN NOT NULL DEFAULT FALSE" in sql
+    assert "party_inference_source TEXT NULL" in sql
+    assert "party_inference_confidence FLOAT NULL" in sql
+    assert "ALTER TABLE poll_options" in sql
+    assert "ADD COLUMN IF NOT EXISTS party_inferred BOOLEAN NOT NULL DEFAULT FALSE" in sql


### PR DESCRIPTION
## 작업 요약
- poll_options에 party inference 메타(3필드) 추가
- `GET /api/v1/matchups/{matchup_id}` 옵션 응답에 party inference 메타 노출
- low confidence(`party_inference_confidence < 0.8`) 시 review_queue 자동 라우팅 추가
- migration/repository/API/ingest 테스트 보강
- 샘플 응답/운영 문서/개발 보고서 동기화

## 변경 파일
- `db/schema.sql`
- `app/models/schemas.py`
- `app/services/repository.py`
- `app/services/ingest_service.py`
- `tests/test_schema_party_inference.py`
- `tests/test_repository_matchup_legal_metadata.py`
- `tests/test_api_routes.py`
- `tests/test_ingest_service.py`
- `docs/02_DATA_MODEL_AND_NORMALIZATION.md`
- `docs/03_UI_UX_SPEC.md`
- `docs/05_RUNBOOK_AND_OPERATIONS.md`
- `data/party_inference_matchup_sample_v1.json`
- `develop_report/2026-02-19_party_inference_schema_api_report.md`

## 검증
- `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q tests/test_schema_party_inference.py tests/test_repository_matchup_legal_metadata.py tests/test_api_routes.py tests/test_ingest_service.py`
- `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q`

Closes #101

Report-Path: develop_report/2026-02-19_party_inference_schema_api_report.md
