### PR TITLE
[DEVELOP] #113 이중소스 병합정책 API v1 반영

### DIFF
--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -28,6 +28,11 @@ class SummaryPoint(BaseModel):
     pollster: str | None = None
     survey_end_date: date | None = None
     audience_scope: Literal["national", "regional", "local"] | None = None
+    source_priority: Literal["official", "article", "mixed"] = "article"
+    official_release_at: datetime | None = None
+    article_published_at: datetime | None = None
+    freshness_hours: float | None = None
+    is_official_confirmed: bool = False
     source_channel: Literal["article", "nesdc"] | None = None
     source_channels: list[Literal["article", "nesdc"]] = Field(default_factory=list)
     verified: bool
@@ -55,6 +60,11 @@ class MapLatestPoint(BaseModel):
     survey_end_date: date | None = None
     option_name: str | None = None
     audience_scope: Literal["national", "regional", "local"] | None = None
+    source_priority: Literal["official", "article", "mixed"] = "article"
+    official_release_at: datetime | None = None
+    article_published_at: datetime | None = None
+    freshness_hours: float | None = None
+    is_official_confirmed: bool = False
     source_channel: Literal["article", "nesdc"] | None = None
     source_channels: list[Literal["article", "nesdc"]] = Field(default_factory=list)
 
@@ -123,6 +133,11 @@ class MatchupOut(BaseModel):
     date_inference_confidence: float | None = None
     nesdc_enriched: bool = False
     needs_manual_review: bool = False
+    source_priority: Literal["official", "article", "mixed"] = "article"
+    official_release_at: datetime | None = None
+    article_published_at: datetime | None = None
+    freshness_hours: float | None = None
+    is_official_confirmed: bool = False
     poll_fingerprint: str | None = None
     source_channel: Literal["article", "nesdc"] | None = None
     source_channels: list[Literal["article", "nesdc"]] | None = None

--- a/data/dual_source_merge_policy_samples_v1.json
+++ b/data/dual_source_merge_policy_samples_v1.json
@@ -1,0 +1,81 @@
+{
+  "summary": {
+    "as_of": "2026-02-19",
+    "party_support": [
+      {
+        "option_name": "더불어민주당",
+        "value_mid": 42.0,
+        "pollster": "KBS",
+        "survey_end_date": "2026-02-18",
+        "audience_scope": "national",
+        "source_priority": "mixed",
+        "official_release_at": "2026-02-18T03:00:00Z",
+        "article_published_at": "2026-02-18T01:00:00Z",
+        "freshness_hours": 30.5,
+        "is_official_confirmed": true,
+        "source_channel": "nesdc",
+        "source_channels": ["article", "nesdc"],
+        "verified": true
+      }
+    ],
+    "presidential_approval": [
+      {
+        "option_name": "국정안정론",
+        "value_mid": 54.0,
+        "pollster": "KBS",
+        "survey_end_date": "2026-02-18",
+        "audience_scope": "national",
+        "source_priority": "article",
+        "official_release_at": null,
+        "article_published_at": "2026-02-18T03:00:00Z",
+        "freshness_hours": 28.5,
+        "is_official_confirmed": false,
+        "source_channel": "article",
+        "source_channels": ["article"],
+        "verified": true
+      }
+    ],
+    "scope_breakdown": {
+      "national": 2,
+      "regional": 1,
+      "local": 1,
+      "unknown": 0
+    }
+  },
+  "map_latest": {
+    "as_of": "2026-02-19",
+    "items": [
+      {
+        "region_code": "11-000",
+        "office_type": "광역자치단체장",
+        "title": "서울시장 가상대결",
+        "value_mid": 44.0,
+        "survey_end_date": "2026-02-18",
+        "option_name": "정원오",
+        "audience_scope": "regional",
+        "source_priority": "mixed",
+        "official_release_at": "2026-02-18T03:00:00Z",
+        "article_published_at": "2026-02-18T01:00:00Z",
+        "freshness_hours": 30.5,
+        "is_official_confirmed": true,
+        "source_channel": "nesdc",
+        "source_channels": ["article", "nesdc"]
+      }
+    ],
+    "scope_breakdown": {
+      "national": 0,
+      "regional": 1,
+      "local": 0,
+      "unknown": 0
+    }
+  },
+  "matchup": {
+    "matchup_id": "20260603|광역자치단체장|11-000",
+    "source_priority": "mixed",
+    "official_release_at": "2026-02-18T03:00:00Z",
+    "article_published_at": "2026-02-18T01:00:00Z",
+    "freshness_hours": 30.5,
+    "is_official_confirmed": true,
+    "source_channels": ["article", "nesdc"]
+  }
+}

--- a/develop_report/2026-02-19_dual_source_merge_policy_api_v1_report.md
+++ b/develop_report/2026-02-19_dual_source_merge_policy_api_v1_report.md
@@ -1,0 +1,63 @@
+# 2026-02-19 Dual Source Merge Policy API v1 Report
+
+## 1. 작업 목표
+- Issue: #113 `[DEVELOP] 기사+NESDC 이중소스 병합정책 API v1(source_priority/freshness)`
+- 목표:
+  1. 이중소스 병합 정책을 API에서 명시적으로 노출
+  2. `summary/map/matchup` 응답 계약 동기화
+  3. 스코프 오염/병합 충돌 회귀 보장
+
+## 2. 구현 내용
+1. API 계약 확장 (`app/models/schemas.py`)
+- `summary/map/matchup`에 신규 필드 반영
+  - `source_priority` (`official|article|mixed`)
+  - `official_release_at`
+  - `article_published_at`
+  - `freshness_hours`
+  - `is_official_confirmed`
+
+2. source meta 파생 로직 (`app/api/routes.py`)
+- 공통 함수 `_derive_source_meta()` 추가
+- 산출 규칙:
+  - `source_priority`
+    - `mixed`: `source_channels`에 `article`+`nesdc` 동시 존재
+    - `official`: `nesdc`만 존재
+    - `article`: 그 외
+  - `is_official_confirmed`: `nesdc` 포함 여부
+  - `official_release_at`: 공식소스 존재 시 관측치 `updated_at` 기준
+  - `article_published_at`: `articles.published_at`
+  - `freshness_hours`: `official_release_at` 우선, 없으면 `article_published_at`, 없으면 `observation_updated_at`
+
+3. repository 조회 보강 (`app/services/repository.py`)
+- `summary/map/matchup` 조회에 `observation_updated_at`, `article_published_at` 추가
+- `summary`는 기존 스코프 정책 유지(`audience_scope='national'` only)
+
+4. 문서 동기화
+- `docs/02_DATA_MODEL_AND_NORMALIZATION.md`: dual-source 파생필드 규칙 추가
+- `docs/03_UI_UX_SPEC.md`: summary/map/matchup 필드 표 및 규칙 반영
+- `docs/05_RUNBOOK_AND_OPERATIONS.md`: freshness/source_priority 운영 체크 추가
+
+5. 샘플 응답
+- `data/dual_source_merge_policy_samples_v1.json`
+
+## 3. 회귀/계약 테스트
+1. 타깃 테스트
+- 명령:
+  - `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q tests/test_api_routes.py tests/test_repository_dashboard_summary_scope.py tests/test_repository_matchup_legal_metadata.py tests/test_poll_fingerprint.py`
+- 결과: `12 passed`
+
+2. 전체 테스트
+- 명령:
+  - `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q`
+- 결과: `69 passed`
+
+## 4. 수용 기준 점검
+1. 계약 테스트 PASS: 완료
+2. 병합 우선순위/충돌 회귀 PASS: 완료
+- `tests/test_api_routes.py`에서 `source_priority`/`is_official_confirmed`/`freshness_hours` 검증
+- `tests/test_poll_fingerprint.py`의 충돌 검증 유지
+3. 기존 endpoint 호환성 회귀 PASS: 완료 (전체 테스트 통과)
+
+## 5. 산출물
+- `develop_report/2026-02-19_dual_source_merge_policy_api_v1_report.md`
+- `data/dual_source_merge_policy_samples_v1.json`

--- a/docs/02_DATA_MODEL_AND_NORMALIZATION.md
+++ b/docs/02_DATA_MODEL_AND_NORMALIZATION.md
@@ -113,6 +113,12 @@
 2. 신규 `source_channels`는 채널 집합(`article`, `nesdc`)을 누적 저장한다.
 3. 병합 후 `source_channel`은 기존 규칙(`nesdc` 존재 시 `nesdc`)으로 유지하고, 상세 provenance는 `source_channels`로 조회한다.
 4. 기존 레거시 데이터는 마이그레이션 시 `source_channels = [source_channel]`로 백필한다.
+5. API 파생 필드:
+- `source_priority`: `official|article|mixed`
+- `is_official_confirmed`: `source_channels`에 `nesdc` 포함 시 `true`
+- `official_release_at`: 공식소스 포함 시 관측치 최신 갱신시각 기준
+- `article_published_at`: 연결 기사의 `published_at`
+- `freshness_hours`: `official_release_at` 우선, 없으면 `article_published_at` 기준 현재시각과의 시간차
 
 ## 9. 법정메타 null/결측 정책
 1. 수집기에서 값이 없거나 추론 불가인 경우 `survey_start_date`, `survey_end_date`, `confidence_level`, `margin_of_error`, `response_rate`, `sample_size`는 `null` 저장한다.

--- a/docs/03_UI_UX_SPEC.md
+++ b/docs/03_UI_UX_SPEC.md
@@ -58,12 +58,12 @@
 
 | 화면 기능 | 사용 API | 핵심 테이블 | 필수 필드 |
 |---|---|---|---|
-| 최신 정당/대통령 요약 | `GET /api/v1/dashboard/summary` | `poll_observations`, `poll_options` | `pollster`, `survey_end_date`, `option_name`, `value_mid`, `verified`, `audience_scope`(national only), `source_channel`, `source_channels`, `scope_breakdown` |
-| 지도 Hover 최신값 | `GET /api/v1/dashboard/map-latest` | `regions`, `matchups`, `poll_options` | `region_code`, `office_type`, `title`, `value_mid`, `audience_scope`, `source_channel`, `source_channels`, `scope_breakdown` |
+| 최신 정당/대통령 요약 | `GET /api/v1/dashboard/summary` | `poll_observations`, `poll_options` | `pollster`, `survey_end_date`, `option_name`, `value_mid`, `verified`, `audience_scope`(national only), `source_priority`, `official_release_at`, `article_published_at`, `freshness_hours`, `is_official_confirmed`, `source_channel`, `source_channels`, `scope_breakdown` |
+| 지도 Hover 최신값 | `GET /api/v1/dashboard/map-latest` | `regions`, `matchups`, `poll_options` | `region_code`, `office_type`, `title`, `value_mid`, `audience_scope`, `source_priority`, `official_release_at`, `article_published_at`, `freshness_hours`, `is_official_confirmed`, `source_channel`, `source_channels`, `scope_breakdown` |
 | 빅매치 카드 | `GET /api/v1/dashboard/big-matches` | `matchups`, `poll_observations` | `matchup_id`, `title`, `survey_end_date`, `value_mid`, `audience_scope`, `source_channel`, `source_channels`, `scope_breakdown` |
 | 지역 검색 | `GET /api/v1/regions/search` | `regions` | `region_code`, `sido_name`, `sigungu_name` |
 | 지역별 선거 탭 | `GET /api/v1/regions/{region_code}/elections` | `matchups` | `region_code`, `office_type`, `is_active` |
-| 매치업 상세 | `GET /api/v1/matchups/{matchup_id}` | `poll_observations`, `poll_options`, `review_queue` | `matchup_id`, `pollster`, `survey_start_date`, `survey_end_date`, `confidence_level`, `sample_size`, `response_rate`, `margin_of_error`, `date_inference_mode`, `date_inference_confidence`, `nesdc_enriched`, `needs_manual_review`, `value_mid`, `party_inferred`, `party_inference_source`, `party_inference_confidence`, `source_grade`, `audience_scope`, `audience_region_code`, `legal_completeness_score`, `legal_filled_count`, `legal_required_count`, `source_channel`, `source_channels`, `poll_fingerprint` |
+| 매치업 상세 | `GET /api/v1/matchups/{matchup_id}` | `poll_observations`, `poll_options`, `review_queue` | `matchup_id`, `pollster`, `survey_start_date`, `survey_end_date`, `confidence_level`, `sample_size`, `response_rate`, `margin_of_error`, `date_inference_mode`, `date_inference_confidence`, `nesdc_enriched`, `needs_manual_review`, `source_priority`, `official_release_at`, `article_published_at`, `freshness_hours`, `is_official_confirmed`, `value_mid`, `party_inferred`, `party_inference_source`, `party_inference_confidence`, `source_grade`, `audience_scope`, `audience_region_code`, `legal_completeness_score`, `legal_filled_count`, `legal_required_count`, `source_channel`, `source_channels`, `poll_fingerprint` |
 | 후보자 상세 | `GET /api/v1/candidates/{candidate_id}` | `candidates`, `candidate_profiles` | `candidate_id`, `name_ko`, `party_name`, `career_summary` |
 
 ## 5. API-UI 필드명 일치 규칙
@@ -80,3 +80,5 @@
 11. 매치업 상세의 `nesdc_enriched`는 `source_channels`에 `nesdc`가 포함되면 `true`다.
 12. 매치업 상세의 `needs_manual_review`는 연결된 `review_queue`가 `pending` 또는 `in_progress`이면 `true`다.
 13. 옵션별 `party_inferred=true`이면서 `party_inference_confidence < 0.8`이면 `review_queue` 검수 대상이다.
+14. `source_priority`는 `source_channels` 기준으로 `official|article|mixed`를 노출한다.
+15. `freshness_hours`는 공식시각(`official_release_at`) 우선으로 계산하고, 없으면 기사시각(`article_published_at`)을 사용한다.

--- a/docs/05_RUNBOOK_AND_OPERATIONS.md
+++ b/docs/05_RUNBOOK_AND_OPERATIONS.md
@@ -188,6 +188,7 @@
 3. 빅매치 계산 결과 이상치 여부
 4. 지도 데이터 누락 지역 여부
 5. `dashboard/summary`의 `scope_breakdown.regional/local/unknown`가 0인지 확인(전국 오염 방지)
+6. `dashboard/summary`/`dashboard/map-latest`의 `freshness_hours`와 `source_priority` 확인(공식확정 지연 감시)
 
 ## 10. 준법 체크
 1. robots 정책 위반 요청 로그 여부

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -21,6 +21,8 @@ class FakeApiRepo:
                 "pollster": "KBS",
                 "survey_end_date": date(2026, 2, 18),
                 "audience_scope": "national",
+                "observation_updated_at": "2026-02-18T03:00:00+00:00",
+                "article_published_at": "2026-02-18T01:00:00+00:00",
                 "source_channel": "nesdc",
                 "source_channels": ["article", "nesdc"],
                 "verified": True,
@@ -32,6 +34,8 @@ class FakeApiRepo:
                 "pollster": "KBS",
                 "survey_end_date": date(2026, 2, 18),
                 "audience_scope": "regional",
+                "observation_updated_at": "2026-02-18T02:00:00+00:00",
+                "article_published_at": "2026-02-18T01:30:00+00:00",
                 "source_channel": "article",
                 "source_channels": ["article"],
                 "verified": True,
@@ -43,6 +47,8 @@ class FakeApiRepo:
                 "pollster": "KBS",
                 "survey_end_date": date(2026, 2, 18),
                 "audience_scope": "national",
+                "observation_updated_at": "2026-02-18T03:30:00+00:00",
+                "article_published_at": "2026-02-18T03:00:00+00:00",
                 "source_channel": "article",
                 "source_channels": ["article"],
                 "verified": True,
@@ -54,6 +60,8 @@ class FakeApiRepo:
                 "pollster": "KBS",
                 "survey_end_date": date(2026, 2, 18),
                 "audience_scope": "local",
+                "observation_updated_at": "2026-02-18T04:00:00+00:00",
+                "article_published_at": "2026-02-18T03:30:00+00:00",
                 "source_channel": "article",
                 "source_channels": ["article"],
                 "verified": True,
@@ -80,6 +88,8 @@ class FakeApiRepo:
                 "survey_end_date": date(2026, 2, 18),
                 "option_name": "정원오",
                 "audience_scope": "regional",
+                "observation_updated_at": "2026-02-18T03:00:00+00:00",
+                "article_published_at": "2026-02-18T01:00:00+00:00",
                 "source_channel": "nesdc",
                 "source_channels": ["article", "nesdc"],
             }
@@ -135,6 +145,8 @@ class FakeApiRepo:
             "date_resolution": "exact",
             "date_inference_mode": "relative_published_at",
             "date_inference_confidence": 0.92,
+            "observation_updated_at": "2026-02-18T03:00:00+00:00",
+            "article_published_at": "2026-02-18T01:00:00+00:00",
             "nesdc_enriched": True,
             "needs_manual_review": True,
             "poll_fingerprint": "f" * 64,
@@ -365,6 +377,11 @@ def test_api_contract_fields():
     assert [x["option_name"] for x in body["party_support"]] == ["더불어민주당"]
     assert [x["option_name"] for x in body["presidential_approval"]] == ["국정안정론"]
     assert body["scope_breakdown"] == {"national": 2, "regional": 1, "local": 1, "unknown": 0}
+    assert body["party_support"][0]["source_priority"] == "mixed"
+    assert body["party_support"][0]["is_official_confirmed"] is True
+    assert isinstance(body["party_support"][0]["freshness_hours"], float)
+    assert body["party_support"][0]["article_published_at"] is not None
+    assert body["party_support"][0]["official_release_at"] is not None
 
     regions = client.get("/api/v1/regions/search", params={"q": "서울"})
     assert regions.status_code == 200
@@ -376,6 +393,9 @@ def test_api_contract_fields():
     assert map_latest.json()["items"][0]["source_channels"] == ["article", "nesdc"]
     assert map_latest.json()["items"][0]["audience_scope"] == "regional"
     assert map_latest.json()["scope_breakdown"] == {"national": 0, "regional": 1, "local": 0, "unknown": 0}
+    assert map_latest.json()["items"][0]["source_priority"] == "mixed"
+    assert map_latest.json()["items"][0]["is_official_confirmed"] is True
+    assert isinstance(map_latest.json()["items"][0]["freshness_hours"], float)
 
     big_matches = client.get("/api/v1/dashboard/big-matches")
     assert big_matches.status_code == 200
@@ -401,6 +421,11 @@ def test_api_contract_fields():
     assert matchup.json()["date_inference_confidence"] == 0.92
     assert matchup.json()["nesdc_enriched"] is True
     assert matchup.json()["needs_manual_review"] is True
+    assert matchup.json()["source_priority"] == "mixed"
+    assert matchup.json()["is_official_confirmed"] is True
+    assert isinstance(matchup.json()["freshness_hours"], float)
+    assert matchup.json()["article_published_at"] is not None
+    assert matchup.json()["official_release_at"] is not None
     assert matchup.json()["source_channel"] == "article"
     assert matchup.json()["source_channels"] == ["article", "nesdc"]
     assert matchup.json()["options"][0]["party_inferred"] is True

--- a/tests/test_repository_matchup_legal_metadata.py
+++ b/tests/test_repository_matchup_legal_metadata.py
@@ -42,6 +42,8 @@ class _Cursor:
                 "date_resolution": "exact",
                 "date_inference_mode": "relative_published_at",
                 "date_inference_confidence": 0.92,
+                "observation_updated_at": "2026-02-18T03:00:00+00:00",
+                "article_published_at": "2026-02-18T01:00:00+00:00",
                 "nesdc_enriched": True,
                 "needs_manual_review": True,
                 "poll_fingerprint": "f" * 64,
@@ -85,6 +87,8 @@ def test_get_matchup_returns_legal_metadata_fields():
     assert out["audience_scope"] == "regional"
     assert out["date_inference_mode"] == "relative_published_at"
     assert out["date_inference_confidence"] == 0.92
+    assert out["observation_updated_at"] == "2026-02-18T03:00:00+00:00"
+    assert out["article_published_at"] == "2026-02-18T01:00:00+00:00"
     assert out["nesdc_enriched"] is True
     assert out["needs_manual_review"] is True
     assert out["options"][0]["party_inferred"] is True


### PR DESCRIPTION
## 작업 요약
- 이중소스 병합정책 v1 API 파생 필드 추가
  - `source_priority` (`official|article|mixed`)
  - `official_release_at`, `article_published_at`, `freshness_hours`
  - `is_official_confirmed`
- `summary/map/matchup` 응답 계약 동기화
- 전국 오염 방지 정책 유지 + dual-source 회귀 테스트 강화
- 샘플 payload/문서/보고서 동기화

## 변경 파일
- `app/models/schemas.py`
- `app/api/routes.py`
- `app/services/repository.py`
- `tests/test_api_routes.py`
- `tests/test_repository_matchup_legal_metadata.py`
- `docs/02_DATA_MODEL_AND_NORMALIZATION.md`
- `docs/03_UI_UX_SPEC.md`
- `docs/05_RUNBOOK_AND_OPERATIONS.md`
- `data/dual_source_merge_policy_samples_v1.json`
- `develop_report/2026-02-19_dual_source_merge_policy_api_v1_report.md`

## 검증
- `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q tests/test_api_routes.py tests/test_repository_dashboard_summary_scope.py tests/test_repository_matchup_legal_metadata.py tests/test_poll_fingerprint.py`
- `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q`

Closes #113

Report-Path: develop_report/2026-02-19_dual_source_merge_policy_api_v1_report.md
