### PR TITLE
feat(web): promote public UI from RC shell to dashboard

### DIFF
--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -4,13 +4,12 @@ on:
   workflow_dispatch:
     inputs:
       root_dir:
-        description: "Web root directory"
+        description: "Public web root directory"
         required: true
         default: "apps/web"
         type: choice
         options:
           - apps/web
-          - apps/staging-web
       issue_number:
         description: "Issue number to post preview URL"
         required: true

--- a/apps/web/app/_components/format.js
+++ b/apps/web/app/_components/format.js
@@ -1,0 +1,41 @@
+const DATE_FORMATTER = new Intl.DateTimeFormat("ko-KR", {
+  year: "numeric",
+  month: "short",
+  day: "numeric"
+});
+
+const DATETIME_FORMATTER = new Intl.DateTimeFormat("ko-KR", {
+  year: "numeric",
+  month: "short",
+  day: "numeric",
+  hour: "2-digit",
+  minute: "2-digit"
+});
+
+export function formatPercent(value) {
+  if (value === null || value === undefined || Number.isNaN(Number(value))) return "-";
+  return `${Number(value).toFixed(1)}%`;
+}
+
+export function formatDate(value) {
+  if (!value) return "-";
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return "-";
+  return DATE_FORMATTER.format(parsed);
+}
+
+export function formatDateTime(value) {
+  if (!value) return "-";
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return "-";
+  return DATETIME_FORMATTER.format(parsed);
+}
+
+export function joinChannels(channels) {
+  if (!Array.isArray(channels) || channels.length === 0) return "-";
+  return channels.join(" · ");
+}
+
+export function cn(...tokens) {
+  return tokens.filter(Boolean).join(" ");
+}

--- a/apps/web/app/candidates/[candidate_id]/page.js
+++ b/apps/web/app/candidates/[candidate_id]/page.js
@@ -1,21 +1,102 @@
 import Link from "next/link";
 
+import { formatDate, formatDateTime, joinChannels } from "../../_components/format";
 import { fetchApi } from "../../_lib/api";
+
+const RELATED_MATCHUP_ALIAS_BY_CANDIDATE = {
+  "cand-jwo": "m_2026_seoul_mayor"
+};
 
 export default async function CandidatePage({ params }) {
   const resolvedParams = await params;
   const candidateId = resolvedParams.candidate_id;
   const payload = await fetchApi(`/api/v1/candidates/${encodeURIComponent(candidateId)}`);
 
+  if (!payload.ok) {
+    return (
+      <main className="detail-root">
+        <section className="panel error-panel">
+          <h1>후보 정보를 불러오지 못했습니다.</h1>
+          <p>요청 ID: {candidateId}</p>
+          <p>status: {payload.status}</p>
+          <p className="muted-text">{JSON.stringify(payload.body)}</p>
+          <Link href="/" className="text-link">
+            대시보드로 이동
+          </Link>
+        </section>
+      </main>
+    );
+  }
+
+  const candidate = payload.body;
+  const relatedAlias = RELATED_MATCHUP_ALIAS_BY_CANDIDATE[candidateId];
+  const relatedMatchup = relatedAlias
+    ? await fetchApi(`/api/v1/matchups/${encodeURIComponent(relatedAlias)}`)
+    : { ok: false, body: null };
+
   return (
-    <main>
-      <h1 style={{ marginTop: 0 }}>Candidate Route RC</h1>
-      <p>candidate_id: {candidateId}</p>
-      <p>
-        <Link href="/">Back to /</Link>
-      </p>
-      <p>api_status: {payload.status}</p>
-      <pre style={{ whiteSpace: "pre-wrap" }}>{JSON.stringify(payload.body, null, 2)}</pre>
+    <main className="detail-root">
+      <section className="panel detail-hero">
+        <div>
+          <p className="kicker">CANDIDATE DETAIL</p>
+          <h1>{candidate.name_ko}</h1>
+          <p>
+            {candidate.party_name || "정당 미상"} · {candidate.job || "직업 정보 없음"}
+          </p>
+        </div>
+        <div className="hero-actions">
+          <Link href="/search" className="text-link">
+            지역 검색
+          </Link>
+          <Link href="/" className="text-link">
+            대시보드
+          </Link>
+        </div>
+      </section>
+
+      <section className="detail-grid">
+        <article className="panel">
+          <h3>기본 정보</h3>
+          <dl className="meta-grid">
+            <dt>candidate_id</dt>
+            <dd>{candidate.candidate_id}</dd>
+            <dt>정당</dt>
+            <dd>{candidate.party_name || "-"}</dd>
+            <dt>성별</dt>
+            <dd>{candidate.gender || "-"}</dd>
+            <dt>생년월일</dt>
+            <dd>{formatDate(candidate.birth_date)}</dd>
+            <dt>직업</dt>
+            <dd>{candidate.job || "-"}</dd>
+            <dt>약력</dt>
+            <dd>{candidate.career_summary || "-"}</dd>
+            <dt>선거이력</dt>
+            <dd>{candidate.election_history || "-"}</dd>
+            <dt>출처 채널</dt>
+            <dd>{joinChannels(candidate.source_channels)}</dd>
+            <dt>최신시각</dt>
+            <dd>{formatDateTime(candidate.article_published_at || candidate.official_release_at)}</dd>
+          </dl>
+        </article>
+
+        <article className="panel">
+          <h3>관련 매치업 요약</h3>
+          {relatedMatchup.ok ? (
+            <div className="related-card">
+              <strong>{relatedMatchup.body.title}</strong>
+              <p>
+                {relatedMatchup.body.pollster || "조사기관 미상"} · {formatDate(relatedMatchup.body.survey_end_date)}
+              </p>
+              <p className="muted-text">matchup_id: {relatedMatchup.body.matchup_id}</p>
+              <Link href={`/matchups/${encodeURIComponent(relatedAlias)}`} className="text-link small">
+                매치업 상세 보기
+              </Link>
+            </div>
+          ) : (
+            <div className="empty-state">연결된 매치업 정보가 없습니다.</div>
+          )}
+        </article>
+      </section>
     </main>
   );
 }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,0 +1,549 @@
+:root {
+  --bg: #f0f4f8;
+  --ink: #0f172a;
+  --muted: #516173;
+  --card: #ffffff;
+  --line: #d9e4ef;
+  --brand: #0e7490;
+  --brand-strong: #164e63;
+  --danger: #b91c1c;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background:
+    radial-gradient(circle at 14% 18%, #d0ebff 0%, transparent 36%),
+    radial-gradient(circle at 82% 8%, #cffafe 0%, transparent 30%),
+    var(--bg);
+  color: var(--ink);
+  font-family: "Noto Sans KR", "IBM Plex Sans KR", "Apple SD Gothic Neo", sans-serif;
+  line-height: 1.5;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 40;
+  backdrop-filter: blur(8px);
+  border-bottom: 1px solid #d5e2f0;
+  background: color-mix(in srgb, #f8fbff 82%, transparent);
+}
+
+.site-header-inner {
+  max-width: 1160px;
+  margin: 0 auto;
+  padding: 14px 20px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.brand {
+  font-family: "Space Grotesk", "Noto Sans KR", sans-serif;
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: var(--brand-strong);
+}
+
+.site-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.site-nav a {
+  border: 1px solid transparent;
+  padding: 6px 10px;
+  border-radius: 10px;
+  font-size: 0.9rem;
+  color: #1e293b;
+}
+
+.site-nav a:hover {
+  border-color: #bae6fd;
+  background: #ecfeff;
+}
+
+.page-shell {
+  max-width: 1160px;
+  margin: 0 auto;
+  padding: 24px 20px 56px;
+}
+
+main {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.kicker {
+  margin: 0;
+  font-size: 0.72rem;
+  letter-spacing: 0.12em;
+  font-weight: 700;
+  color: var(--brand);
+}
+
+.panel {
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  background: var(--card);
+  padding: 18px;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.05);
+  animation: fadeInUp 0.45s ease both;
+}
+
+.hero {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: 1.4fr 1fr;
+}
+
+.hero h1 {
+  margin: 4px 0 8px;
+  font-family: "Space Grotesk", "Noto Sans KR", sans-serif;
+  font-size: clamp(1.35rem, 3vw, 2rem);
+}
+
+.hero p {
+  margin: 0;
+  color: #1f2f40;
+}
+
+.hero-meta {
+  border: 1px dashed #a5c5dd;
+  border-radius: 14px;
+  padding: 12px;
+  background: linear-gradient(160deg, #f0f9ff 0%, #ecfeff 100%);
+}
+
+.hero-meta strong {
+  display: block;
+  word-break: break-all;
+  color: #0c4a6e;
+  margin: 4px 0;
+}
+
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.panel-header h3,
+.panel h3 {
+  margin: 0;
+  font-size: 1.06rem;
+}
+
+.panel-header p,
+.panel p {
+  margin: 4px 0 0;
+  color: var(--muted);
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.summary-list {
+  display: grid;
+  gap: 10px;
+}
+
+.summary-row {
+  border: 1px solid #e5edf4;
+  border-radius: 12px;
+  padding: 10px 12px;
+  background: #fafcff;
+}
+
+.summary-row strong {
+  font-size: 0.98rem;
+}
+
+.summary-value {
+  font-weight: 700;
+  font-size: 1.05rem;
+  color: #0f766e;
+  margin-top: 2px;
+}
+
+.summary-meta {
+  margin: 6px 0 0;
+  font-size: 0.82rem;
+  color: #5f7184;
+}
+
+.region-layout {
+  display: grid;
+  grid-template-columns: 1.2fr 1fr;
+  gap: 14px;
+}
+
+.map-shell {
+  border: 1px solid #d8e7f4;
+  border-radius: 14px;
+  background: linear-gradient(180deg, #f8fcff 0%, #f1f5f9 100%);
+  min-height: 470px;
+  padding: 8px;
+}
+
+.korea-map {
+  width: 100%;
+  height: 100%;
+}
+
+.region-detail {
+  border: 1px solid #d9e7f4;
+  border-radius: 14px;
+  padding: 12px;
+  background: #f9fcff;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.region-detail h3 {
+  margin: 0;
+}
+
+.region-detail p {
+  margin: 2px 0;
+}
+
+.region-block {
+  border: 1px solid #dde8f3;
+  background: #ffffff;
+  border-radius: 10px;
+  padding: 10px;
+}
+
+.region-name {
+  margin: 0;
+  font-weight: 700;
+}
+
+.region-code {
+  margin: 0;
+  font-size: 0.82rem;
+  color: #64748b;
+}
+
+.region-chip-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.region-chip {
+  border: 1px solid #b8d8eb;
+  background: #fff;
+  border-radius: 999px;
+  padding: 5px 10px;
+  font-size: 0.78rem;
+  cursor: pointer;
+}
+
+.region-chip.active,
+.region-chip:hover {
+  background: #0f766e;
+  color: #fff;
+  border-color: #0f766e;
+}
+
+.election-list {
+  list-style: none;
+  margin: 8px 0 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.election-list li a {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid #dbe8f4;
+  border-radius: 10px;
+  padding: 8px;
+  gap: 2px;
+  background: #fff;
+}
+
+.election-list li a:hover {
+  border-color: #a2d4f2;
+  background: #f0f9ff;
+}
+
+.bigmatch-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.bigmatch-card {
+  border: 1px solid #d6e6f2;
+  border-radius: 12px;
+  background: linear-gradient(160deg, #f5fbff 0%, #eefdfc 100%);
+  padding: 12px;
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.bigmatch-card:hover {
+  border-color: #7dd3fc;
+  transform: translateY(-2px);
+}
+
+.bigmatch-card p {
+  margin: 6px 0 0;
+  font-size: 0.9rem;
+}
+
+.bigmatch-office {
+  margin: 0;
+  font-size: 0.75rem;
+  color: #0e7490;
+}
+
+.search-form {
+  display: flex;
+  gap: 8px;
+}
+
+.search-form input {
+  flex: 1;
+  border: 1px solid #bad4e7;
+  border-radius: 10px;
+  padding: 10px 12px;
+  font-size: 0.95rem;
+}
+
+.search-form button {
+  border: 0;
+  border-radius: 10px;
+  padding: 10px 14px;
+  background: #0f766e;
+  color: #fff;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.search-layout {
+  display: grid;
+  grid-template-columns: minmax(280px, 0.9fr) 1.1fr;
+  gap: 12px;
+  margin-top: 14px;
+}
+
+.inset-panel {
+  background: #f9fcff;
+}
+
+.region-result-list {
+  margin: 8px 0 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 6px;
+}
+
+.region-result-list li a {
+  display: grid;
+  gap: 1px;
+  border: 1px solid #d8e6f3;
+  border-radius: 10px;
+  background: #fff;
+  padding: 9px;
+}
+
+.region-result-list li a.active,
+.region-result-list li a:hover {
+  border-color: #0891b2;
+  background: #ecfeff;
+}
+
+.region-result-list span {
+  color: #5d6d7f;
+  font-size: 0.85rem;
+}
+
+.tab-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 10px;
+}
+
+.tab {
+  border: 1px solid #bfd9ea;
+  border-radius: 999px;
+  padding: 6px 10px;
+  font-size: 0.82rem;
+  background: #fff;
+}
+
+.tab.active,
+.tab:hover {
+  background: #0f766e;
+  border-color: #0f766e;
+  color: #fff;
+}
+
+.election-list.full li a {
+  gap: 4px;
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.detail-hero {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: flex-start;
+}
+
+.hero-actions {
+  display: flex;
+  gap: 10px;
+}
+
+.option-bars {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.option-row-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.bar-track {
+  width: 100%;
+  height: 10px;
+  border-radius: 999px;
+  background: #deebf7;
+  overflow: hidden;
+  margin-top: 6px;
+}
+
+.bar-fill {
+  display: block;
+  height: 100%;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #06b6d4 0%, #0891b2 100%);
+}
+
+.meta-grid {
+  margin: 0;
+  display: grid;
+  grid-template-columns: 138px 1fr;
+  gap: 6px 12px;
+}
+
+.meta-grid dt {
+  color: #526172;
+  font-size: 0.84rem;
+}
+
+.meta-grid dd {
+  margin: 0;
+  word-break: break-word;
+}
+
+.related-card {
+  border: 1px solid #dbe6f2;
+  border-radius: 12px;
+  padding: 12px;
+  background: #f8fdff;
+}
+
+.text-link {
+  color: #155e75;
+  font-weight: 700;
+}
+
+.text-link.small {
+  font-size: 0.85rem;
+}
+
+.muted-text {
+  color: #64748b;
+  font-size: 0.84rem;
+}
+
+.error-panel {
+  border-color: #fecaca;
+  background: #fff5f5;
+}
+
+.error-chip {
+  display: inline-flex;
+  margin-top: 10px;
+  border: 1px solid #fecaca;
+  color: var(--danger);
+  background: #fff1f2;
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-size: 0.82rem;
+}
+
+.empty-state {
+  border: 1px dashed #c5d8e7;
+  border-radius: 10px;
+  color: #5f7082;
+  padding: 12px;
+  font-size: 0.88rem;
+  background: #f8fbff;
+}
+
+@media (max-width: 980px) {
+  .hero,
+  .summary-grid,
+  .region-layout,
+  .search-layout,
+  .detail-grid,
+  .bigmatch-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .detail-hero {
+    flex-direction: column;
+  }
+
+  .hero-actions {
+    flex-wrap: wrap;
+  }
+}
+
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/apps/web/app/layout.js
+++ b/apps/web/app/layout.js
@@ -1,13 +1,30 @@
+import Link from "next/link";
+
+import "./globals.css";
+
 export const metadata = {
-  title: "Election 2026 Web RC",
-  description: "Public RC routes for home/matchup/candidate"
+  title: "Election 2026 Dashboard",
+  description: "2026 선거 여론조사 대시보드"
 };
 
 export default function RootLayout({ children }) {
   return (
     <html lang="ko">
-      <body style={{ fontFamily: "system-ui, sans-serif", margin: 0, padding: "24px", background: "#f8fafc" }}>
-        {children}
+      <body>
+        <header className="site-header">
+          <div className="site-header-inner">
+            <Link href="/" className="brand">
+              2026 Elections
+            </Link>
+            <nav className="site-nav">
+              <Link href="/">대시보드</Link>
+              <Link href="/search">지역 검색</Link>
+              <Link href="/matchups/m_2026_seoul_mayor">매치업</Link>
+              <Link href="/candidates/cand-jwo">후보</Link>
+            </nav>
+          </div>
+        </header>
+        <div className="page-shell">{children}</div>
       </body>
     </html>
   );

--- a/apps/web/app/matchups/[matchup_id]/page.js
+++ b/apps/web/app/matchups/[matchup_id]/page.js
@@ -1,21 +1,112 @@
 import Link from "next/link";
 
+import { formatDate, formatDateTime, formatPercent, joinChannels } from "../../_components/format";
 import { fetchApi } from "../../_lib/api";
+
+const CANDIDATE_ALIAS_BY_NAME = {
+  정원오: "cand-jwo"
+};
 
 export default async function MatchupPage({ params }) {
   const resolvedParams = await params;
   const matchupId = resolvedParams.matchup_id;
   const payload = await fetchApi(`/api/v1/matchups/${encodeURIComponent(matchupId)}`);
 
+  if (!payload.ok) {
+    return (
+      <main className="detail-root">
+        <section className="panel error-panel">
+          <h1>매치업을 불러오지 못했습니다.</h1>
+          <p>요청 ID: {matchupId}</p>
+          <p>status: {payload.status}</p>
+          <p className="muted-text">{JSON.stringify(payload.body)}</p>
+          <Link href="/" className="text-link">
+            대시보드로 이동
+          </Link>
+        </section>
+      </main>
+    );
+  }
+
+  const matchup = payload.body;
+  const options = Array.isArray(matchup.options) ? [...matchup.options] : [];
+  options.sort((a, b) => (b.value_mid || 0) - (a.value_mid || 0));
+  const maxValue = Math.max(...options.map((option) => option.value_mid || 0), 1);
+
   return (
-    <main>
-      <h1 style={{ marginTop: 0 }}>Matchup Route RC</h1>
-      <p>matchup_id: {matchupId}</p>
-      <p>
-        <Link href="/">Back to /</Link>
-      </p>
-      <p>api_status: {payload.status}</p>
-      <pre style={{ whiteSpace: "pre-wrap" }}>{JSON.stringify(payload.body, null, 2)}</pre>
+    <main className="detail-root">
+      <section className="panel detail-hero">
+        <div>
+          <p className="kicker">MATCHUP DETAIL</p>
+          <h1>{matchup.title || matchup.matchup_id}</h1>
+          <p>
+            {matchup.pollster || "조사기관 미상"} · {formatDate(matchup.survey_start_date)} ~ {formatDate(matchup.survey_end_date)}
+          </p>
+        </div>
+        <div className="hero-actions">
+          <Link href="/search" className="text-link">
+            지역 검색
+          </Link>
+          <Link href="/" className="text-link">
+            대시보드
+          </Link>
+        </div>
+      </section>
+
+      <section className="detail-grid">
+        <article className="panel">
+          <h3>후보별 최신 지표</h3>
+          <ul className="option-bars">
+            {options.map((option) => {
+              const width = Math.max(6, Math.round(((option.value_mid || 0) / maxValue) * 100));
+              const candidateAlias = CANDIDATE_ALIAS_BY_NAME[option.option_name];
+              return (
+                <li key={option.option_name}>
+                  <div className="option-row-head">
+                    <strong>{option.option_name}</strong>
+                    <span>{formatPercent(option.value_mid)}</span>
+                  </div>
+                  <div className="bar-track">
+                    <span className="bar-fill" style={{ width: `${width}%` }} />
+                  </div>
+                  <p className="muted-text">원문: {option.value_raw || "-"}</p>
+                  {candidateAlias ? (
+                    <Link href={`/candidates/${candidateAlias}`} className="text-link small">
+                      후보 상세 보기
+                    </Link>
+                  ) : null}
+                </li>
+              );
+            })}
+          </ul>
+        </article>
+
+        <article className="panel">
+          <h3>조사 메타데이터</h3>
+          <dl className="meta-grid">
+            <dt>matchup_id</dt>
+            <dd>{matchup.matchup_id}</dd>
+            <dt>region_code</dt>
+            <dd>{matchup.region_code || "-"}</dd>
+            <dt>office_type</dt>
+            <dd>{matchup.office_type || "-"}</dd>
+            <dt>표본수</dt>
+            <dd>{matchup.sample_size || "-"}</dd>
+            <dt>응답률</dt>
+            <dd>{matchup.response_rate ? `${matchup.response_rate}%` : "-"}</dd>
+            <dt>오차범위</dt>
+            <dd>{matchup.margin_of_error ? `±${matchup.margin_of_error}%p` : "-"}</dd>
+            <dt>신뢰수준</dt>
+            <dd>{matchup.confidence_level ? `${matchup.confidence_level}%` : "-"}</dd>
+            <dt>source_grade</dt>
+            <dd>{matchup.source_grade || "-"}</dd>
+            <dt>업데이트</dt>
+            <dd>{formatDateTime(matchup.article_published_at || matchup.official_release_at)}</dd>
+            <dt>source_channels</dt>
+            <dd>{joinChannels(matchup.source_channels)}</dd>
+          </dl>
+        </article>
+      </section>
     </main>
   );
 }

--- a/apps/web/app/page.js
+++ b/apps/web/app/page.js
@@ -1,36 +1,138 @@
 import Link from "next/link";
 
+import RegionalMapPanel from "./_components/RegionalMapPanel";
+import { formatDate, formatPercent, joinChannels } from "./_components/format";
 import { API_BASE, fetchApi } from "./_lib/api";
 
+function SummaryColumn({ title, description, items }) {
+  return (
+    <article className="panel">
+      <header className="panel-header">
+        <div>
+          <h3>{title}</h3>
+          <p>{description}</p>
+        </div>
+      </header>
+
+      {items.length === 0 ? <div className="empty-state">표시할 데이터가 없습니다.</div> : null}
+
+      <div className="summary-list">
+        {items.map((item) => (
+          <div key={`${item.option_name}-${item.survey_end_date}`} className="summary-row">
+            <div>
+              <strong>{item.option_name}</strong>
+              <p className="muted-text">
+                {item.pollster} · {formatDate(item.survey_end_date)}
+              </p>
+            </div>
+            <div className="summary-value">{formatPercent(item.value_mid)}</div>
+            <p className="summary-meta">채널: {joinChannels(item.source_channels)}</p>
+          </div>
+        ))}
+      </div>
+    </article>
+  );
+}
+
+function BigMatchCards({ items }) {
+  return (
+    <section className="panel">
+      <header className="panel-header">
+        <div>
+          <h3>이 주의 빅매치</h3>
+          <p>격차(spread)가 작아 접전인 매치업을 우선 정렬합니다.</p>
+        </div>
+        <Link href="/search" className="text-link">
+          지역 검색으로 이동
+        </Link>
+      </header>
+
+      {items.length === 0 ? <div className="empty-state">빅매치 데이터가 없습니다.</div> : null}
+
+      <div className="bigmatch-grid">
+        {items.map((item) => (
+          <Link
+            key={item.matchup_id}
+            href={`/matchups/${encodeURIComponent(item.matchup_id)}`}
+            className="bigmatch-card"
+          >
+            <p className="bigmatch-office">{item.audience_scope || "지역 조사"}</p>
+            <strong>{item.title}</strong>
+            <p>대표값 {formatPercent(item.value_mid)}</p>
+            <p>조사 종료 {formatDate(item.survey_end_date)}</p>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}
+
 export default async function HomePage() {
-  const summary = await fetchApi("/api/v1/dashboard/summary");
+  const [summaryRes, mapRes, bigMatchRes] = await Promise.all([
+    fetchApi("/api/v1/dashboard/summary"),
+    fetchApi("/api/v1/dashboard/map-latest"),
+    fetchApi("/api/v1/dashboard/big-matches")
+  ]);
+
+  const partyItems = summaryRes.ok && Array.isArray(summaryRes.body?.party_support) ? summaryRes.body.party_support : [];
+  const presidentialItems =
+    summaryRes.ok && Array.isArray(summaryRes.body?.presidential_approval) ? summaryRes.body.presidential_approval : [];
+  const mapItems = mapRes.ok && Array.isArray(mapRes.body?.items) ? mapRes.body.items : [];
+  const bigMatchItems = bigMatchRes.ok && Array.isArray(bigMatchRes.body?.items) ? bigMatchRes.body.items : [];
 
   return (
-    <main>
-      <h1 style={{ marginTop: 0 }}>Election 2026 Public Web RC</h1>
-      <p>API Base: {API_BASE}</p>
-      <ul>
-        <li>
-          <Link href="/matchups/m_2026_seoul_mayor">/matchups/m_2026_seoul_mayor</Link>
-        </li>
-        <li>
-          <Link href="/candidates/cand-jwo">/candidates/cand-jwo</Link>
-        </li>
-      </ul>
-      {summary.ok ? (
+    <main className="dashboard-root">
+      <section className="hero panel">
         <div>
-          <p>summary status: {summary.status}</p>
-          <p>party_support count: {Array.isArray(summary.body?.party_support) ? summary.body.party_support.length : 0}</p>
+          <p className="kicker">ELECTION 2026</p>
+          <h1>전국 여론조사 대시보드</h1>
           <p>
-            presidential_approval count:{" "}
-            {Array.isArray(summary.body?.presidential_approval) ? summary.body.presidential_approval.length : 0}
+            정당·대통령 요약, 지역별 최신 매치업, 빅매치를 한 화면에서 확인할 수 있습니다.
           </p>
         </div>
-      ) : (
-        <div>
-          <p style={{ color: "#b91c1c" }}>summary fetch failed: status {summary.status}</p>
-          <pre style={{ whiteSpace: "pre-wrap" }}>{JSON.stringify(summary.body, null, 2)}</pre>
+        <div className="hero-meta">
+          <p>운영 API</p>
+          <strong>{API_BASE}</strong>
+          <p className="muted-text">데이터는 운영 API 기준 실시간 조회 결과를 사용합니다.</p>
         </div>
+      </section>
+
+      {!summaryRes.ok ? (
+        <section className="panel error-panel">
+          <h3>요약 데이터 로드 실패</h3>
+          <p>status: {summaryRes.status}</p>
+        </section>
+      ) : null}
+
+      <section className="summary-grid">
+        <SummaryColumn
+          title="최신 정당 지지도"
+          description="전국 스코프 기준 최신 조사"
+          items={partyItems}
+        />
+        <SummaryColumn
+          title="대통령 지지율"
+          description="전국 스코프 기준 최신 조사"
+          items={presidentialItems}
+        />
+      </section>
+
+      {!mapRes.ok ? (
+        <section className="panel error-panel">
+          <h3>지도 데이터 로드 실패</h3>
+          <p>status: {mapRes.status}</p>
+        </section>
+      ) : (
+        <RegionalMapPanel items={mapItems} apiBase={API_BASE} />
+      )}
+
+      {!bigMatchRes.ok ? (
+        <section className="panel error-panel">
+          <h3>빅매치 데이터 로드 실패</h3>
+          <p>status: {bigMatchRes.status}</p>
+        </section>
+      ) : (
+        <BigMatchCards items={bigMatchItems} />
       )}
     </main>
   );

--- a/apps/web/app/search/page.js
+++ b/apps/web/app/search/page.js
@@ -1,0 +1,125 @@
+import Link from "next/link";
+
+import { formatDate } from "../_components/format";
+import { fetchApi } from "../_lib/api";
+
+const OFFICE_TABS = [
+  "광역자치단체장",
+  "광역의회",
+  "교육감",
+  "기초자치단체장",
+  "기초의회",
+  "재보궐"
+];
+
+function buildQueryString(params) {
+  const query = new URLSearchParams();
+  Object.entries(params).forEach(([key, value]) => {
+    if (value) query.set(key, value);
+  });
+  const text = query.toString();
+  return text ? `?${text}` : "";
+}
+
+export default async function SearchPage({ searchParams }) {
+  const resolved = await searchParams;
+  const q = (resolved?.q || "").trim();
+  const selectedRegion = resolved?.region || "";
+  const selectedOffice = resolved?.office || "all";
+
+  const regionsRes = q ? await fetchApi(`/api/v1/regions/search?q=${encodeURIComponent(q)}`) : { ok: true, body: [] };
+  const regions = regionsRes.ok && Array.isArray(regionsRes.body) ? regionsRes.body : [];
+  const regionCode = selectedRegion || regions[0]?.region_code || "";
+
+  const electionsRes = regionCode ? await fetchApi(`/api/v1/regions/${encodeURIComponent(regionCode)}/elections`) : { ok: true, body: [] };
+  const elections = electionsRes.ok && Array.isArray(electionsRes.body) ? electionsRes.body : [];
+
+  const filteredElections =
+    selectedOffice === "all" ? elections : elections.filter((election) => election.office_type === selectedOffice);
+
+  return (
+    <main className="search-root">
+      <section className="panel">
+        <header className="panel-header">
+          <div>
+            <h1>지역 검색</h1>
+            <p>기초자치단체 단위로 검색하고 선거 타입별 매치업으로 이동합니다.</p>
+          </div>
+          <Link href="/" className="text-link">
+            대시보드로
+          </Link>
+        </header>
+
+        <form method="GET" className="search-form">
+          <input name="q" defaultValue={q} placeholder="예: 서울 강남구, 경기 시흥시" aria-label="지역 검색" />
+          <button type="submit">검색</button>
+        </form>
+
+        {q && !regionsRes.ok ? <div className="error-chip">검색 API 오류: {regionsRes.status}</div> : null}
+
+        {q && regionsRes.ok ? (
+          <div className="search-layout">
+            <section className="panel inset-panel">
+              <h3>검색 결과 ({regions.length})</h3>
+              {regions.length === 0 ? <div className="empty-state">검색 결과가 없습니다.</div> : null}
+              <ul className="region-result-list">
+                {regions.map((region) => {
+                  const href = buildQueryString({ q, region: region.region_code, office: selectedOffice === "all" ? "" : selectedOffice });
+                  const active = region.region_code === regionCode;
+                  return (
+                    <li key={region.region_code}>
+                      <Link className={active ? "active" : ""} href={`/search${href}`}>
+                        <strong>{region.sido_name}</strong>
+                        <span>{region.sigungu_name}</span>
+                        <span>{region.region_code}</span>
+                      </Link>
+                    </li>
+                  );
+                })}
+              </ul>
+            </section>
+
+            <section className="panel inset-panel">
+              <h3>선거 타입</h3>
+              <div className="tab-row">
+                <Link
+                  href={`/search${buildQueryString({ q, region: regionCode })}`}
+                  className={selectedOffice === "all" ? "tab active" : "tab"}
+                >
+                  전체
+                </Link>
+                {OFFICE_TABS.map((officeType) => (
+                  <Link
+                    key={officeType}
+                    href={`/search${buildQueryString({ q, region: regionCode, office: officeType })}`}
+                    className={selectedOffice === officeType ? "tab active" : "tab"}
+                  >
+                    {officeType}
+                  </Link>
+                ))}
+              </div>
+
+              {!electionsRes.ok ? <div className="error-chip">선거 목록 API 오류: {electionsRes.status}</div> : null}
+
+              {electionsRes.ok && filteredElections.length === 0 ? <div className="empty-state">조건에 맞는 선거가 없습니다.</div> : null}
+
+              {electionsRes.ok && filteredElections.length > 0 ? (
+                <ul className="election-list full">
+                  {filteredElections.map((election) => (
+                    <li key={election.matchup_id}>
+                      <Link href={`/matchups/${encodeURIComponent(election.matchup_id)}`}>
+                        <span>{election.office_type}</span>
+                        <strong>{election.title}</strong>
+                        <span>{election.is_active ? "활성" : "비활성"}</span>
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              ) : null}
+            </section>
+          </div>
+        ) : null}
+      </section>
+    </main>
+  );
+}

--- a/develop_report/2026-02-20_issue143_public_ui_promotion_report.md
+++ b/develop_report/2026-02-20_issue143_public_ui_promotion_report.md
@@ -1,0 +1,75 @@
+# 2026-02-20 Issue #143 Public UI Promotion Report
+
+## 1. 목적
+- 공개 웹을 RC 셸 화면에서 실제 대시보드 화면으로 승격하고, `/`, `/search`, `/matchups/{id}`, `/candidates/{id}` 4개 라우트를 운영 API 기준으로 정착한다.
+
+## 2. 반영 범위
+1. 홈(`/`) 실컴포넌트 반영
+- 최신 정당/대통령 요약 카드
+- 지역 지도 인터랙션(GeoJSON + 지역 선택)
+- 빅매치 카드
+
+2. 검색(`/search`) 신규 반영
+- 지역 검색 입력
+- 검색 결과 목록
+- 선거 타입 탭(6종)
+- 지역별 선거 링크
+
+3. 매치업/후보 상세 화면 승격
+- raw JSON 중심 RC 렌더 제거
+- 카드/메타/링크 중심 상세 화면으로 교체
+
+4. 배포 소스 경로 단일화 명시
+- Vercel preview workflow `root_dir` 선택값을 `apps/web` 단일로 제한
+- 배포 문서에 공개 도메인 소스 경로 단일 기준(`apps/web`) 반영
+
+## 3. 변경 파일
+1. `.github/workflows/vercel-preview.yml`
+2. `apps/web/app/layout.js`
+3. `apps/web/app/globals.css`
+4. `apps/web/app/page.js`
+5. `apps/web/app/search/page.js`
+6. `apps/web/app/matchups/[matchup_id]/page.js`
+7. `apps/web/app/candidates/[candidate_id]/page.js`
+8. `apps/web/app/_components/RegionalMapPanel.js`
+9. `apps/web/app/_components/format.js`
+10. `docs/04_DEPLOYMENT_AND_ENVIRONMENT.md`
+11. `develop_report/2026-02-20_issue143_public_ui_promotion_report.md`
+
+## 4. RC 임시 문구 제거
+- 제거 대상 문구:
+  - `Election 2026 Public Web RC`
+  - `Matchup Route RC`
+  - `Candidate Route RC`
+  - raw count(`party_support count`, `presidential_approval count`) 중심 표기
+- 결과: 운영 화면 텍스트/컴포넌트 기준으로 교체 완료
+
+## 5. 로컬 검증
+1. 빌드
+```bash
+npm --prefix apps/web ci
+npm --prefix apps/web run build
+```
+결과: 성공
+
+2. 로컬 라우트 스모크
+```bash
+PORT=3334 API_BASE_URL="https://2026-api-production.up.railway.app" NEXT_PUBLIC_API_BASE_URL="https://2026-api-production.up.railway.app" npm --prefix apps/web run start -- --port 3334
+curl http://127.0.0.1:3334/
+curl http://127.0.0.1:3334/search
+curl http://127.0.0.1:3334/matchups/m_2026_seoul_mayor
+curl http://127.0.0.1:3334/candidates/cand-jwo
+```
+결과:
+- `/` 200
+- `/search` 200
+- `/matchups/m_2026_seoul_mayor` 200
+- `/candidates/cand-jwo` 200
+
+## 6. 운영 반영 후 확인 계획
+1. 공개 도메인 4개 라우트 200 확인
+2. 홈 위젯(summary/map/big-matches) 렌더 확인
+3. QA 이슈 #146에 재게이트 요청 코멘트 전달
+
+## 7. 결론
+- 공개 웹은 RC 셸 구조에서 실제 대시보드 구조로 승격되었고, 운영 API base(`https://2026-api-production.up.railway.app`)를 유지한다.

--- a/docs/04_DEPLOYMENT_AND_ENVIRONMENT.md
+++ b/docs/04_DEPLOYMENT_AND_ENVIRONMENT.md
@@ -166,7 +166,7 @@ scripts/qa/smoke_staging.sh --api-base "$API_BASE" --web-base "$WEB_BASE"
 - `VERCEL_SCOPE` (team slug)
 - `VERCEL_PROJECT_NAME`
 4. Dispatch 입력:
-- `root_dir`: `apps/web` (공개 라우트 RC 기본), 필요 시 `apps/staging-web`
+- `root_dir`: `apps/web` (공개 도메인 배포 단일 소스 경로)
 - `issue_number`: URL 코멘트를 남길 이슈 번호(실행 시 명시 입력)
 5. 실행 결과:
 - Preview URL 추출 후 `issue_number`에 코멘트 자동 작성
@@ -180,7 +180,7 @@ scripts/qa/smoke_staging.sh --api-base "$API_BASE" --web-base "$WEB_BASE"
 - `main` (GitHub Deployment Production ref 기준)
 3. RC 배포 설정:
 - 타깃: `Vercel`
-- 프로젝트 루트: `apps/web` (공개 라우트 RC), 필요 시 `apps/staging-web` fallback
+- 프로젝트 루트 단일 기준: `apps/web` (공개 도메인 배포 소스 경로)
 - 배포 입력값은 GitHub Secrets(`VERCEL_TOKEN`, `VERCEL_SCOPE`, `VERCEL_PROJECT_NAME`)으로만 주입
 - Preview/Production 공통 API base 고정값: `https://2026-api-production.up.railway.app`
 4. 공개 라우트 RC 확인 대상:
@@ -188,7 +188,7 @@ scripts/qa/smoke_staging.sh --api-base "$API_BASE" --web-base "$WEB_BASE"
 - `/matchups/m_2026_seoul_mayor`
 - `/candidates/cand-jwo`
 5. 웹 API endpoint 환경변수 계약:
-- 코드 기준: `apps/web/app/_lib/api.js` (staging 대체 경로: `apps/staging-web/app/page.js`)
+- 코드 기준: `apps/web/app/_lib/api.js`
 - 해석 우선순위: `API_BASE_URL` -> `NEXT_PUBLIC_API_BASE_URL` -> `https://2026-api-production.up.railway.app`
 - 개발(local) 권장:
   - `API_BASE_URL=http://127.0.0.1:8100`


### PR DESCRIPTION
## Summary
- 공개 웹 4개 화면(`/`, `/search`, `/matchups/{id}`, `/candidates/{id}`)을 RC 셸에서 실제 대시보드 UI로 승격
- 홈에 summary 카드 + 지역 지도 인터랙션 + 빅매치 섹션 반영
- 배포 소스 경로를 `apps/web` 단일 기준으로 workflow/문서 동기화

## Linked Issue
- Closes #143

## Report-Path
Report-Path: develop_report/2026-02-20_issue143_public_ui_promotion_report.md

## Checklist
- [x] docs 계약(필드/API/용어)과 일치
- [x] 테스트 또는 검증 로그 첨부
- [x] 보안 정보(key/secret) 미포함 확인
- [x] Report-Path 파일이 이번 PR에 포함됨
