### PR TITLE
[DEVELOP] #123 웹 RC 고정값/런북 문서화

### DIFF
--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -10,11 +10,9 @@ on:
         type: choice
         options:
           - apps/staging-web
-          - apps/web
       issue_number:
         description: "Issue number to post preview URL"
         required: true
-        default: "92"
         type: string
 
 permissions:

--- a/develop_report/2026-02-19_issue123_web_rc_lock_report.md
+++ b/develop_report/2026-02-19_issue123_web_rc_lock_report.md
@@ -1,0 +1,69 @@
+# 2026-02-19 Issue #123 Web RC Lock Report
+
+## 1. 목적
+- Issue #123 `[DEVELOP] 웹 확인용 RC 고정(공개 URL/API env/런북)` 대응
+- 공개 확인 URL/브랜치/배포설정 고정 문서화, API env 확인, RC 체크리스트(runbook) 작성
+
+## 2. 반영 파일
+1. `.github/workflows/vercel-preview.yml`
+2. `docs/04_DEPLOYMENT_AND_ENVIRONMENT.md`
+3. `docs/05_RUNBOOK_AND_OPERATIONS.md`
+4. `develop_report/2026-02-19_issue123_web_rc_lock_report.md`
+
+## 3. 구현 내용
+1. Vercel Preview dispatch 입력 고정
+- `root_dir` 선택지를 `apps/staging-web` 단일값으로 고정
+- `issue_number`는 실행 시 명시 입력(기본값 제거)
+
+2. 배포/환경 문서 고정
+- 공개 확인 URL: `https://2026-deploy.vercel.app`
+- 배포 기준 브랜치: `main` (Production deployment ref 기준)
+- 웹 API env 우선순위(`API_BASE_URL -> NEXT_PUBLIC_API_BASE_URL -> 127.0.0.1`) 명시
+- 스테이징/공개 환경에서 env 누락 시 fallback(`summary fetch failed`) 동작 명시
+
+3. RC 런북 체크리스트 추가
+- URL 접근(200) 확인
+- 핵심 API 3개(`/dashboard/summary`, `/regions/search`, `/candidates/{id}`) 확인 명령
+- 빈데이터/오류 fallback 확인 절차 추가
+
+## 4. 검증 기록 (2026-02-19 UTC)
+1. 공개 URL 접근 확인
+```bash
+curl -sS -o /tmp/issue123_web_home.html -w "HOME_STATUS=%{http_code}\n" "https://2026-deploy.vercel.app"
+```
+- 결과: `HOME_STATUS=200`
+
+2. 공개 웹 도메인에서 API 경로 응답 확인
+```bash
+curl -sS -o /tmp/issue123_api_dashboard.json -w "%{http_code}\n" "https://2026-deploy.vercel.app/api/v1/dashboard/summary"
+curl -sS -o /tmp/issue123_api_regions.json -w "%{http_code}\n" "https://2026-deploy.vercel.app/api/v1/regions/search?query=%EC%84%9C%EC%9A%B8"
+curl -sS -o /tmp/issue123_api_candidate.json -w "%{http_code}\n" "https://2026-deploy.vercel.app/api/v1/candidates/cand-jwo"
+```
+- 결과: 3개 모두 `404` (웹 도메인 자체 API 미제공 상태)
+
+3. 홈 fallback 렌더 확인
+```bash
+rg -n "Election 2026 Staging|API Base|summary fetch failed" /tmp/issue123_web_home.html
+```
+- 결과:
+  - `Election 2026 Staging` 노출 확인
+  - `API Base: http://127.0.0.1:8100` 노출 확인
+  - `summary fetch failed: fetch failed` 노출 확인
+
+4. Production deployment ref 확인
+```bash
+gh api "repos/iAmSomething/2026-/deployments?per_page=100" --jq '[.[] | select(.environment=="Production")][0] | {ref,created_at,environment}'
+git branch -r --contains b32e774ea9936570364a35bcd0d584603011407b
+```
+- 결과:
+  - Production ref: `b32e774ea9936570364a35bcd0d584603011407b`
+  - 포함 브랜치: `origin/main`
+
+## 5. 수용 기준 판정
+1. 공개 URL 접근 200 확인: `PASS`
+2. RC 런북 보고서 제출: `PASS`
+3. 재현 명령/링크 포함: `PASS`
+
+## 6. 의사결정 필요사항
+1. 스테이징/공개 웹에서 실제 API 연동 성공 상태를 보여주기 위해 Vercel 환경변수 `NEXT_PUBLIC_API_BASE_URL` 고정값을 어떤 URL로 운영할지 확정 필요
+2. preview URL의 접근 정책(`public` vs `auth_gated`)을 운영 기본값으로 확정 필요

--- a/docs/04_DEPLOYMENT_AND_ENVIRONMENT.md
+++ b/docs/04_DEPLOYMENT_AND_ENVIRONMENT.md
@@ -164,9 +164,30 @@ scripts/qa/smoke_staging.sh --api-base "$API_BASE" --web-base "$WEB_BASE"
 - `VERCEL_SCOPE` (team slug)
 - `VERCEL_PROJECT_NAME`
 4. Dispatch 입력:
-- `root_dir`: `apps/staging-web` 또는 `apps/web`
-- `issue_number`: URL 코멘트를 남길 이슈 번호(기본 `92`)
+- `root_dir`: `apps/staging-web` (RC 고정)
+- `issue_number`: URL 코멘트를 남길 이슈 번호(실행 시 명시 입력)
 5. 실행 결과:
 - Preview URL 추출 후 `issue_number`에 코멘트 자동 작성
 - 접근 검증(`curl`) 로그와 배포 로그를 artifact로 업로드
 - Vercel Preview Protection이 켜진 경우 `401`을 `auth_gated` 접근으로 기록한다.
+
+## 13. 웹 확인용 RC 고정값 (Issue #123)
+1. 공개 확인 URL(Production):
+- `https://2026-deploy.vercel.app`
+2. 배포 기준 브랜치:
+- `main` (GitHub Deployment Production ref 기준)
+3. RC 배포 설정:
+- 타깃: `Vercel`
+- 프로젝트 루트: `apps/staging-web`
+- 배포 입력값은 GitHub Secrets(`VERCEL_TOKEN`, `VERCEL_SCOPE`, `VERCEL_PROJECT_NAME`)으로만 주입
+4. 웹 API endpoint 환경변수 계약:
+- 코드 기준: `apps/staging-web/app/page.js`
+- 해석 우선순위: `API_BASE_URL` -> `NEXT_PUBLIC_API_BASE_URL` -> `http://127.0.0.1:8100`
+- 개발(local) 권장:
+  - `API_BASE_URL=http://127.0.0.1:8100`
+  - `NEXT_PUBLIC_API_BASE_URL=http://127.0.0.1:8100`
+- 스테이징/공개 확인 권장:
+  - `NEXT_PUBLIC_API_BASE_URL=<공개 API Base URL>`
+  - 필요 시 `API_BASE_URL`도 동일 값으로 주입
+5. fallback 동작:
+- 스테이징/공개 환경에서 API Base env가 비어 있으면 `127.0.0.1` fallback이 렌더링되어 연동 실패(`summary fetch failed`)가 표시될 수 있다.

--- a/docs/05_RUNBOOK_AND_OPERATIONS.md
+++ b/docs/05_RUNBOOK_AND_OPERATIONS.md
@@ -243,3 +243,27 @@ python -m app.jobs.bootstrap_ingest --input data/bootstrap_ingest_coverage_v2.js
 - `idempotent_check.delta.regions_covered == 0`
 - `idempotent_check.delta.sido_covered == 0`
 - `idempotent_check.delta.observations_total == 0`
+
+## 14. 웹 RC 체크리스트 (Issue #123)
+1. 준비 변수:
+```bash
+WEB_URL="https://2026-deploy.vercel.app"
+API_BASE="<공개 API Base URL>"
+```
+2. URL 접근(200) 확인:
+```bash
+curl -sS -o /tmp/web_rc_home.html -w "%{http_code}\n" "$WEB_URL"
+```
+3. 홈 렌더 핵심 문자열 확인:
+```bash
+rg -n "Election 2026 Staging|API Base|summary fetch failed" /tmp/web_rc_home.html
+```
+4. API 3개 연동 확인(200 기대):
+```bash
+curl -sS -o /tmp/web_rc_summary.json -w "%{http_code}\n" "$API_BASE/api/v1/dashboard/summary"
+curl -sS -o /tmp/web_rc_regions.json -w "%{http_code}\n" "$API_BASE/api/v1/regions/search?query=%EC%84%9C%EC%9A%B8"
+curl -sS -o /tmp/web_rc_candidate.json -w "%{http_code}\n" "$API_BASE/api/v1/candidates/cand-jwo"
+```
+5. fallback/오류 표시 확인:
+- `summary fetch failed`가 보이면 web이 정상적으로 오류 fallback을 렌더링한 상태다.
+- 스테이징/공개 환경에서는 `API_BASE`를 `127.0.0.1`이 아닌 실제 API URL로 지정해야 연동 성공 상태를 확인할 수 있다.


### PR DESCRIPTION
## Summary
- lock Vercel preview `root_dir` to `apps/staging-web` for web RC consistency
- document RC fixed target (public URL, branch, deploy settings, API env contract)
- add web RC runbook checklist (URL 200, API 3 endpoints, fallback behavior)
- add develop report with reproducible commands and verification evidence

## Verification
- `curl -sS -o /tmp/issue123_web_home.html -w "HOME_STATUS=%{http_code}\n" "https://2026-deploy.vercel.app"` -> `HOME_STATUS=200`
- `rg -n "Election 2026 Staging|API Base|summary fetch failed" /tmp/issue123_web_home.html`
- `gh api "repos/iAmSomething/2026-/deployments?per_page=100" --jq '[.[] | select(.environment=="Production")][0] | {ref,created_at,environment}'`

Report-Path: develop_report/2026-02-19_issue123_web_rc_lock_report.md
Closes #123
