### PR TITLE
fix: align API base defaults to live Railway domain

### DIFF
--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -29,7 +29,7 @@ jobs:
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
       VERCEL_SCOPE: ${{ secrets.VERCEL_SCOPE }}
       VERCEL_PROJECT_NAME: ${{ secrets.VERCEL_PROJECT_NAME }}
-      WEB_API_BASE_URL: https://2026-api.up.railway.app
+      WEB_API_BASE_URL: https://2026-api-production.up.railway.app
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/apps/staging-web/app/page.js
+++ b/apps/staging-web/app/page.js
@@ -1,4 +1,7 @@
-const API_BASE = process.env.API_BASE_URL || process.env.NEXT_PUBLIC_API_BASE_URL || 'https://2026-api.up.railway.app';
+const API_BASE =
+  process.env.API_BASE_URL ||
+  process.env.NEXT_PUBLIC_API_BASE_URL ||
+  'https://2026-api-production.up.railway.app';
 
 async function getSummary() {
   try {

--- a/apps/web/app/_lib/api.js
+++ b/apps/web/app/_lib/api.js
@@ -1,5 +1,5 @@
 export const API_BASE =
-  process.env.API_BASE_URL || process.env.NEXT_PUBLIC_API_BASE_URL || "https://2026-api.up.railway.app";
+  process.env.API_BASE_URL || process.env.NEXT_PUBLIC_API_BASE_URL || "https://2026-api-production.up.railway.app";
 
 export async function fetchApi(path) {
   const url = `${API_BASE}${path}`;

--- a/develop_report/2026-02-20_issue129_domain_baseline_update_report.md
+++ b/develop_report/2026-02-20_issue129_domain_baseline_update_report.md
@@ -1,0 +1,75 @@
+# 2026-02-20 Issue #129 Domain Baseline Update Report
+
+## 1. 목적
+- Railway 실운영 API 기준 도메인을 실제 응답 가능한 값으로 고정하고, web/CI/runbook 기본값을 동기화한다.
+
+## 2. 배경
+1. 기존 이슈 기준값: `https://2026-api.up.railway.app`
+2. 실측 결과: 위 도메인은 `404 Application not found`
+3. 실제 배포 서비스 도메인: `https://2026-api-production.up.railway.app`
+4. Railway 정책상 `*.up.railway.app`은 Custom Domain으로 직접 지정 불가하여, 생성 도메인을 운영 기준으로 사용
+
+## 3. 반영 파일
+1. `.github/workflows/vercel-preview.yml`
+2. `apps/web/app/_lib/api.js`
+3. `apps/staging-web/app/page.js`
+4. `scripts/qa/smoke_public_api.sh`
+5. `docs/04_DEPLOYMENT_AND_ENVIRONMENT.md`
+6. `docs/05_RUNBOOK_AND_OPERATIONS.md`
+7. `develop_report/2026-02-20_issue129_domain_baseline_update_report.md`
+
+## 4. 변경 내용
+1. 공개/프리뷰 API 기본값을 `https://2026-api-production.up.railway.app`로 통일
+2. 웹 fallback 해석 우선순위는 기존 유지
+- `API_BASE_URL` -> `NEXT_PUBLIC_API_BASE_URL` -> 고정 기본값
+3. 공개 API 스모크 스크립트 기본 타깃 도메인 교체
+4. 배포/운영 런북 예시 명령의 API base 교체
+
+## 5. 실측 결과 (UTC)
+### 5.1 API 스모크
+```bash
+scripts/qa/smoke_public_api.sh \
+  --api-base "https://2026-api-production.up.railway.app" \
+  --web-origin "https://2026-deploy.vercel.app" \
+  --out-dir /tmp/public_api_smoke_issue129
+```
+
+결과:
+- `health=200`
+- `summary=200`
+- `regions=200`
+- `candidate=200`
+- `cors=200`
+- `cors_allow_origin=https://2026-deploy.vercel.app`
+- 판정: `PASS`
+
+샘플 body:
+- `/health` -> `{"status":"ok"}`
+- `/api/v1/dashboard/summary` -> `{"as_of":null,"party_support":[],...}`
+- `/api/v1/regions/search?q=서울` -> `[ {"region_code":"11-000",...} ]`
+- `/api/v1/candidates/cand-jwo` -> `{"candidate_id":"cand-jwo",...}`
+
+### 5.2 웹 라우트 RC
+```bash
+curl -sS -o /tmp/issue129_web_home.html -w "web_home %{http_code}\n" "https://2026-deploy.vercel.app/"
+curl -sS -o /tmp/issue129_web_matchup.html -w "web_matchup %{http_code}\n" "https://2026-deploy.vercel.app/matchups/m_2026_seoul_mayor"
+curl -sS -o /tmp/issue129_web_candidate.html -w "web_candidate %{http_code}\n" "https://2026-deploy.vercel.app/candidates/cand-jwo"
+```
+
+결과:
+- `web_home 200`
+- `web_matchup 200`
+- `web_candidate 200`
+
+### 5.3 기존 고정값 도메인 상태
+```bash
+curl -sS -o /tmp/issue129_old_domain_health.txt -w "old_health %{http_code}\n" "https://2026-api.up.railway.app/health"
+```
+
+결과:
+- `old_health 404`
+- body: `{"status":"error","code":404,"message":"Application not found",...}`
+
+## 6. 결론
+- 실서비스 기준에서 #129의 배포/CORS/헬스체크 요구사항은 충족되었다.
+- 다만 도메인은 이슈 본문의 `2026-api.up.railway.app` 대신, 실제 동작 도메인 `2026-api-production.up.railway.app`을 운영 기준으로 확정해야 한다.

--- a/docs/04_DEPLOYMENT_AND_ENVIRONMENT.md
+++ b/docs/04_DEPLOYMENT_AND_ENVIRONMENT.md
@@ -182,19 +182,19 @@ scripts/qa/smoke_staging.sh --api-base "$API_BASE" --web-base "$WEB_BASE"
 - 타깃: `Vercel`
 - 프로젝트 루트: `apps/web` (공개 라우트 RC), 필요 시 `apps/staging-web` fallback
 - 배포 입력값은 GitHub Secrets(`VERCEL_TOKEN`, `VERCEL_SCOPE`, `VERCEL_PROJECT_NAME`)으로만 주입
-- Preview/Production 공통 API base 고정값: `https://2026-api.up.railway.app`
+- Preview/Production 공통 API base 고정값: `https://2026-api-production.up.railway.app`
 4. 공개 라우트 RC 확인 대상:
 - `/`
 - `/matchups/m_2026_seoul_mayor`
 - `/candidates/cand-jwo`
 5. 웹 API endpoint 환경변수 계약:
 - 코드 기준: `apps/web/app/_lib/api.js` (staging 대체 경로: `apps/staging-web/app/page.js`)
-- 해석 우선순위: `API_BASE_URL` -> `NEXT_PUBLIC_API_BASE_URL` -> `https://2026-api.up.railway.app`
+- 해석 우선순위: `API_BASE_URL` -> `NEXT_PUBLIC_API_BASE_URL` -> `https://2026-api-production.up.railway.app`
 - 개발(local) 권장:
   - `API_BASE_URL=http://127.0.0.1:8100`
   - `NEXT_PUBLIC_API_BASE_URL=http://127.0.0.1:8100`
 - 스테이징/공개 확인 권장:
-  - `NEXT_PUBLIC_API_BASE_URL=https://2026-api.up.railway.app`
+  - `NEXT_PUBLIC_API_BASE_URL=https://2026-api-production.up.railway.app`
   - 필요 시 `API_BASE_URL`도 동일 값으로 주입
 6. fallback 동작:
 - 스테이징/공개 환경에서 API Base env가 비어 있어도 Railway 공개 URL을 fallback으로 사용한다.

--- a/docs/05_RUNBOOK_AND_OPERATIONS.md
+++ b/docs/05_RUNBOOK_AND_OPERATIONS.md
@@ -248,7 +248,7 @@ python -m app.jobs.bootstrap_ingest --input data/bootstrap_ingest_coverage_v2.js
 1. 준비 변수:
 ```bash
 WEB_URL="https://2026-deploy.vercel.app"
-API_BASE="https://2026-api.up.railway.app"
+API_BASE="https://2026-api-production.up.railway.app"
 ```
 2. URL 접근(200) 확인:
 ```bash
@@ -266,7 +266,7 @@ curl -sS -o /tmp/web_rc_candidate.json -w "%{http_code}\n" "$API_BASE/api/v1/can
 ```
 5. fallback/오류 표시 확인:
 - `summary fetch failed`가 보이면 web이 정상적으로 오류 fallback을 렌더링한 상태다.
-- 스테이징/공개 환경 기본값은 `https://2026-api.up.railway.app`이며, 장애 시 fallback 오류 문구를 확인한다.
+- 스테이징/공개 환경 기본값은 `https://2026-api-production.up.railway.app`이며, 장애 시 fallback 오류 문구를 확인한다.
 6. 내부 운영 API 토큰 정책 유지:
 - `/api/v1/jobs/*`는 `Authorization: Bearer <INTERNAL_JOB_TOKEN>` 필수
 - `/api/v1/review/*` 계열 엔드포인트도 토큰 필수 정책 유지
@@ -275,7 +275,7 @@ curl -sS -o /tmp/web_rc_candidate.json -w "%{http_code}\n" "$API_BASE/api/v1/can
 1. 스크립트:
 - `scripts/qa/smoke_public_api.sh`
 2. 기본 타깃:
-- `API_BASE=https://2026-api.up.railway.app`
+- `API_BASE=https://2026-api-production.up.railway.app`
 - `WEB_ORIGIN=https://2026-deploy.vercel.app`
 3. 검증 항목:
 - `GET /health` (200)
@@ -286,7 +286,7 @@ curl -sS -o /tmp/web_rc_candidate.json -w "%{http_code}\n" "$API_BASE/api/v1/can
 4. 실행 예시:
 ```bash
 scripts/qa/smoke_public_api.sh \
-  --api-base "https://2026-api.up.railway.app" \
+  --api-base "https://2026-api-production.up.railway.app" \
   --web-origin "https://2026-deploy.vercel.app" \
   --out-dir /tmp/public_api_smoke
 ```

--- a/scripts/qa/smoke_public_api.sh
+++ b/scripts/qa/smoke_public_api.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-API_BASE="${API_BASE:-https://2026-api.up.railway.app}"
+API_BASE="${API_BASE:-https://2026-api-production.up.railway.app}"
 WEB_ORIGIN="${WEB_ORIGIN:-https://2026-deploy.vercel.app}"
 OUT_DIR="${OUT_DIR:-/tmp/public_api_smoke}"
 


### PR DESCRIPTION
## Summary
- web/preview/smoke/runbook 기본 API 도메인을 실배포 응답 도메인으로 통일
- `https://2026-api-production.up.railway.app` 기준으로 fallback/CI 기본값 반영
- #129 closeout 증빙 보고서 추가

## Linked Issue
- Closes #129

## Report-Path
Report-Path: develop_report/2026-02-20_issue129_domain_baseline_update_report.md

## Checklist
- [x] docs 계약(필드/API/용어)과 일치
- [x] 테스트 또는 검증 로그 첨부
- [x] 보안 정보(key/secret) 미포함 확인
- [x] Report-Path 파일이 이번 PR에 포함됨
