### PR TITLE
fix: align public matchup alias with canonical API id

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -34,6 +34,10 @@ from app.services.ingest_service import ingest_payload
 
 router = APIRouter(prefix="/api/v1", tags=["v1"])
 
+MATCHUP_ID_ALIASES = {
+    "m_2026_seoul_mayor": "20260603|광역자치단체장|11-000",
+}
+
 
 def _build_scope_breakdown(rows: list[dict]) -> dict[str, int]:
     counts = {"national": 0, "regional": 0, "local": 0, "unknown": 0}
@@ -219,7 +223,8 @@ def get_region_elections(region_code: str, repo=Depends(get_repository)):
 
 @router.get("/matchups/{matchup_id}", response_model=MatchupOut)
 def get_matchup(matchup_id: str, repo=Depends(get_repository)):
-    matchup = repo.get_matchup(matchup_id)
+    resolved_matchup_id = MATCHUP_ID_ALIASES.get(matchup_id, matchup_id)
+    matchup = repo.get_matchup(resolved_matchup_id)
     if not matchup:
         raise HTTPException(status_code=404, detail="matchup not found")
     source_meta = _derive_source_meta(matchup)

--- a/develop_report/2026-02-20_issue139_matchup_id_alignment_report.md
+++ b/develop_report/2026-02-20_issue139_matchup_id_alignment_report.md
@@ -1,0 +1,55 @@
+# 2026-02-20 Issue #139 Matchup ID Alignment Report
+
+## 1. 목적
+- 공개 웹 라우트 `/matchups/m_2026_seoul_mayor`와 백엔드 `matchup_id`를 정합화하여 페이지 내부 `api_status`를 200으로 만든다.
+
+## 2. 원인 진단
+1. 공개 웹 라우트는 `m_2026_seoul_mayor`를 사용
+2. 실제 API 데이터 식별자는 `20260603|광역자치단체장|11-000`
+3. 실측 기준 기존 alias 호출은 404
+```bash
+curl -sS -o /tmp/issue140_matchup_alias.json -w "%{http_code}\n" \
+  "https://2026-api-production.up.railway.app/api/v1/matchups/m_2026_seoul_mayor"
+# 404
+```
+
+## 3. 구현
+1. 서버 alias 매핑(B안) 적용
+- `app/api/routes.py`
+- `MATCHUP_ID_ALIASES["m_2026_seoul_mayor"] = "20260603|광역자치단체장|11-000"`
+- `/api/v1/matchups/{matchup_id}` 진입 시 alias를 canonical id로 resolve 후 조회
+
+2. 테스트 보강
+- `tests/test_api_routes.py`
+- `/api/v1/matchups/m_2026_seoul_mayor` 호출 시 200 + canonical `matchup_id` 반환 검증 추가
+
+3. 운영 문서 반영
+- `docs/05_RUNBOOK_AND_OPERATIONS.md`
+- 공개 웹 매치업 RC 라우트가 alias -> canonical로 조회된다는 운영 노트 추가
+
+## 4. 로컬 검증
+```bash
+/Users/gimtaehun/election2026_codex/.venv/bin/python -m pytest -q tests/test_api_routes.py
+```
+결과:
+- `8 passed`
+
+## 5. 공개 환경 재검증 절차(머지 후)
+1. API alias 응답 확인
+```bash
+curl -sS -o /tmp/issue140_post_alias.json -w "api_alias %{http_code}\n" \
+  "https://2026-api-production.up.railway.app/api/v1/matchups/m_2026_seoul_mayor"
+```
+2. 웹 라우트 확인
+```bash
+curl -sS -o /tmp/issue140_post_matchup.html -w "web_matchup %{http_code}\n" \
+  "https://2026-deploy.vercel.app/matchups/m_2026_seoul_mayor"
+rg -n "api_status" /tmp/issue140_post_matchup.html
+```
+3. 수용 기준 판정
+- `api_alias 200`
+- `web_matchup 200`
+- 웹 HTML에 `api_status: 200` 표기
+
+## 6. 결론
+- alias 매핑을 서버에 추가해 공개 URL과 실제 데이터 식별자 간 불일치를 제거했다.

--- a/docs/05_RUNBOOK_AND_OPERATIONS.md
+++ b/docs/05_RUNBOOK_AND_OPERATIONS.md
@@ -308,6 +308,8 @@ done
 3. 판정:
 - 3개 URL이 모두 `200`이면 PASS
 - `404`가 하나라도 나오면 Vercel 프로젝트 루트(`apps/web`) 및 최신 배포 상태를 우선 점검
+4. 매치업 ID 정합화 참고:
+- 공개 웹 라우트 `/matchups/m_2026_seoul_mayor`는 API alias 매핑으로 canonical `matchup_id`(`20260603|광역자치단체장|11-000`)를 조회한다.
 
 ## 17. API 커스텀 도메인 컷오버 런북 (Issue #137)
 1. 사전 고정:

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -456,6 +456,9 @@ def test_api_contract_fields():
     assert matchup.json()["options"][0]["party_inference_confidence"] == 0.86
     assert matchup.json()["options"][0]["needs_manual_review"] is False
     assert matchup.json()["options"][1]["needs_manual_review"] is True
+    matchup_alias = client.get("/api/v1/matchups/m_2026_seoul_mayor")
+    assert matchup_alias.status_code == 200
+    assert matchup_alias.json()["matchup_id"] == "20260603|광역자치단체장|11-000"
 
     candidate = client.get("/api/v1/candidates/cand-jwo")
     assert candidate.status_code == 200


### PR DESCRIPTION
## Summary
- `/api/v1/matchups/{matchup_id}`에 `m_2026_seoul_mayor` alias 매핑 추가
- 공개 웹 라우트가 canonical matchup 데이터로 조회되도록 정합화
- API 계약 테스트와 운영 런북/보고서 반영

## Linked Issue
- Closes #140

## Report-Path
Report-Path: develop_report/2026-02-20_issue139_matchup_id_alignment_report.md

## Checklist
- [x] docs 계약(필드/API/용어)과 일치
- [x] 테스트 또는 검증 로그 첨부
- [x] 보안 정보(key/secret) 미포함 확인
- [x] Report-Path 파일이 이번 PR에 포함됨
