### PR TITLE
[DEVELOP] #107 스코프 분리 집계정책 강화

### DIFF
--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -27,15 +27,24 @@ class SummaryPoint(BaseModel):
     value_mid: float | None = None
     pollster: str | None = None
     survey_end_date: date | None = None
+    audience_scope: Literal["national", "regional", "local"] | None = None
     source_channel: Literal["article", "nesdc"] | None = None
     source_channels: list[Literal["article", "nesdc"]] = Field(default_factory=list)
     verified: bool
+
+
+class ScopeBreakdownOut(BaseModel):
+    national: int = 0
+    regional: int = 0
+    local: int = 0
+    unknown: int = 0
 
 
 class DashboardSummaryOut(BaseModel):
     as_of: date | None = None
     party_support: list[SummaryPoint]
     presidential_approval: list[SummaryPoint]
+    scope_breakdown: ScopeBreakdownOut = Field(default_factory=ScopeBreakdownOut)
 
 
 class MapLatestPoint(BaseModel):
@@ -45,6 +54,7 @@ class MapLatestPoint(BaseModel):
     value_mid: float | None = None
     survey_end_date: date | None = None
     option_name: str | None = None
+    audience_scope: Literal["national", "regional", "local"] | None = None
     source_channel: Literal["article", "nesdc"] | None = None
     source_channels: list[Literal["article", "nesdc"]] = Field(default_factory=list)
 
@@ -52,6 +62,7 @@ class MapLatestPoint(BaseModel):
 class DashboardMapLatestOut(BaseModel):
     as_of: date | None = None
     items: list[MapLatestPoint]
+    scope_breakdown: ScopeBreakdownOut = Field(default_factory=ScopeBreakdownOut)
 
 
 class BigMatchPoint(BaseModel):
@@ -60,6 +71,7 @@ class BigMatchPoint(BaseModel):
     survey_end_date: date | None = None
     value_mid: float | None = None
     spread: float | None = None
+    audience_scope: Literal["national", "regional", "local"] | None = None
     source_channel: Literal["article", "nesdc"] | None = None
     source_channels: list[Literal["article", "nesdc"]] = Field(default_factory=list)
 
@@ -67,6 +79,7 @@ class BigMatchPoint(BaseModel):
 class DashboardBigMatchesOut(BaseModel):
     as_of: date | None = None
     items: list[BigMatchPoint]
+    scope_breakdown: ScopeBreakdownOut = Field(default_factory=ScopeBreakdownOut)
 
 
 class RegionElectionOut(BaseModel):

--- a/app/services/repository.py
+++ b/app/services/repository.py
@@ -333,7 +333,7 @@ class PostgresRepository:
         if as_of is not None:
             as_of_filter = "AND o.survey_end_date <= %s"
             params.append(as_of)
-        scope_filter = "AND (o.audience_scope = 'national' OR o.audience_scope IS NULL)"
+        scope_filter = "AND o.audience_scope = 'national'"
 
         query = f"""
             WITH latest AS (
@@ -352,6 +352,7 @@ class PostgresRepository:
                 po.value_mid,
                 o.pollster,
                 o.survey_end_date,
+                o.audience_scope,
                 o.source_channel,
                 COALESCE(o.source_channels, CASE WHEN o.source_channel IS NULL THEN ARRAY[]::text[] ELSE ARRAY[o.source_channel] END) AS source_channels,
                 o.verified
@@ -386,6 +387,7 @@ class PostgresRepository:
                     po.option_name,
                     po.value_mid,
                     o.survey_end_date,
+                    o.audience_scope,
                     o.source_channel,
                     COALESCE(
                         o.source_channels,
@@ -412,6 +414,7 @@ class PostgresRepository:
                 r.value_mid,
                 r.survey_end_date,
                 r.option_name,
+                r.audience_scope,
                 r.source_channel,
                 r.source_channels
             FROM ranked r
@@ -439,6 +442,7 @@ class PostgresRepository:
                     o.id,
                     o.matchup_id,
                     o.survey_end_date,
+                    o.audience_scope,
                     o.source_channel,
                     COALESCE(
                         o.source_channels,
@@ -485,6 +489,7 @@ class PostgresRepository:
                 s.survey_end_date,
                 s.value_mid,
                 s.spread,
+                lo.audience_scope,
                 lo.source_channel,
                 lo.source_channels
             FROM scored s

--- a/data/scope_segregation_dashboard_samples_v1.json
+++ b/data/scope_segregation_dashboard_samples_v1.json
@@ -1,0 +1,89 @@
+{
+  "dashboard_summary": {
+    "as_of": "2026-02-19",
+    "party_support": [
+      {
+        "option_name": "더불어민주당",
+        "value_mid": 42.0,
+        "pollster": "KBS",
+        "survey_end_date": "2026-02-18",
+        "audience_scope": "national",
+        "source_channel": "nesdc",
+        "source_channels": [
+          "article",
+          "nesdc"
+        ],
+        "verified": true
+      }
+    ],
+    "presidential_approval": [
+      {
+        "option_name": "국정안정론",
+        "value_mid": 54.0,
+        "pollster": "KBS",
+        "survey_end_date": "2026-02-18",
+        "audience_scope": "national",
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": true
+      }
+    ],
+    "scope_breakdown": {
+      "national": 2,
+      "regional": 1,
+      "local": 1,
+      "unknown": 0
+    }
+  },
+  "dashboard_map_latest": {
+    "as_of": "2026-02-19",
+    "items": [
+      {
+        "region_code": "11-000",
+        "office_type": "광역자치단체장",
+        "title": "서울시장 가상대결",
+        "value_mid": 44.0,
+        "survey_end_date": "2026-02-18",
+        "option_name": "정원오",
+        "audience_scope": "regional",
+        "source_channel": "nesdc",
+        "source_channels": [
+          "article",
+          "nesdc"
+        ]
+      }
+    ],
+    "scope_breakdown": {
+      "national": 0,
+      "regional": 1,
+      "local": 0,
+      "unknown": 0
+    }
+  },
+  "dashboard_big_matches": {
+    "as_of": "2026-02-19",
+    "items": [
+      {
+        "matchup_id": "20260603|광역자치단체장|11-000",
+        "title": "서울시장 가상대결",
+        "survey_end_date": "2026-02-18",
+        "value_mid": 44.0,
+        "spread": 2.0,
+        "audience_scope": "regional",
+        "source_channel": "nesdc",
+        "source_channels": [
+          "article",
+          "nesdc"
+        ]
+      }
+    ],
+    "scope_breakdown": {
+      "national": 0,
+      "regional": 1,
+      "local": 0,
+      "unknown": 0
+    }
+  }
+}

--- a/develop_report/2026-02-19_scope_segregation_api_policy_report.md
+++ b/develop_report/2026-02-19_scope_segregation_api_policy_report.md
@@ -1,0 +1,56 @@
+# 2026-02-19 Scope Segregation API Policy Report
+
+## 1. 작업 목표
+- Issue: #107 `[DEVELOP] 스코프 분리 집계정책 강화(전국 오염 방지)`
+- 목표:
+  1. `dashboard summary`에 전국 스코프 강제 반영
+  2. `summary/map/big-matches`에 `audience_scope` 및 `scope_breakdown` 노출
+  3. 스코프 오염 회귀 테스트 추가
+
+## 2. 구현 내용
+1. 응답 계약 확장 (`app/models/schemas.py`)
+- `SummaryPoint`, `MapLatestPoint`, `BigMatchPoint`에 `audience_scope` 추가
+- `ScopeBreakdownOut` 모델 추가 (`national/regional/local/unknown`)
+- `DashboardSummaryOut`, `DashboardMapLatestOut`, `DashboardBigMatchesOut`에 `scope_breakdown` 추가
+
+2. 집계 정책 강제 (`app/services/repository.py`, `app/api/routes.py`)
+- `fetch_dashboard_summary` SQL 필터를 `o.audience_scope = 'national'`로 강화
+- `audience_scope IS NULL` 임시 포함 제거
+- API 라우트에서 summary 처리 시 `audience_scope='national'`만 결과 배열에 반영(이중 방어)
+- map/big-matches 조회 결과에 `audience_scope` 포함
+- summary/map/big-matches 응답에 `scope_breakdown` 계산/노출
+
+3. 회귀 방지 테스트 (`tests/test_api_routes.py`, `tests/test_repository_dashboard_summary_scope.py`)
+- summary 오염 데이터(regional/local)가 repo에서 들어와도 응답 결과는 national-only 유지 검증
+- `scope_breakdown`이 스코프별 카운트를 노출하는지 검증
+- repository query에 national-only 필터가 적용되고 `audience_scope IS NULL`이 제거됐는지 검증
+
+4. 문서/운영 업데이트
+- `docs/02_DATA_MODEL_AND_NORMALIZATION.md`
+  - summary 스코프 규칙에서 `audience_scope IS NULL` 제외로 업데이트
+  - dashboard 3개 API의 `scope_breakdown` 노출 규칙 추가
+- `docs/03_UI_UX_SPEC.md`
+  - summary/map/big-matches 필수 필드에 `audience_scope`, `scope_breakdown` 반영
+- `docs/05_RUNBOOK_AND_OPERATIONS.md`
+  - 운영 일일 체크에 `scope_breakdown.regional/local/unknown == 0` 확인 항목 추가
+
+5. 샘플 응답 추가
+- `data/scope_segregation_dashboard_samples_v1.json`
+
+## 3. 검증
+1. 타깃 테스트
+- 명령: `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q tests/test_api_routes.py tests/test_repository_dashboard_summary_scope.py`
+- 결과: `8 passed`
+
+2. 전체 테스트
+- 명령: `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q`
+- 결과: `69 passed`
+
+## 4. DoD 점검
+1. API 계약/회귀 테스트 PASS: 완료
+2. 샘플 응답 + 문서 업데이트: 완료
+3. 보고서 제출: 완료
+
+## 5. 산출물
+- `develop_report/2026-02-19_scope_segregation_api_policy_report.md`
+- `data/scope_segregation_dashboard_samples_v1.json`

--- a/docs/02_DATA_MODEL_AND_NORMALIZATION.md
+++ b/docs/02_DATA_MODEL_AND_NORMALIZATION.md
@@ -98,8 +98,9 @@
 
 ## 6. 스코프 분리 집계 규칙
 1. `GET /api/v1/dashboard/summary`는 `audience_scope='national'` 데이터만 집계한다.
-2. 레거시 데이터 호환을 위해 `audience_scope IS NULL`도 임시 포함한다.
-3. `audience_scope='regional'|'local'` 관측치는 요약 집계에서 제외한다.
+2. `audience_scope IS NULL` 관측치는 summary 집계에서 제외한다.
+3. `audience_scope='regional'|'local'` 관측치는 summary 집계에서 제외한다.
+4. `GET /api/v1/dashboard/summary`, `GET /api/v1/dashboard/map-latest`, `GET /api/v1/dashboard/big-matches`는 `scope_breakdown`을 함께 노출한다.
 
 ## 7. 중복제어(fingerprint) 규칙
 1. fingerprint 기본 입력: `pollster`, `sponsor`, `survey_start_date`, `survey_end_date`, `region_code(or region_text)`, `sample_size`, `method`

--- a/docs/03_UI_UX_SPEC.md
+++ b/docs/03_UI_UX_SPEC.md
@@ -58,9 +58,9 @@
 
 | 화면 기능 | 사용 API | 핵심 테이블 | 필수 필드 |
 |---|---|---|---|
-| 최신 정당/대통령 요약 | `GET /api/v1/dashboard/summary` | `poll_observations`, `poll_options` | `pollster`, `survey_end_date`, `option_name`, `value_mid`, `verified`, `audience_scope`(national only), `source_channel`, `source_channels` |
-| 지도 Hover 최신값 | `GET /api/v1/dashboard/map-latest` | `regions`, `matchups`, `poll_options` | `region_code`, `office_type`, `title`, `value_mid`, `source_channel`, `source_channels` |
-| 빅매치 카드 | `GET /api/v1/dashboard/big-matches` | `matchups`, `poll_observations` | `matchup_id`, `title`, `survey_end_date`, `value_mid`, `source_channel`, `source_channels` |
+| 최신 정당/대통령 요약 | `GET /api/v1/dashboard/summary` | `poll_observations`, `poll_options` | `pollster`, `survey_end_date`, `option_name`, `value_mid`, `verified`, `audience_scope`(national only), `source_channel`, `source_channels`, `scope_breakdown` |
+| 지도 Hover 최신값 | `GET /api/v1/dashboard/map-latest` | `regions`, `matchups`, `poll_options` | `region_code`, `office_type`, `title`, `value_mid`, `audience_scope`, `source_channel`, `source_channels`, `scope_breakdown` |
+| 빅매치 카드 | `GET /api/v1/dashboard/big-matches` | `matchups`, `poll_observations` | `matchup_id`, `title`, `survey_end_date`, `value_mid`, `audience_scope`, `source_channel`, `source_channels`, `scope_breakdown` |
 | 지역 검색 | `GET /api/v1/regions/search` | `regions` | `region_code`, `sido_name`, `sigungu_name` |
 | 지역별 선거 탭 | `GET /api/v1/regions/{region_code}/elections` | `matchups` | `region_code`, `office_type`, `is_active` |
 | 매치업 상세 | `GET /api/v1/matchups/{matchup_id}` | `poll_observations`, `poll_options`, `review_queue` | `matchup_id`, `pollster`, `survey_start_date`, `survey_end_date`, `confidence_level`, `sample_size`, `response_rate`, `margin_of_error`, `date_inference_mode`, `date_inference_confidence`, `nesdc_enriched`, `needs_manual_review`, `value_mid`, `party_inferred`, `party_inference_source`, `party_inference_confidence`, `source_grade`, `audience_scope`, `audience_region_code`, `legal_completeness_score`, `legal_filled_count`, `legal_required_count`, `source_channel`, `source_channels`, `poll_fingerprint` |
@@ -72,9 +72,11 @@
 3. 검증 배지는 `verified` 또는 `source_grade` 기준
 4. 지역 선택의 기준 키는 `region_code` 단일 사용
 5. 대시보드 요약 카드는 `audience_scope='national'`로 스코프 분리된 데이터만 사용
-6. 매치업 상세는 조사 스코프(`audience_scope`)와 법정 completeness(`legal_*`)를 함께 노출
-7. 대시보드 계열 API의 `source_channels`는 null 대신 빈 배열(`[]`)을 기본값으로 노출
-8. 매치업 상세의 법정메타 결측값은 `null`로 유지한다(숫자/날짜 모두 동일)
-9. 매치업 상세의 `nesdc_enriched`는 `source_channels`에 `nesdc`가 포함되면 `true`다.
-10. 매치업 상세의 `needs_manual_review`는 연결된 `review_queue`가 `pending` 또는 `in_progress`이면 `true`다.
-11. 옵션별 `party_inferred=true`이면서 `party_inference_confidence < 0.8`이면 `review_queue` 검수 대상이다.
+6. 요약 API는 `audience_scope IS NULL` 데이터를 포함하지 않는다.
+7. summary/map-latest/big-matches는 `scope_breakdown`으로 스코프별 개수를 함께 노출한다.
+8. 매치업 상세는 조사 스코프(`audience_scope`)와 법정 completeness(`legal_*`)를 함께 노출
+9. 대시보드 계열 API의 `source_channels`는 null 대신 빈 배열(`[]`)을 기본값으로 노출
+10. 매치업 상세의 법정메타 결측값은 `null`로 유지한다(숫자/날짜 모두 동일)
+11. 매치업 상세의 `nesdc_enriched`는 `source_channels`에 `nesdc`가 포함되면 `true`다.
+12. 매치업 상세의 `needs_manual_review`는 연결된 `review_queue`가 `pending` 또는 `in_progress`이면 `true`다.
+13. 옵션별 `party_inferred=true`이면서 `party_inference_confidence < 0.8`이면 `review_queue` 검수 대상이다.

--- a/docs/05_RUNBOOK_AND_OPERATIONS.md
+++ b/docs/05_RUNBOOK_AND_OPERATIONS.md
@@ -187,6 +187,7 @@
 2. 검수 큐 24시간 초과 항목 여부
 3. 빅매치 계산 결과 이상치 여부
 4. 지도 데이터 누락 지역 여부
+5. `dashboard/summary`의 `scope_breakdown.regional/local/unknown`가 0인지 확인(전국 오염 방지)
 
 ## 10. 준법 체크
 1. robots 정책 위반 요청 로그 여부

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -20,8 +20,20 @@ class FakeApiRepo:
                 "value_mid": 42.0,
                 "pollster": "KBS",
                 "survey_end_date": date(2026, 2, 18),
+                "audience_scope": "national",
                 "source_channel": "nesdc",
                 "source_channels": ["article", "nesdc"],
+                "verified": True,
+            },
+            {
+                "option_type": "party_support",
+                "option_name": "지역정당A",
+                "value_mid": 22.0,
+                "pollster": "KBS",
+                "survey_end_date": date(2026, 2, 18),
+                "audience_scope": "regional",
+                "source_channel": "article",
+                "source_channels": ["article"],
                 "verified": True,
             },
             {
@@ -30,6 +42,18 @@ class FakeApiRepo:
                 "value_mid": 54.0,
                 "pollster": "KBS",
                 "survey_end_date": date(2026, 2, 18),
+                "audience_scope": "national",
+                "source_channel": "article",
+                "source_channels": ["article"],
+                "verified": True,
+            },
+            {
+                "option_type": "presidential_approval",
+                "option_name": "지역이슈안정론",
+                "value_mid": 33.0,
+                "pollster": "KBS",
+                "survey_end_date": date(2026, 2, 18),
+                "audience_scope": "local",
                 "source_channel": "article",
                 "source_channels": ["article"],
                 "verified": True,
@@ -55,6 +79,7 @@ class FakeApiRepo:
                 "value_mid": 44.0,
                 "survey_end_date": date(2026, 2, 18),
                 "option_name": "정원오",
+                "audience_scope": "regional",
                 "source_channel": "nesdc",
                 "source_channels": ["article", "nesdc"],
             }
@@ -68,6 +93,7 @@ class FakeApiRepo:
                 "survey_end_date": date(2026, 2, 18),
                 "value_mid": 44.0,
                 "spread": 2.0,
+                "audience_scope": "regional",
                 "source_channel": "nesdc",
                 "source_channels": ["article", "nesdc"],
             }
@@ -334,6 +360,11 @@ def test_api_contract_fields():
     assert "value_mid" in body["party_support"][0]
     assert "source_channels" in body["party_support"][0]
     assert body["party_support"][0]["source_channels"] == ["article", "nesdc"]
+    assert body["party_support"][0]["audience_scope"] == "national"
+    assert all(x["audience_scope"] == "national" for x in body["party_support"] + body["presidential_approval"])
+    assert [x["option_name"] for x in body["party_support"]] == ["더불어민주당"]
+    assert [x["option_name"] for x in body["presidential_approval"]] == ["국정안정론"]
+    assert body["scope_breakdown"] == {"national": 2, "regional": 1, "local": 1, "unknown": 0}
 
     regions = client.get("/api/v1/regions/search", params={"q": "서울"})
     assert regions.status_code == 200
@@ -343,11 +374,15 @@ def test_api_contract_fields():
     assert map_latest.status_code == 200
     assert map_latest.json()["items"][0]["region_code"] == "11-000"
     assert map_latest.json()["items"][0]["source_channels"] == ["article", "nesdc"]
+    assert map_latest.json()["items"][0]["audience_scope"] == "regional"
+    assert map_latest.json()["scope_breakdown"] == {"national": 0, "regional": 1, "local": 0, "unknown": 0}
 
     big_matches = client.get("/api/v1/dashboard/big-matches")
     assert big_matches.status_code == 200
     assert big_matches.json()["items"][0]["matchup_id"] == "20260603|광역자치단체장|11-000"
     assert big_matches.json()["items"][0]["source_channels"] == ["article", "nesdc"]
+    assert big_matches.json()["items"][0]["audience_scope"] == "regional"
+    assert big_matches.json()["scope_breakdown"] == {"national": 0, "regional": 1, "local": 0, "unknown": 0}
 
     region_elections = client.get("/api/v1/regions/11-000/elections")
     assert region_elections.status_code == 200

--- a/tests/test_repository_dashboard_summary_scope.py
+++ b/tests/test_repository_dashboard_summary_scope.py
@@ -37,7 +37,7 @@ def test_dashboard_summary_query_filters_regional_scope():
 
     assert len(conn._cursor.executed) == 1
     query, params = conn._cursor.executed[0]
-    scope_filter = "(o.audience_scope = 'national' OR o.audience_scope IS NULL)"
+    scope_filter = "o.audience_scope = 'national'"
     assert query.count(scope_filter) >= 2
     assert params == [date(2026, 2, 19)]
 
@@ -49,5 +49,6 @@ def test_dashboard_summary_query_filters_scope_without_as_of():
     repo.fetch_dashboard_summary(as_of=None)
 
     query, params = conn._cursor.executed[0]
-    assert "(o.audience_scope = 'national' OR o.audience_scope IS NULL)" in query
+    assert "o.audience_scope = 'national'" in query
+    assert "o.audience_scope IS NULL" not in query
     assert params == []


### PR DESCRIPTION
## 작업 요약
- dashboard summary를 `audience_scope='national'`만 집계하도록 강화
- summary/map-latest/big-matches 응답에 `audience_scope` 및 `scope_breakdown` 노출
- summary 오염(regional/local) 회귀 테스트 추가
- 샘플 응답/문서/운영 체크리스트 동기화

## 변경 파일
- `app/models/schemas.py`
- `app/api/routes.py`
- `app/services/repository.py`
- `tests/test_api_routes.py`
- `tests/test_repository_dashboard_summary_scope.py`
- `docs/02_DATA_MODEL_AND_NORMALIZATION.md`
- `docs/03_UI_UX_SPEC.md`
- `docs/05_RUNBOOK_AND_OPERATIONS.md`
- `data/scope_segregation_dashboard_samples_v1.json`
- `develop_report/2026-02-19_scope_segregation_api_policy_report.md`

## 검증
- `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q tests/test_api_routes.py tests/test_repository_dashboard_summary_scope.py`
- `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q`

Closes #107

Report-Path: develop_report/2026-02-19_scope_segregation_api_policy_report.md
