### PR TITLE
fix(develop): scope/dual-source API-DB contract alignment (#120)

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -122,6 +122,7 @@ def get_dashboard_summary(
             pollster=row["pollster"],
             survey_end_date=row["survey_end_date"],
             audience_scope=row.get("audience_scope"),
+            audience_region_code=row.get("audience_region_code"),
             source_priority=source_meta["source_priority"],
             official_release_at=source_meta["official_release_at"],
             article_published_at=source_meta["article_published_at"],
@@ -163,6 +164,7 @@ def get_dashboard_map_latest(
                 survey_end_date=row.get("survey_end_date"),
                 option_name=row.get("option_name"),
                 audience_scope=row.get("audience_scope"),
+                audience_region_code=row.get("audience_region_code"),
                 source_priority=source_meta["source_priority"],
                 official_release_at=source_meta["official_release_at"],
                 article_published_at=source_meta["article_published_at"],
@@ -230,7 +232,11 @@ def get_candidate(
     if not candidate:
         raise HTTPException(status_code=404, detail="candidate not found")
     enriched = data_go_service.enrich_candidate(dict(candidate))
-    return CandidateOut(**enriched)
+    source_meta = _derive_source_meta(enriched)
+    payload = dict(enriched)
+    payload.update(source_meta)
+    payload["source_channels"] = payload.get("source_channels") or []
+    return CandidateOut(**payload)
 
 
 @router.get("/ops/metrics/summary", response_model=OpsMetricsSummaryOut)

--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -16,9 +16,16 @@ class CandidateOut(BaseModel):
     name_ko: str
     party_name: str | None = None
     party_inferred: bool = False
-    party_inference_source: str | None = None
+    party_inference_source: Literal["name_rule", "article_context", "manual"] | None = None
     party_inference_confidence: float | None = None
     needs_manual_review: bool = False
+    source_channel: Literal["article", "nesdc"] | None = None
+    source_channels: list[Literal["article", "nesdc"]] = Field(default_factory=list)
+    source_priority: Literal["official", "article", "mixed"] = "article"
+    official_release_at: datetime | None = None
+    article_published_at: datetime | None = None
+    freshness_hours: float | None = None
+    is_official_confirmed: bool = False
     gender: str | None = None
     birth_date: date | None = None
     job: str | None = None
@@ -32,6 +39,7 @@ class SummaryPoint(BaseModel):
     pollster: str | None = None
     survey_end_date: date | None = None
     audience_scope: Literal["national", "regional", "local"] | None = None
+    audience_region_code: str | None = None
     source_priority: Literal["official", "article", "mixed"] = "article"
     official_release_at: datetime | None = None
     article_published_at: datetime | None = None
@@ -64,6 +72,7 @@ class MapLatestPoint(BaseModel):
     survey_end_date: date | None = None
     option_name: str | None = None
     audience_scope: Literal["national", "regional", "local"] | None = None
+    audience_region_code: str | None = None
     source_priority: Literal["official", "article", "mixed"] = "article"
     official_release_at: datetime | None = None
     article_published_at: datetime | None = None
@@ -109,7 +118,7 @@ class MatchupOptionOut(BaseModel):
     value_mid: float | None = None
     value_raw: str | None = None
     party_inferred: bool = False
-    party_inference_source: str | None = None
+    party_inference_source: Literal["name_rule", "article_context", "manual"] | None = None
     party_inference_confidence: float | None = None
     needs_manual_review: bool = False
 
@@ -280,9 +289,13 @@ class CandidateInput(BaseModel):
     name_ko: str
     party_name: str | None = None
     party_inferred: bool = False
-    party_inference_source: str | None = None
+    party_inference_source: Literal["name_rule", "article_context", "manual"] | None = None
     party_inference_confidence: float | None = None
     needs_manual_review: bool = False
+    source_channel: Literal["article", "nesdc"] = "article"
+    source_channels: list[Literal["article", "nesdc"]] | None = None
+    official_release_at: datetime | None = None
+    article_published_at: datetime | None = None
     gender: str | None = None
     birth_date: date | None = None
     job: str | None = None
@@ -317,6 +330,7 @@ class PollObservationInput(BaseModel):
     poll_fingerprint: str | None = None
     source_channel: Literal["article", "nesdc"] = "article"
     source_channels: list[Literal["article", "nesdc"]] | None = None
+    official_release_at: datetime | None = None
     verified: bool = False
     source_grade: str = "C"
 
@@ -330,7 +344,7 @@ class PollOptionInput(BaseModel):
     value_mid: float | None = None
     is_missing: bool = False
     party_inferred: bool = False
-    party_inference_source: str | None = None
+    party_inference_source: Literal["name_rule", "article_context", "manual"] | None = None
     party_inference_confidence: float | None = None
     needs_manual_review: bool = False
 

--- a/app/services/fingerprint.py
+++ b/app/services/fingerprint.py
@@ -102,6 +102,7 @@ def merge_observation_by_priority(existing: dict, incoming: dict) -> dict:
         "date_resolution",
         "date_inference_mode",
         "date_inference_confidence",
+        "official_release_at",
         "method",
     )
     for field in meta_fields:

--- a/develop_report/2026-02-19_issue120_scope_dualsource_contract_v2_report.md
+++ b/develop_report/2026-02-19_issue120_scope_dualsource_contract_v2_report.md
@@ -1,0 +1,111 @@
+# 2026-02-19 Issue #120 Scope/Dual-Source Contract Fix v2 Report
+
+## 1) 작업 목표
+- Issue: [#120](https://github.com/iAmSomething/2026-/issues/120)
+- 제목: `[DEVELOP] 스코프/이중소스 API-DB 계약 보정 v2(#109/#115)`
+- 목표:
+1. `summary/map/matchup` 스코프/소스 계약 누락 보정
+2. `summary/candidate/matchup` 이중소스/신선도 계약 반영
+3. DB/Repository 경로 반영
+4. 테스트/QA 게이트 강제 검증
+5. PM 정책 메모 반영
+   - `party_inference_source` enum 고정
+   - `needs_manual_review`는 review_queue 파생
+
+## 2) 구현 내용
+1. API 스키마 확장 (`app/models/schemas.py`)
+- `SummaryPoint`:
+  - `audience_region_code` 추가
+- `MapLatestPoint`:
+  - `audience_region_code` 추가
+- `CandidateOut`:
+  - source/freshness 메타 추가
+    - `source_channel`, `source_channels`
+    - `source_priority`, `official_release_at`, `article_published_at`, `freshness_hours`, `is_official_confirmed`
+- `party_inference_source` 타입 고정:
+  - `CandidateOut/Input`, `MatchupOptionOut`, `PollOptionInput`에 `Literal["name_rule","article_context","manual"]` 적용
+- `CandidateInput`, `PollObservationInput`에 source/official datetime 입력 필드 추가
+
+2. API 라우트 보정 (`app/api/routes.py`)
+- `GET /api/v1/dashboard/summary`:
+  - `audience_region_code` 전달 반영
+- `GET /api/v1/dashboard/map-latest`:
+  - `audience_region_code` 전달 반영
+- `GET /api/v1/candidates/{candidate_id}`:
+  - `_derive_source_meta` 적용
+  - 후보 응답에도 `source_priority/freshness/official_release/article_published/is_official_confirmed` 계산 반영
+
+3. Repository/DB 경로 보정 (`app/services/repository.py`, `db/schema.sql`)
+- candidates 저장/조회 경로 확장
+  - 저장: `source_channel`, `source_channels`, `official_release_at`, `article_published_at` upsert 반영
+  - 조회: 위 필드 + `observation_updated_at(profile_updated_at)` 반환
+  - `needs_manual_review`는 후보 조회 시 `review_queue` 존재 여부(`pending/in_progress`)로 파생
+- poll_observations 경로 확장
+  - `official_release_at` insert/update/select 반영
+- summary/map/matchup 조회 확장
+  - `audience_region_code` select 반영
+  - `official_release_at` select 반영
+- summary query 개선
+  - hardcoded national SQL 필터 제거
+  - `option_type + audience_scope` 단위 latest 집계로 스코프 분리 유지
+- fingerprint merge 보강 (`app/services/fingerprint.py`)
+  - `official_release_at` 병합 대상에 추가
+
+4. DB 제약/마이그레이션 정책 반영 (`db/schema.sql`)
+- candidates 테이블:
+  - `source_channel`, `source_channels`, `official_release_at`, `article_published_at` 추가
+  - `source_channel/source_channels` 체크 제약 추가
+- poll_observations:
+  - `official_release_at` 컬럼 추가
+- enum 정책 반영:
+  - `candidates_party_inference_source_check`
+  - `poll_options_party_inference_source_check`
+- 백필 성격:
+  - `source_channels`가 비어있으면 `source_channel`로 채우는 비차단 UPDATE 반영
+
+5. 테스트/QA 게이트 강화
+- `tests/test_api_routes.py`
+  - summary/map의 `audience_region_code` 검증 추가
+  - candidate source/freshness 메타 검증 추가
+- `tests/test_repository_dashboard_summary_scope.py`
+  - summary SQL 기대값을 스코프 분리 집계 로직 기준으로 갱신
+- `tests/test_repository_matchup_legal_metadata.py`
+  - `official_release_at` 경로 검증 보강
+- `tests/test_schema_party_inference.py`
+  - 후보 `needs_manual_review` 저장 컬럼 기대 제거
+  - enum/source_channels 제약 기대 추가
+- `scripts/qa/check_phase1.sh`
+  - summary/candidate 계약 검증 항목 확장
+- `scripts/qa/run_api_contract_suite.sh`
+  - FakeRepo 및 성공 케이스 assert를 신규 계약 필드 기준으로 확장
+
+## 3) 검증 결과
+1. 타겟 테스트
+- 명령:
+  - `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q tests/test_api_routes.py tests/test_repository_matchup_legal_metadata.py tests/test_schema_party_inference.py tests/test_repository_source_channels.py tests/test_poll_fingerprint.py`
+- 결과: `13 passed`
+
+2. 전체 테스트
+- 명령:
+  - `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q`
+- 결과: `69 passed`
+
+3. API 계약 스위트
+- 명령:
+  - `scripts/qa/run_api_contract_suite.sh`
+- 결과: `total=28, pass=28, fail=0`
+
+4. Phase1 게이트
+- 명령:
+  - `scripts/qa/check_phase1.sh`
+- 결과:
+  - `fail=0`
+  - warning 2건(collector precision report 부재, core issue 미종료)은 기존 non-blocking
+
+## 4) 수용 기준 점검
+1. #109/#115 공통 FAIL 원인(API/DB 계약 누락): 보정 완료
+2. pytest + API contract suite PASS: 완료
+3. #109/#115 재게이트 요청 코멘트: PR 머지 후 이슈 코멘트로 요청 예정
+
+## 5) 산출물
+- `develop_report/2026-02-19_issue120_scope_dualsource_contract_v2_report.md`

--- a/scripts/qa/check_phase1.sh
+++ b/scripts/qa/check_phase1.sh
@@ -206,8 +206,15 @@ obj=json.loads(urllib.request.urlopen(base+"/api/v1/dashboard/summary").read().d
 assert "party_support" in obj
 assert "presidential_approval" in obj
 if obj["party_support"]:
-    for k in ["option_name","value_mid","pollster","survey_end_date","verified"]:
+    for k in [
+        "option_name","value_mid","pollster","survey_end_date","verified",
+        "audience_scope","audience_region_code","source_channel","source_channels",
+        "source_priority","freshness_hours","official_release_at","article_published_at","is_official_confirmed"
+    ]:
         assert k in obj["party_support"][0]
+    assert obj["party_support"][0]["source_channel"] in ("article", "nesdc", None)
+    assert isinstance(obj["party_support"][0]["source_channels"], list)
+    assert obj["party_support"][0]["source_priority"] in ("official", "article", "mixed")
 print("summary ok")
 PY
 
@@ -230,13 +237,19 @@ candidate_id="cand-jwo"
 obj=json.loads(urllib.request.urlopen(base+f"/api/v1/candidates/{candidate_id}").read().decode())
 for k in [
     "candidate_id","name_ko","party_name",
-    "party_inferred","party_inference_source","party_inference_confidence","needs_manual_review"
+    "party_inferred","party_inference_source","party_inference_confidence","needs_manual_review",
+    "source_channel","source_channels",
+    "source_priority","freshness_hours","official_release_at","article_published_at","is_official_confirmed"
 ]:
     assert k in obj
 assert isinstance(obj["party_inferred"], bool)
 assert isinstance(obj["needs_manual_review"], bool)
 assert obj["party_inference_source"] is None or isinstance(obj["party_inference_source"], str)
 assert obj["party_inference_confidence"] is None or isinstance(obj["party_inference_confidence"], (int, float))
+assert obj["source_priority"] in ("official", "article", "mixed")
+assert obj["freshness_hours"] is None or isinstance(obj["freshness_hours"], (int, float))
+assert isinstance(obj["is_official_confirmed"], bool)
+assert isinstance(obj["source_channels"], list)
 print("candidate ok")
 PY
 fi

--- a/tests/test_repository_dashboard_summary_scope.py
+++ b/tests/test_repository_dashboard_summary_scope.py
@@ -29,7 +29,7 @@ class _RecordingConn:
         return self._cursor
 
 
-def test_dashboard_summary_query_filters_regional_scope():
+def test_dashboard_summary_query_partitions_by_audience_scope():
     conn = _RecordingConn(rows=[])
     repo = PostgresRepository(conn)
 
@@ -37,18 +37,18 @@ def test_dashboard_summary_query_filters_regional_scope():
 
     assert len(conn._cursor.executed) == 1
     query, params = conn._cursor.executed[0]
-    scope_filter = "o.audience_scope = 'national'"
-    assert query.count(scope_filter) >= 2
+    assert "GROUP BY po.option_type, o.audience_scope" in query
+    assert "l.audience_scope IS NOT DISTINCT FROM o.audience_scope" in query
     assert params == [date(2026, 2, 19)]
 
 
-def test_dashboard_summary_query_filters_scope_without_as_of():
+def test_dashboard_summary_query_no_hardcoded_national_filter_without_as_of():
     conn = _RecordingConn(rows=[])
     repo = PostgresRepository(conn)
 
     repo.fetch_dashboard_summary(as_of=None)
 
     query, params = conn._cursor.executed[0]
-    assert "o.audience_scope = 'national'" in query
-    assert "o.audience_scope IS NULL" not in query
+    assert "o.audience_scope = 'national'" not in query
+    assert "IS NOT DISTINCT FROM o.audience_scope" in query
     assert params == []

--- a/tests/test_repository_matchup_legal_metadata.py
+++ b/tests/test_repository_matchup_legal_metadata.py
@@ -43,6 +43,7 @@ class _Cursor:
                 "date_inference_mode": "relative_published_at",
                 "date_inference_confidence": 0.92,
                 "observation_updated_at": "2026-02-18T03:00:00+00:00",
+                "official_release_at": None,
                 "article_published_at": "2026-02-18T01:00:00+00:00",
                 "nesdc_enriched": True,
                 "needs_manual_review": True,
@@ -89,6 +90,7 @@ def test_get_matchup_returns_legal_metadata_fields():
     assert out["date_inference_mode"] == "relative_published_at"
     assert out["date_inference_confidence"] == 0.92
     assert out["observation_updated_at"] == "2026-02-18T03:00:00+00:00"
+    assert out["official_release_at"] is None
     assert out["article_published_at"] == "2026-02-18T01:00:00+00:00"
     assert out["nesdc_enriched"] is True
     assert out["needs_manual_review"] is True

--- a/tests/test_schema_party_inference.py
+++ b/tests/test_schema_party_inference.py
@@ -8,6 +8,9 @@ def test_schema_contains_party_inference_columns() -> None:
     assert "party_inference_confidence FLOAT NULL" in sql
     assert "needs_manual_review BOOLEAN NOT NULL DEFAULT FALSE" in sql
     assert "ALTER TABLE candidates" in sql
-    assert "ADD COLUMN IF NOT EXISTS needs_manual_review BOOLEAN NOT NULL DEFAULT FALSE" in sql
+    assert "ADD COLUMN IF NOT EXISTS source_channel TEXT NULL" in sql
+    assert "ADD COLUMN IF NOT EXISTS source_channels TEXT[] NULL" in sql
+    assert "candidates_party_inference_source_check" in sql
     assert "ALTER TABLE poll_options" in sql
     assert "ADD COLUMN IF NOT EXISTS party_inferred BOOLEAN NOT NULL DEFAULT FALSE" in sql
+    assert "poll_options_party_inference_source_check" in sql


### PR DESCRIPTION
## Summary
- Apply scope/dual-source contract fixes for summary/map/matchup/candidate across API schema, repository SQL, and DB migrations.
- Add candidate source metadata path and derive candidate `needs_manual_review` from `review_queue`.
- Enforce `party_inference_source` enum policy in schema/DB checks and expand QA contract gates.

## Linked Issue
- Closes #120

## Report-Path
Report-Path: develop_report/2026-02-19_issue120_scope_dualsource_contract_v2_report.md

## Checklist
- [x] docs 계약(필드/API/용어)과 일치
- [x] 테스트 또는 검증 로그 첨부
- [x] 보안 정보(key/secret) 미포함 확인
- [x] Report-Path 파일이 이번 PR에 포함됨

## Verification
- `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q tests/test_api_routes.py tests/test_repository_matchup_legal_metadata.py tests/test_schema_party_inference.py tests/test_repository_source_channels.py tests/test_poll_fingerprint.py`
- `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q`
- `scripts/qa/run_api_contract_suite.sh`
- `scripts/qa/check_phase1.sh`
