### PR TITLE
docs: lock API domain strategy and custom-domain cutover runbook

### DIFF
--- a/develop_report/2026-02-20_issue137_api_domain_strategy_report.md
+++ b/develop_report/2026-02-20_issue137_api_domain_strategy_report.md
@@ -1,0 +1,34 @@
+# 2026-02-20 Issue #137 API Domain Strategy Report
+
+## 1. 결정사항
+1. 단기(즉시): 운영 API 기준값은 `https://2026-api-production.up.railway.app` 유지
+2. 중기(베타/운영 직전): 커스텀 도메인 `https://api.<your-domain>`로 1회 컷오버
+
+## 2. 결정 근거
+1. 현재 기준 도메인은 실측 smoke/CORS/웹 라우트 연동이 검증되어 안정 운영 상태
+2. 커스텀 도메인 전환은 벤더 종속 완화, 주소 안정성, 대외 신뢰성 측면에서 필요
+3. 지금 즉시 전환보다, 운영 안정 유지 후 계획된 1회 컷오버가 리스크 최소화
+
+## 3. 반영 파일
+1. `docs/04_DEPLOYMENT_AND_ENVIRONMENT.md`
+2. `docs/05_RUNBOOK_AND_OPERATIONS.md`
+3. `develop_report/2026-02-20_issue137_api_domain_strategy_report.md`
+
+## 4. 문서 반영 내용
+1. 배포 문서에 API 도메인 전략 섹션 추가
+- 현재 기준 도메인 유지 원칙
+- 커스텀 도메인 전환 시점/완료 기준
+- 실패 시 롤백 기준
+2. 운영 런북에 커스텀 도메인 컷오버 절차 추가
+- DNS -> Railway Domain/TLS -> Vercel env 변경 -> 재배포 -> smoke 검증
+
+## 5. 후속 이슈
+1. 생성: `#137 [DEVELOP] API 커스텀 도메인 전환(api.<domain>) 실행`
+2. 라벨: `role/develop`, `type/task`, `priority/p1`, `status/backlog`
+3. 담당: `iAmSomething`
+
+## 6. 의사결정 요청(Owner)
+1. 실제 사용할 운영 도메인 확정
+- 예: `api.2026election.kr` 또는 `api.<보유도메인>`
+2. 컷오버 실행 윈도우 확정
+- 권장: 트래픽 낮은 시간대 30분 윈도우

--- a/docs/04_DEPLOYMENT_AND_ENVIRONMENT.md
+++ b/docs/04_DEPLOYMENT_AND_ENVIRONMENT.md
@@ -198,3 +198,17 @@ scripts/qa/smoke_staging.sh --api-base "$API_BASE" --web-base "$WEB_BASE"
   - 필요 시 `API_BASE_URL`도 동일 값으로 주입
 6. fallback 동작:
 - 스테이징/공개 환경에서 API Base env가 비어 있어도 Railway 공개 URL을 fallback으로 사용한다.
+
+## 14. API 도메인 전략 (Issue #137)
+1. 현재 운영 기준:
+- `https://2026-api-production.up.railway.app`
+- 이유: 실배포 응답(health/API/CORS) 검증 완료 상태로 즉시 안정 운영 가능
+2. 전환 전략:
+- 베타/운영 직전에 1회 커스텀 도메인(`api.<your-domain>`)으로 컷오버
+- 컷오버 전까지는 기존 Railway 생성 도메인을 기준값으로 유지
+3. 컷오버 완료 기준:
+- Railway Custom Domain + TLS 활성화
+- Vercel env(`API_BASE_URL`, `NEXT_PUBLIC_API_BASE_URL`) 신규 도메인 반영
+- 공개 API smoke 200 및 공개 웹 3개 URL 200 재검증
+4. 롤백 기준:
+- 컷오버 후 API/CORS 실패 시 즉시 env를 `https://2026-api-production.up.railway.app`로 복귀


### PR DESCRIPTION
## Summary
- 운영 API 도메인 전략(단기 유지/중기 커스텀 도메인 컷오버) 문서화
- 커스텀 도메인 전환 런북(검증/롤백 포함) 추가
- develop 보고서 추가

## Linked Issue
- Closes #137

## Report-Path
Report-Path: develop_report/2026-02-20_issue137_api_domain_strategy_report.md

## Checklist
- [x] docs 계약(필드/API/용어)과 일치
- [x] 테스트 또는 검증 로그 첨부
- [x] 보안 정보(key/secret) 미포함 확인
- [x] Report-Path 파일이 이번 PR에 포함됨
