### PR TITLE
fix(develop): party inference API/DB contract gaps (#117)

### DIFF
--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -15,6 +15,10 @@ class CandidateOut(BaseModel):
     candidate_id: str
     name_ko: str
     party_name: str | None = None
+    party_inferred: bool = False
+    party_inference_source: str | None = None
+    party_inference_confidence: float | None = None
+    needs_manual_review: bool = False
     gender: str | None = None
     birth_date: date | None = None
     job: str | None = None
@@ -107,6 +111,7 @@ class MatchupOptionOut(BaseModel):
     party_inferred: bool = False
     party_inference_source: str | None = None
     party_inference_confidence: float | None = None
+    needs_manual_review: bool = False
 
 
 class MatchupOut(BaseModel):
@@ -274,6 +279,10 @@ class CandidateInput(BaseModel):
     candidate_id: str
     name_ko: str
     party_name: str | None = None
+    party_inferred: bool = False
+    party_inference_source: str | None = None
+    party_inference_confidence: float | None = None
+    needs_manual_review: bool = False
     gender: str | None = None
     birth_date: date | None = None
     job: str | None = None
@@ -323,6 +332,7 @@ class PollOptionInput(BaseModel):
     party_inferred: bool = False
     party_inference_source: str | None = None
     party_inference_confidence: float | None = None
+    needs_manual_review: bool = False
 
 
 class IngestRecordInput(BaseModel):

--- a/app/services/ingest_service.py
+++ b/app/services/ingest_service.py
@@ -32,6 +32,15 @@ def _normalize_option(option: PollOptionInput) -> dict:
         payload["value_max"] = normalized.value_max
         payload["value_mid"] = normalized.value_mid
         payload["is_missing"] = normalized.is_missing
+
+    confidence = payload.get("party_inference_confidence")
+    if payload.get("party_inferred") and confidence is not None:
+        try:
+            payload["needs_manual_review"] = float(confidence) < PARTY_INFERENCE_REVIEW_THRESHOLD
+        except (TypeError, ValueError):
+            payload["needs_manual_review"] = False
+    else:
+        payload["needs_manual_review"] = bool(payload.get("needs_manual_review", False))
     return payload
 
 

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -12,6 +12,10 @@ CREATE TABLE IF NOT EXISTS candidates (
     candidate_id TEXT PRIMARY KEY,
     name_ko TEXT NOT NULL,
     party_name TEXT NULL,
+    party_inferred BOOLEAN NOT NULL DEFAULT FALSE,
+    party_inference_source TEXT NULL,
+    party_inference_confidence FLOAT NULL,
+    needs_manual_review BOOLEAN NOT NULL DEFAULT FALSE,
     gender TEXT NULL,
     birth_date DATE NULL,
     job TEXT NULL,
@@ -19,6 +23,12 @@ CREATE TABLE IF NOT EXISTS candidates (
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
+
+ALTER TABLE candidates
+    ADD COLUMN IF NOT EXISTS party_inferred BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS party_inference_source TEXT NULL,
+    ADD COLUMN IF NOT EXISTS party_inference_confidence FLOAT NULL,
+    ADD COLUMN IF NOT EXISTS needs_manual_review BOOLEAN NOT NULL DEFAULT FALSE;
 
 CREATE TABLE IF NOT EXISTS candidate_profiles (
     id BIGSERIAL PRIMARY KEY,
@@ -185,6 +195,7 @@ CREATE TABLE IF NOT EXISTS poll_options (
     party_inferred BOOLEAN NOT NULL DEFAULT FALSE,
     party_inference_source TEXT NULL,
     party_inference_confidence FLOAT NULL,
+    needs_manual_review BOOLEAN NOT NULL DEFAULT FALSE,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     UNIQUE (observation_id, option_type, option_name)
@@ -193,7 +204,8 @@ CREATE TABLE IF NOT EXISTS poll_options (
 ALTER TABLE poll_options
     ADD COLUMN IF NOT EXISTS party_inferred BOOLEAN NOT NULL DEFAULT FALSE,
     ADD COLUMN IF NOT EXISTS party_inference_source TEXT NULL,
-    ADD COLUMN IF NOT EXISTS party_inference_confidence FLOAT NULL;
+    ADD COLUMN IF NOT EXISTS party_inference_confidence FLOAT NULL,
+    ADD COLUMN IF NOT EXISTS needs_manual_review BOOLEAN NOT NULL DEFAULT FALSE;
 
 CREATE TABLE IF NOT EXISTS review_queue (
     id BIGSERIAL PRIMARY KEY,

--- a/develop_report/2026-02-19_issue117_party_inference_contract_fix_report.md
+++ b/develop_report/2026-02-19_issue117_party_inference_contract_fix_report.md
@@ -1,0 +1,93 @@
+# 2026-02-19 Issue #117 Party Inference Contract Fix Report
+
+## 1. 작업 목표
+- Issue: [#117](https://github.com/iAmSomething/2026-/issues/117)
+- 제목: `[DEVELOP] 정당 추정 API/DB 계약 누락 보정(v1)`
+- 목표:
+1. `CandidateOut`, `MatchupOptionOut`에 정당 추정/검수 필드 4종 반영
+2. `candidates`, `poll_options` DB 컬럼 + 마이그레이션 반영
+3. repository 읽기/쓰기 경로 반영
+4. API/QA 테스트 게이트 강화
+
+## 2. 구현 내용
+1. API 스키마 확장
+- `app/models/schemas.py`
+  - `CandidateOut`: `party_inferred`, `party_inference_source`, `party_inference_confidence`, `needs_manual_review` 추가
+  - `MatchupOptionOut`: 동일 4필드 추가
+  - 입력 경로 일관성을 위해 `CandidateInput`, `PollOptionInput`에도 동일 필드(기본값 포함) 확장
+
+2. DB 스키마/마이그레이션 반영
+- `db/schema.sql`
+  - `candidates` 테이블에 4필드 추가 + `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` 마이그레이션 추가
+  - `poll_options` 테이블에 `needs_manual_review` 컬럼 추가 + 마이그레이션 추가
+
+3. Repository 읽기/쓰기 경로 반영
+- `app/services/repository.py`
+  - `upsert_candidate`:
+    - 신규 4필드 insert/update 반영
+    - 기본값(`False/None`) 주입
+  - `get_candidate`:
+    - 신규 4필드 select 반영
+  - `upsert_poll_option`:
+    - `needs_manual_review` insert/update 반영
+    - 기본값 `False` 주입
+  - `get_matchup`:
+    - option 조회 시 `needs_manual_review` 반환
+
+4. Ingest 경로 반영
+- `app/services/ingest_service.py`
+  - `party_inferred=true` + `party_inference_confidence < 0.8`이면 옵션 `needs_manual_review=true` 자동 설정
+
+5. 테스트/게이트 강화
+- `tests/test_api_routes.py`
+  - 후보/매치업 옵션 신규 필드 존재 및 타입 검증 추가
+- `tests/test_repository_matchup_legal_metadata.py`
+  - option `needs_manual_review` 반환 검증 추가
+- `tests/test_schema_party_inference.py`
+  - `candidates/poll_options` 신규 컬럼+마이그레이션 문자열 검증 추가
+- `scripts/qa/check_phase1.sh`
+  - candidate API 계약 검증에 신규 4필드 + 타입 검증 추가
+- `scripts/qa/run_api_contract_suite.sh`
+  - FakeRepo 응답에 신규 필드 반영
+  - matchup/candidate 성공 계약 assert 강화
+
+## 3. 검증 결과
+1. 타겟 테스트
+- 명령:
+  - `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q tests/test_api_routes.py tests/test_repository_matchup_legal_metadata.py tests/test_schema_party_inference.py`
+- 결과: `8 passed`
+
+2. 전체 테스트
+- 명령:
+  - `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q`
+- 결과: `69 passed`
+
+3. API Contract Suite
+- 명령:
+  - `scripts/qa/run_api_contract_suite.sh`
+- 결과: `summary: total=28, pass=28, fail=0`
+
+4. Phase1 체크
+- 명령:
+  - `scripts/qa/check_phase1.sh`
+- 결과:
+  - `fail=0`
+  - warning 2건(collector precision report 부재, 코어 이슈 일부 미종료)은 기존 non-blocking 상태
+
+## 4. 수용 기준 대비
+1. API 누락 보정: 완료
+2. DB/Repository 경로 누락 보정: 완료
+3. 테스트/게이트 강화: 완료
+4. `pytest` 및 API contract suite 통과: 완료
+
+## 5. 의사결정 필요 사항
+1. `party_inference_source` 값 표준화 필요
+- 현재는 문자열 자유 입력(`name_rule` 등) 허용
+- 운영 전 enum(예: `name_rule`, `article_context`, `manual`)을 확정할지 결정 필요
+
+2. 후보(`candidates`) 기준 `needs_manual_review` 운영 주체 정의 필요
+- 현재는 DB 컬럼 경로만 열어두고 기본값 `false`
+- 실제 업데이트를 ingest에서 할지, 검수 워크플로우에서 할지 역할 분리 결정 필요
+
+3. 기존 데이터 백필 정책 결정 필요
+- 기존 레코드에 대해 신규 컬럼 기본값(`false/null`) 유지 vs 규칙 기반 재계산 백필 여부 결정 필요

--- a/scripts/qa/check_phase1.sh
+++ b/scripts/qa/check_phase1.sh
@@ -228,8 +228,15 @@ import json, urllib.request
 base="$API_BASE"
 candidate_id="cand-jwo"
 obj=json.loads(urllib.request.urlopen(base+f"/api/v1/candidates/{candidate_id}").read().decode())
-for k in ["candidate_id","name_ko","party_name"]:
+for k in [
+    "candidate_id","name_ko","party_name",
+    "party_inferred","party_inference_source","party_inference_confidence","needs_manual_review"
+]:
     assert k in obj
+assert isinstance(obj["party_inferred"], bool)
+assert isinstance(obj["needs_manual_review"], bool)
+assert obj["party_inference_source"] is None or isinstance(obj["party_inference_source"], str)
+assert obj["party_inference_confidence"] is None or isinstance(obj["party_inference_confidence"], (int, float))
 print("candidate ok")
 PY
 fi

--- a/tests/test_repository_matchup_legal_metadata.py
+++ b/tests/test_repository_matchup_legal_metadata.py
@@ -63,6 +63,7 @@ class _Cursor:
                 "party_inferred": True,
                 "party_inference_source": "name_rule",
                 "party_inference_confidence": 0.84,
+                "needs_manual_review": False,
             }
         ]
 
@@ -94,3 +95,4 @@ def test_get_matchup_returns_legal_metadata_fields():
     assert out["options"][0]["party_inferred"] is True
     assert out["options"][0]["party_inference_source"] == "name_rule"
     assert out["options"][0]["party_inference_confidence"] == 0.84
+    assert out["options"][0]["needs_manual_review"] is False

--- a/tests/test_schema_party_inference.py
+++ b/tests/test_schema_party_inference.py
@@ -6,5 +6,8 @@ def test_schema_contains_party_inference_columns() -> None:
     assert "party_inferred BOOLEAN NOT NULL DEFAULT FALSE" in sql
     assert "party_inference_source TEXT NULL" in sql
     assert "party_inference_confidence FLOAT NULL" in sql
+    assert "needs_manual_review BOOLEAN NOT NULL DEFAULT FALSE" in sql
+    assert "ALTER TABLE candidates" in sql
+    assert "ADD COLUMN IF NOT EXISTS needs_manual_review BOOLEAN NOT NULL DEFAULT FALSE" in sql
     assert "ALTER TABLE poll_options" in sql
     assert "ADD COLUMN IF NOT EXISTS party_inferred BOOLEAN NOT NULL DEFAULT FALSE" in sql


### PR DESCRIPTION
## Summary
- Extend candidate/matchup-option party inference contract fields across schema, DB, repository, and QA gates.
- Add DB migration-safe columns for `candidates` and `poll_options`.
- Expand API/contract tests and submit develop report.

## Linked Issue
- Closes #117

## Report-Path
Report-Path: develop_report/2026-02-19_issue117_party_inference_contract_fix_report.md

## Checklist
- [x] docs 계약(필드/API/용어)과 일치
- [x] 테스트 또는 검증 로그 첨부
- [x] 보안 정보(key/secret) 미포함 확인
- [x] Report-Path 파일이 이번 PR에 포함됨

## Verification
- `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q tests/test_api_routes.py tests/test_repository_matchup_legal_metadata.py tests/test_schema_party_inference.py`
- `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q`
- `scripts/qa/run_api_contract_suite.sh`
- `scripts/qa/check_phase1.sh`
