### PR TITLE
[DEVELOP] #129 Railway API 원격 스모크/증빙 추가

### DIFF
--- a/develop_report/2026-02-20_issue127_railway_api_go_live_report.md
+++ b/develop_report/2026-02-20_issue127_railway_api_go_live_report.md
@@ -1,0 +1,55 @@
+# 2026-02-20 Issue #129 Railway API Go-Live Report
+
+## 1. 목적
+- `https://2026-api.up.railway.app` 실배포 상태를 실측하고, #125 재게이트용 검증 근거를 제출한다.
+
+## 2. 반영 파일
+1. `scripts/qa/smoke_public_api.sh`
+2. `docs/05_RUNBOOK_AND_OPERATIONS.md`
+3. `develop_report/2026-02-20_issue127_railway_api_go_live_report.md`
+
+## 3. 검증 명령
+```bash
+scripts/qa/smoke_public_api.sh \
+  --api-base "https://2026-api.up.railway.app" \
+  --web-origin "https://2026-deploy.vercel.app" \
+  --out-dir /tmp/issue129_public_api
+```
+
+## 4. 실측 결과 (2026-02-20 UTC)
+1. 엔드포인트 상태코드
+- `GET /health` -> `404`
+- `GET /api/v1/dashboard/summary` -> `404`
+- `GET /api/v1/regions/search?query=서울` -> `404`
+- `GET /api/v1/candidates/cand-jwo` -> `404`
+- `OPTIONS /api/v1/dashboard/summary` (CORS preflight) -> `404`
+
+2. 샘플 응답 본문
+```json
+{"status":"error","code":404,"message":"Application not found"}
+```
+
+3. 판정
+- 현재 도메인은 FastAPI 앱 응답이 아니라 Railway 플랫폼 레벨 `Application not found` 상태로 확인됨.
+- 따라서 #129 수용 기준(실측 200 + CORS 확인)은 **미충족(Blocked)**.
+
+## 5. 개발 측 완료 항목
+1. 원격 공개 API 스모크 자동화 스크립트 추가 (`scripts/qa/smoke_public_api.sh`)
+2. 런북에 원격 스모크 절차 추가 (`docs/05_RUNBOOK_AND_OPERATIONS.md` 15절)
+3. 실패 원인 및 실측 로그를 보고서로 고정
+
+## 6. 오너 액션 필요 (외부 인프라)
+1. Railway에서 `2026-api.up.railway.app` 도메인에 FastAPI 서비스를 실제 연결/배포
+2. Railway 서비스 환경변수 주입:
+- `SUPABASE_URL`
+- `SUPABASE_SERVICE_ROLE_KEY`
+- `DATA_GO_KR_KEY`
+- `DATABASE_URL`
+- `INTERNAL_JOB_TOKEN`
+3. 배포 후 아래 재실행으로 수용 기준 검증:
+```bash
+scripts/qa/smoke_public_api.sh \
+  --api-base "https://2026-api.up.railway.app" \
+  --web-origin "https://2026-deploy.vercel.app" \
+  --out-dir /tmp/issue129_public_api
+```

--- a/docs/05_RUNBOOK_AND_OPERATIONS.md
+++ b/docs/05_RUNBOOK_AND_OPERATIONS.md
@@ -270,3 +270,23 @@ curl -sS -o /tmp/web_rc_candidate.json -w "%{http_code}\n" "$API_BASE/api/v1/can
 6. 내부 운영 API 토큰 정책 유지:
 - `/api/v1/jobs/*`는 `Authorization: Bearer <INTERNAL_JOB_TOKEN>` 필수
 - `/api/v1/review/*` 계열 엔드포인트도 토큰 필수 정책 유지
+
+## 15. 공개 API 원격 스모크 (Railway)
+1. 스크립트:
+- `scripts/qa/smoke_public_api.sh`
+2. 기본 타깃:
+- `API_BASE=https://2026-api.up.railway.app`
+- `WEB_ORIGIN=https://2026-deploy.vercel.app`
+3. 검증 항목:
+- `GET /health` (200)
+- `GET /api/v1/dashboard/summary` (200)
+- `GET /api/v1/regions/search?query=서울` (200)
+- `GET /api/v1/candidates/cand-jwo` (200 또는 계약된 404)
+- CORS preflight(`OPTIONS /api/v1/dashboard/summary`) 응답 및 `access-control-allow-origin` 일치
+4. 실행 예시:
+```bash
+scripts/qa/smoke_public_api.sh \
+  --api-base "https://2026-api.up.railway.app" \
+  --web-origin "https://2026-deploy.vercel.app" \
+  --out-dir /tmp/public_api_smoke
+```

--- a/scripts/qa/smoke_public_api.sh
+++ b/scripts/qa/smoke_public_api.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+API_BASE="${API_BASE:-https://2026-api.up.railway.app}"
+WEB_ORIGIN="${WEB_ORIGIN:-https://2026-deploy.vercel.app}"
+OUT_DIR="${OUT_DIR:-/tmp/public_api_smoke}"
+
+usage() {
+  cat <<USAGE
+Usage: $0 [--api-base URL] [--web-origin URL] [--out-dir PATH]
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --api-base)
+      API_BASE="${2:-}"
+      shift 2
+      ;;
+    --web-origin)
+      WEB_ORIGIN="${2:-}"
+      shift 2
+      ;;
+    --out-dir)
+      OUT_DIR="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1"
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+mkdir -p "$OUT_DIR"
+
+request() {
+  local label="$1"
+  local path="$2"
+  local body="$OUT_DIR/${label}.json"
+  local status
+  status="$(curl -sS -o "$body" -w "%{http_code}" "${API_BASE}${path}" || true)"
+  echo "${label} ${status}"
+}
+
+echo "[INFO] API_BASE=${API_BASE}"
+echo "[INFO] WEB_ORIGIN=${WEB_ORIGIN}"
+
+health_status="$(request "health" "/health" | awk '{print $2}')"
+summary_status="$(request "summary" "/api/v1/dashboard/summary" | awk '{print $2}')"
+regions_status="$(request "regions" "/api/v1/regions/search?query=%EC%84%9C%EC%9A%B8" | awk '{print $2}')"
+candidate_status="$(request "candidate" "/api/v1/candidates/cand-jwo" | awk '{print $2}')"
+
+curl -sS -D "$OUT_DIR/cors_headers.txt" -o "$OUT_DIR/cors_body.txt" \
+  -X OPTIONS "${API_BASE}/api/v1/dashboard/summary" \
+  -H "Origin: ${WEB_ORIGIN}" \
+  -H "Access-Control-Request-Method: GET" \
+  -H "Access-Control-Request-Headers: content-type" || true
+
+cors_status="$(awk 'NR==1 {print $2}' "$OUT_DIR/cors_headers.txt")"
+cors_allow_origin="$(awk -F': ' 'tolower($1)=="access-control-allow-origin" {print $2}' "$OUT_DIR/cors_headers.txt" | tr -d '\r')"
+
+echo "[RESULT] health=${health_status} summary=${summary_status} regions=${regions_status} candidate=${candidate_status} cors=${cors_status}"
+echo "[RESULT] cors_allow_origin=${cors_allow_origin:-<empty>}"
+
+failed=0
+[[ "$health_status" == "200" ]] || failed=1
+[[ "$summary_status" == "200" ]] || failed=1
+[[ "$regions_status" == "200" ]] || failed=1
+[[ "$candidate_status" == "200" || "$candidate_status" == "404" ]] || failed=1
+[[ "$cors_status" == "200" || "$cors_status" == "204" ]] || failed=1
+[[ "${cors_allow_origin:-}" == "$WEB_ORIGIN" ]] || failed=1
+
+if [[ "$failed" -eq 1 ]]; then
+  echo "[FAIL] public API smoke check failed"
+  exit 1
+fi
+
+echo "[PASS] public API smoke check passed"


### PR DESCRIPTION
## Summary
- add remote public API smoke script for Railway target (`scripts/qa/smoke_public_api.sh`)
- add runbook section for reproducible remote smoke check procedure
- add go-live measurement report with live HTTP evidence for `https://2026-api.up.railway.app`

## Verification
- `bash -n scripts/qa/smoke_public_api.sh`
- `scripts/qa/smoke_public_api.sh --api-base "https://2026-api.up.railway.app" --web-origin "https://2026-deploy.vercel.app" --out-dir /tmp/issue129_public_api` (expected fail in current state; measured in report)

Report-Path: develop_report/2026-02-20_issue127_railway_api_go_live_report.md
Refs: #129
