### PR TITLE
[DEVELOP] regions/search q+query 호환 패치

### DIFF
--- a/develop_report/2026-02-20_regions_search_query_alias_report.md
+++ b/develop_report/2026-02-20_regions_search_query_alias_report.md
@@ -1,0 +1,44 @@
+# 2026-02-20 Regions Search Query Alias Report
+
+## 1. 목적
+- `GET /api/v1/regions/search`가 `q`와 `query` 파라미터를 모두 허용하도록 API 호환성을 보강한다.
+
+## 2. 반영 파일
+1. `app/api/routes.py`
+2. `tests/test_api_routes.py`
+3. `scripts/qa/smoke_public_api.sh`
+4. `docs/05_RUNBOOK_AND_OPERATIONS.md`
+5. `develop_report/2026-02-20_regions_search_query_alias_report.md`
+
+## 3. 구현 상세
+1. `regions/search`에서 `q`를 우선 사용
+2. `q`가 없으면 query string의 `query` 값을 fallback으로 사용
+3. 둘 다 없으면 `422` 반환
+4. 원격 스모크 스크립트의 지역검색 호출을 `q` 기준으로 정렬
+
+## 4. 검증
+1. 단위 테스트
+```bash
+python3.13 -m venv .venv
+.venv/bin/pip install -r requirements.txt
+.venv/bin/pytest -q tests/test_api_routes.py -k "api_contract_fields"
+```
+- 결과: `1 passed`
+
+2. 공개 API 원격 스모크
+```bash
+scripts/qa/smoke_public_api.sh \
+  --api-base https://2026-production.up.railway.app \
+  --web-origin https://2026-deploy.vercel.app \
+  --out-dir /tmp/regions_alias_public_smoke
+```
+- 결과:
+  - `health=200`
+  - `summary=200`
+  - `regions=200`
+  - `candidate=200`
+  - `cors=200`
+  - `cors_allow_origin=https://2026-deploy.vercel.app`
+
+## 5. 결론
+- `regions/search`는 `q`/`query` 양쪽 호출을 처리 가능해졌고, 현재 공개 웹/공개 API 스모크 경로와 일치한다.

--- a/docs/05_RUNBOOK_AND_OPERATIONS.md
+++ b/docs/05_RUNBOOK_AND_OPERATIONS.md
@@ -261,7 +261,7 @@ rg -n "Election 2026 Staging|API Base|summary fetch failed" /tmp/web_rc_home.htm
 4. API 3개 연동 확인(200 기대):
 ```bash
 curl -sS -o /tmp/web_rc_summary.json -w "%{http_code}\n" "$API_BASE/api/v1/dashboard/summary"
-curl -sS -o /tmp/web_rc_regions.json -w "%{http_code}\n" "$API_BASE/api/v1/regions/search?query=%EC%84%9C%EC%9A%B8"
+curl -sS -o /tmp/web_rc_regions.json -w "%{http_code}\n" "$API_BASE/api/v1/regions/search?q=%EC%84%9C%EC%9A%B8"
 curl -sS -o /tmp/web_rc_candidate.json -w "%{http_code}\n" "$API_BASE/api/v1/candidates/cand-jwo"
 ```
 5. fallback/오류 표시 확인:
@@ -280,7 +280,7 @@ curl -sS -o /tmp/web_rc_candidate.json -w "%{http_code}\n" "$API_BASE/api/v1/can
 3. 검증 항목:
 - `GET /health` (200)
 - `GET /api/v1/dashboard/summary` (200)
-- `GET /api/v1/regions/search?query=서울` (200)
+- `GET /api/v1/regions/search?q=서울` (200, `query` alias도 허용)
 - `GET /api/v1/candidates/cand-jwo` (200 또는 계약된 404)
 - CORS preflight(`OPTIONS /api/v1/dashboard/summary`) 응답 및 `access-control-allow-origin` 일치
 4. 실행 예시:

--- a/scripts/qa/smoke_public_api.sh
+++ b/scripts/qa/smoke_public_api.sh
@@ -53,7 +53,7 @@ echo "[INFO] WEB_ORIGIN=${WEB_ORIGIN}"
 
 health_status="$(request "health" "/health" | awk '{print $2}')"
 summary_status="$(request "summary" "/api/v1/dashboard/summary" | awk '{print $2}')"
-regions_status="$(request "regions" "/api/v1/regions/search?query=%EC%84%9C%EC%9A%B8" | awk '{print $2}')"
+regions_status="$(request "regions" "/api/v1/regions/search?q=%EC%84%9C%EC%9A%B8" | awk '{print $2}')"
 candidate_status="$(request "candidate" "/api/v1/candidates/cand-jwo" | awk '{print $2}')"
 
 curl -sS -D "$OUT_DIR/cors_headers.txt" -o "$OUT_DIR/cors_body.txt" \

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -403,6 +403,11 @@ def test_api_contract_fields():
     regions = client.get("/api/v1/regions/search", params={"q": "서울"})
     assert regions.status_code == 200
     assert regions.json()[0]["region_code"] == "11-000"
+    regions_query_alias = client.get("/api/v1/regions/search", params={"query": "서울"})
+    assert regions_query_alias.status_code == 200
+    assert regions_query_alias.json()[0]["region_code"] == "11-000"
+    regions_missing = client.get("/api/v1/regions/search")
+    assert regions_missing.status_code == 422
 
     map_latest = client.get("/api/v1/dashboard/map-latest")
     assert map_latest.status_code == 200


### PR DESCRIPTION
## Summary
- update `GET /api/v1/regions/search` to accept both `q` and legacy `query` query params
- keep `q` as primary parameter and fallback to `query` when `q` is missing
- add API contract test coverage for `query` alias and missing-param 422 behavior
- align runbook and public smoke script to canonical `q` usage
- add develop report with verification evidence

## Verification
- `.venv/bin/pytest -q tests/test_api_routes.py -k "api_contract_fields"`
- `scripts/qa/smoke_public_api.sh --api-base https://2026-production.up.railway.app --web-origin https://2026-deploy.vercel.app --out-dir /tmp/regions_alias_public_smoke`

Report-Path: develop_report/2026-02-20_regions_search_query_alias_report.md
