### PR TITLE
[DEVELOP] 적용: Railway API base 고정 + public preview + CORS

### DIFF
--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -28,6 +28,7 @@ jobs:
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
       VERCEL_SCOPE: ${{ secrets.VERCEL_SCOPE }}
       VERCEL_PROJECT_NAME: ${{ secrets.VERCEL_PROJECT_NAME }}
+      WEB_API_BASE_URL: https://2026-api.up.railway.app
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -68,6 +69,9 @@ jobs:
       - name: Build web app
         run: npm run build
         working-directory: ${{ inputs.root_dir }}
+        env:
+          API_BASE_URL: ${{ env.WEB_API_BASE_URL }}
+          NEXT_PUBLIC_API_BASE_URL: ${{ env.WEB_API_BASE_URL }}
 
       - name: Deploy preview to Vercel
         id: deploy
@@ -81,6 +85,10 @@ jobs:
             --token "$VERCEL_TOKEN" \
             --scope "$VERCEL_SCOPE" \
             --name "$VERCEL_PROJECT_NAME" \
+            --build-env API_BASE_URL="$WEB_API_BASE_URL" \
+            --build-env NEXT_PUBLIC_API_BASE_URL="$WEB_API_BASE_URL" \
+            --env API_BASE_URL="$WEB_API_BASE_URL" \
+            --env NEXT_PUBLIC_API_BASE_URL="$WEB_API_BASE_URL" \
             2>&1 | tee "$DEPLOY_LOG"
 
           PREVIEW_URL=$(grep -Eo 'https://[^ ]+' "$DEPLOY_LOG" | grep 'vercel.app' | tail -n 1)
@@ -98,18 +106,11 @@ jobs:
           status_code=""
           for _ in $(seq 1 10); do
             status_code=$(curl -sS -o /tmp/vercel-preview-home.html -w "%{http_code}" "$PREVIEW_URL" || true)
-            if [ "$status_code" = "200" ] || [ "$status_code" = "301" ] || [ "$status_code" = "302" ] || [ "$status_code" = "307" ] || [ "$status_code" = "308" ] || [ "$status_code" = "401" ]; then
+            if [ "$status_code" = "200" ] || [ "$status_code" = "301" ] || [ "$status_code" = "302" ] || [ "$status_code" = "307" ] || [ "$status_code" = "308" ]; then
               break
             fi
             sleep 3
           done
-
-          if [ "$status_code" = "401" ]; then
-            echo "verified=true" >> "$GITHUB_OUTPUT"
-            echo "access_mode=auth_gated" >> "$GITHUB_OUTPUT"
-            echo "status_code=$status_code" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
 
           if [ "$status_code" = "200" ] || [ "$status_code" = "301" ] || [ "$status_code" = "302" ] || [ "$status_code" = "307" ] || [ "$status_code" = "308" ]; then
             echo "verified=true" >> "$GITHUB_OUTPUT"

--- a/app/main.py
+++ b/app/main.py
@@ -1,8 +1,32 @@
+import os
+
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
 from app.api.routes import router as api_router
 
+DEFAULT_CORS_ALLOW_ORIGINS = (
+    "https://2026-deploy.vercel.app,"
+    "http://127.0.0.1:3000,"
+    "http://localhost:3000,"
+    "http://127.0.0.1:3300,"
+    "http://localhost:3300"
+)
+
+
+def _resolve_cors_allow_origins() -> list[str]:
+    raw = os.getenv("CORS_ALLOW_ORIGINS", DEFAULT_CORS_ALLOW_ORIGINS)
+    return [origin.strip() for origin in raw.split(",") if origin.strip()]
+
+
 app = FastAPI(title="Election 2026 Backend MVP", version="0.1.0")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=_resolve_cors_allow_origins(),
+    allow_credentials=False,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 app.include_router(api_router)
 
 

--- a/apps/staging-web/app/page.js
+++ b/apps/staging-web/app/page.js
@@ -1,4 +1,4 @@
-const API_BASE = process.env.API_BASE_URL || process.env.NEXT_PUBLIC_API_BASE_URL || 'http://127.0.0.1:8100';
+const API_BASE = process.env.API_BASE_URL || process.env.NEXT_PUBLIC_API_BASE_URL || 'https://2026-api.up.railway.app';
 
 async function getSummary() {
   try {

--- a/develop_report/2026-02-19_issue123_decision_apply_report.md
+++ b/develop_report/2026-02-19_issue123_decision_apply_report.md
@@ -1,0 +1,61 @@
+# 2026-02-19 Issue #123 Decision Apply Report
+
+## 1. 목적
+- 오너 확정사항 즉시 반영:
+  1. `NEXT_PUBLIC_API_BASE_URL` 운영 고정값 `https://2026-api.up.railway.app`
+  2. Preview URL 접근정책 `public`
+  3. API CORS에 `https://2026-deploy.vercel.app` 허용
+  4. 내부 운영 API 토큰 정책 유지
+
+## 2. 반영 파일
+1. `app/main.py`
+2. `apps/staging-web/app/page.js`
+3. `.github/workflows/vercel-preview.yml`
+4. `docs/04_DEPLOYMENT_AND_ENVIRONMENT.md`
+5. `docs/05_RUNBOOK_AND_OPERATIONS.md`
+6. `tests/test_api_routes.py`
+7. `develop_report/2026-02-19_issue123_decision_apply_report.md`
+
+## 3. 구현 상세
+1. FastAPI CORS 설정 추가
+- `app/main.py`에 `CORSMiddleware` 적용
+- 기본 허용 오리진에 `https://2026-deploy.vercel.app` 포함
+- 환경변수 `CORS_ALLOW_ORIGINS`(comma-separated)로 오버라이드 가능
+
+2. 웹 API base 기본값 고정
+- `apps/staging-web/app/page.js` 기본 API base를 `https://2026-api.up.railway.app`로 변경
+
+3. Vercel Preview CI 정책 반영
+- `.github/workflows/vercel-preview.yml`에 `WEB_API_BASE_URL=https://2026-api.up.railway.app` 고정
+- build/deploy 시 `API_BASE_URL`, `NEXT_PUBLIC_API_BASE_URL`를 동일 값으로 주입
+- 접근검증에서 `401(auth_gated)` 허용 제거, `public(2xx/3xx)`만 성공 처리
+
+4. 문서 반영
+- `docs/04_DEPLOYMENT_AND_ENVIRONMENT.md`
+  - CORS 허용 오리진 고정값, preview `public` 정책, API base 고정값 반영
+- `docs/05_RUNBOOK_AND_OPERATIONS.md`
+  - RC 체크리스트 API_BASE 기본값을 Railway URL로 고정
+  - 내부 운영 API 토큰 정책 유지 명시
+
+5. 내부 운영 API 토큰 정책
+- `/api/v1/jobs/run-ingest`의 `Authorization: Bearer <INTERNAL_JOB_TOKEN>` 검증 로직 유지
+
+## 4. 검증
+1. Python 테스트
+```bash
+python3.13 -m venv .venv
+.venv/bin/pip install -r requirements.txt
+.venv/bin/pytest -q tests/test_api_routes.py -k "run_ingest_requires_bearer_token or cors"
+```
+- 결과: `3 passed, 5 deselected`
+
+2. Staging Web 빌드
+```bash
+npm --prefix apps/staging-web ci
+npm --prefix apps/staging-web run build
+```
+- 결과: build 성공
+
+## 5. 비고
+1. Production Vercel 환경변수는 프로젝트 설정값이 우선이며, 이번 반영은 CI deploy 주입 + 앱 기본값으로 동작 안정성을 확보했다.
+2. 오너가 Vercel 프로젝트(Preview/Production) UI에도 동일 값으로 고정한 상태를 유지하면 운영 일관성이 최대화된다.

--- a/docs/04_DEPLOYMENT_AND_ENVIRONMENT.md
+++ b/docs/04_DEPLOYMENT_AND_ENVIRONMENT.md
@@ -76,6 +76,8 @@ PYTHONPATH=. .venv/bin/python scripts/sync_common_codes.py \
 1. 프론트는 공개 API만 접근
 2. 내부 운영 API는 별도 토큰/권한으로 분리
 3. 관리자 승인 API는 서버-서버 통신만 허용
+4. API CORS 허용 오리진:
+- `https://2026-deploy.vercel.app` (운영 고정)
 
 ## 7. 배포 전략
 1. `main` 기준 자동 배포
@@ -169,7 +171,7 @@ scripts/qa/smoke_staging.sh --api-base "$API_BASE" --web-base "$WEB_BASE"
 5. 실행 결과:
 - Preview URL 추출 후 `issue_number`에 코멘트 자동 작성
 - 접근 검증(`curl`) 로그와 배포 로그를 artifact로 업로드
-- Vercel Preview Protection이 켜진 경우 `401`을 `auth_gated` 접근으로 기록한다.
+- Preview 접근정책은 `public` 고정이며 `401`이면 실패 처리한다.
 
 ## 13. 웹 확인용 RC 고정값 (Issue #123)
 1. 공개 확인 URL(Production):
@@ -180,14 +182,15 @@ scripts/qa/smoke_staging.sh --api-base "$API_BASE" --web-base "$WEB_BASE"
 - 타깃: `Vercel`
 - 프로젝트 루트: `apps/staging-web`
 - 배포 입력값은 GitHub Secrets(`VERCEL_TOKEN`, `VERCEL_SCOPE`, `VERCEL_PROJECT_NAME`)으로만 주입
+- Preview/Production 공통 API base 고정값: `https://2026-api.up.railway.app`
 4. 웹 API endpoint 환경변수 계약:
 - 코드 기준: `apps/staging-web/app/page.js`
-- 해석 우선순위: `API_BASE_URL` -> `NEXT_PUBLIC_API_BASE_URL` -> `http://127.0.0.1:8100`
+- 해석 우선순위: `API_BASE_URL` -> `NEXT_PUBLIC_API_BASE_URL` -> `https://2026-api.up.railway.app`
 - 개발(local) 권장:
   - `API_BASE_URL=http://127.0.0.1:8100`
   - `NEXT_PUBLIC_API_BASE_URL=http://127.0.0.1:8100`
 - 스테이징/공개 확인 권장:
-  - `NEXT_PUBLIC_API_BASE_URL=<공개 API Base URL>`
+  - `NEXT_PUBLIC_API_BASE_URL=https://2026-api.up.railway.app`
   - 필요 시 `API_BASE_URL`도 동일 값으로 주입
 5. fallback 동작:
-- 스테이징/공개 환경에서 API Base env가 비어 있으면 `127.0.0.1` fallback이 렌더링되어 연동 실패(`summary fetch failed`)가 표시될 수 있다.
+- 스테이징/공개 환경에서 API Base env가 비어 있어도 Railway 공개 URL을 fallback으로 사용한다.

--- a/docs/05_RUNBOOK_AND_OPERATIONS.md
+++ b/docs/05_RUNBOOK_AND_OPERATIONS.md
@@ -248,7 +248,7 @@ python -m app.jobs.bootstrap_ingest --input data/bootstrap_ingest_coverage_v2.js
 1. 준비 변수:
 ```bash
 WEB_URL="https://2026-deploy.vercel.app"
-API_BASE="<공개 API Base URL>"
+API_BASE="https://2026-api.up.railway.app"
 ```
 2. URL 접근(200) 확인:
 ```bash
@@ -266,4 +266,7 @@ curl -sS -o /tmp/web_rc_candidate.json -w "%{http_code}\n" "$API_BASE/api/v1/can
 ```
 5. fallback/오류 표시 확인:
 - `summary fetch failed`가 보이면 web이 정상적으로 오류 fallback을 렌더링한 상태다.
-- 스테이징/공개 환경에서는 `API_BASE`를 `127.0.0.1`이 아닌 실제 API URL로 지정해야 연동 성공 상태를 확인할 수 있다.
+- 스테이징/공개 환경 기본값은 `https://2026-api.up.railway.app`이며, 장애 시 fallback 오류 문구를 확인한다.
+6. 내부 운영 API 토큰 정책 유지:
+- `/api/v1/jobs/*`는 `Authorization: Bearer <INTERNAL_JOB_TOKEN>` 필수
+- `/api/v1/review/*` 계열 엔드포인트도 토큰 필수 정책 유지

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -650,6 +650,32 @@ def test_run_ingest_requires_bearer_token(monkeypatch: pytest.MonkeyPatch):
     get_settings.cache_clear()
 
 
+def test_cors_allows_public_web_origin():
+    client = TestClient(app)
+    res = client.options(
+        "/health",
+        headers={
+            "Origin": "https://2026-deploy.vercel.app",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+    assert res.status_code == 200
+    assert res.headers.get("access-control-allow-origin") == "https://2026-deploy.vercel.app"
+
+
+def test_cors_rejects_unknown_origin():
+    client = TestClient(app)
+    res = client.options(
+        "/health",
+        headers={
+            "Origin": "https://malicious.example.com",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+    assert res.status_code == 400
+    assert res.headers.get("access-control-allow-origin") is None
+
+
 def test_candidate_endpoint_merges_data_go_fields():
     app.dependency_overrides[get_repository] = override_repo
     app.dependency_overrides[get_candidate_data_go_service] = lambda: FakeCandidateDataGoService(


### PR DESCRIPTION
## Summary
- apply owner-decided fixed API base URL (`https://2026-api.up.railway.app`) to staging web default and Vercel preview CI build/deploy env
- switch preview access policy to `public` only by failing `401` in preview verification
- add FastAPI CORS middleware and include `https://2026-deploy.vercel.app` as allowed origin
- keep internal job API bearer-token requirement and add CORS regression tests
- sync deployment/runbook docs with the above and add develop report

## Verification
- `python3.13 -m venv .venv && .venv/bin/pip install -r requirements.txt`
- `.venv/bin/pytest -q tests/test_api_routes.py -k "run_ingest_requires_bearer_token or cors"` (`3 passed`)
- `npm --prefix apps/staging-web ci`
- `npm --prefix apps/staging-web run build` (success)

Report-Path: develop_report/2026-02-19_issue123_decision_apply_report.md
Refs: #123
