### PR TITLE
feat(web): reflect baseline visual param scenarios B02-B10

### DIFF
--- a/apps/web/app/_components/RegionalMapPanel.js
+++ b/apps/web/app/_components/RegionalMapPanel.js
@@ -56,13 +56,22 @@ function pickLatestByRegion(items) {
   return map;
 }
 
-export default function RegionalMapPanel({ items, apiBase }) {
+export default function RegionalMapPanel({
+  items,
+  apiBase,
+  initialSelectedRegionCode = null,
+  selectedRegionHint = ""
+}) {
   const [hoveredCode, setHoveredCode] = useState(null);
-  const [selectedCode, setSelectedCode] = useState(null);
+  const [selectedCode, setSelectedCode] = useState(initialSelectedRegionCode);
   const [geoState, setGeoState] = useState("loading");
   const [geoJson, setGeoJson] = useState(null);
   const [electionsState, setElectionsState] = useState("idle");
   const [elections, setElections] = useState([]);
+
+  useEffect(() => {
+    setSelectedCode(initialSelectedRegionCode || null);
+  }, [initialSelectedRegionCode]);
 
   useEffect(() => {
     let mounted = true;
@@ -200,6 +209,12 @@ export default function RegionalMapPanel({ items, apiBase }) {
           <h3>지역 인터랙션</h3>
           <p>지도에서 지역을 선택하면 최신 조사와 연결된 매치업을 확인할 수 있습니다.</p>
         </header>
+
+        {selectedRegionHint ? (
+          <div className="param-callout">
+            baseline selected_region 적용: <strong>{selectedRegionHint}</strong>
+          </div>
+        ) : null}
 
         {!activeCode ? <div className="empty-state">지역을 선택해 주세요.</div> : null}
 

--- a/apps/web/app/_components/demoParams.js
+++ b/apps/web/app/_components/demoParams.js
@@ -1,0 +1,59 @@
+const REGION_PARAM_ALIASES = {
+  "KR-11": "11-000",
+  "KR-26": "26-000",
+  "KR-41": "41-000"
+};
+
+const QUERY_ALIASES = {
+  연수국: "연수구"
+};
+
+export function normalizeRegionParam(regionParam) {
+  if (!regionParam || typeof regionParam !== "string") {
+    return { input: "", normalized: null, corrected: false };
+  }
+  const trimmed = regionParam.trim();
+  if (!trimmed) return { input: "", normalized: null, corrected: false };
+
+  if (REGION_PARAM_ALIASES[trimmed]) {
+    return {
+      input: trimmed,
+      normalized: REGION_PARAM_ALIASES[trimmed],
+      corrected: true
+    };
+  }
+
+  if (/^\d{2}(?:-\d{3})?$/.test(trimmed)) {
+    return {
+      input: trimmed,
+      normalized: trimmed.length === 2 ? `${trimmed}-000` : trimmed,
+      corrected: trimmed.length === 2
+    };
+  }
+
+  return { input: trimmed, normalized: trimmed, corrected: false };
+}
+
+export function normalizeDemoQuery(query) {
+  if (!query || typeof query !== "string") {
+    return { input: "", normalized: "", corrected: false };
+  }
+  const trimmed = query.trim();
+  if (!trimmed) return { input: "", normalized: "", corrected: false };
+  const mapped = QUERY_ALIASES[trimmed] || trimmed;
+  return {
+    input: trimmed,
+    normalized: mapped,
+    corrected: mapped !== trimmed
+  };
+}
+
+export function parseOnFlag(value) {
+  if (typeof value !== "string") return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "on" || normalized === "yes";
+}
+
+export function toScenarioBadge(text, tone = "info") {
+  return { text, tone };
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -509,6 +509,91 @@ main {
   font-size: 0.82rem;
 }
 
+.param-callout {
+  margin: 10px 0 0;
+  border: 1px solid #bfdbfe;
+  border-radius: 10px;
+  background: #eff6ff;
+  color: #1e3a8a;
+  font-size: 0.84rem;
+  padding: 8px 10px;
+}
+
+.scenario-panel {
+  border-style: dashed;
+}
+
+.badge-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.state-badge {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  border: 1px solid #d0e3f3;
+  background: #f8fbff;
+  color: #1e293b;
+  padding: 4px 10px;
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.state-badge.info {
+  border-color: #bae6fd;
+  background: #ecfeff;
+  color: #155e75;
+}
+
+.state-badge.ok {
+  border-color: #bbf7d0;
+  background: #f0fdf4;
+  color: #166534;
+}
+
+.state-badge.warn {
+  border-color: #fed7aa;
+  background: #fff7ed;
+  color: #9a3412;
+}
+
+.scenario-copy {
+  margin-top: 8px;
+  font-size: 0.88rem;
+}
+
+.empty-actions {
+  margin-top: 10px;
+  border: 1px dashed #c7d7e8;
+  border-radius: 10px;
+  padding: 10px;
+  background: #f8fbff;
+}
+
+.empty-actions p {
+  margin: 0 0 6px;
+  font-size: 0.84rem;
+  color: #475569;
+}
+
+.empty-actions-links {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.empty-actions-links a {
+  border: 1px solid #bfdbfe;
+  background: #eff6ff;
+  color: #1d4ed8;
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
 .empty-state {
   border: 1px dashed #c5d8e7;
   border-radius: 10px;

--- a/develop_report/2026-02-20_issue148_visual_param_enablement_report.md
+++ b/develop_report/2026-02-20_issue148_visual_param_enablement_report.md
@@ -1,0 +1,67 @@
+# 2026-02-20 Issue #148 Visual Param Enablement Report
+
+## 1. 목적
+- 공개 웹 baseline 파라미터 시나리오(B02~B10)가 실제 UI 상태(카피/배지/패널)로 반영되도록 구현한다.
+
+## 2. 구현 범위
+1. Home
+- `scope_mix=1` 시 스코프 혼재 경고 배지/카피 노출
+- `selected_region=KR-11` 시 `11-000`으로 정규화하여 지역 패널 선택 상태 반영
+
+2. Search
+- `demo_query=연수국` 시 alias 보정(`연수구`) 상태 노출
+- `demo_query=없는지역명` 시 empty-state + 대체 액션(서울/인천 재검색) 노출
+
+3. Matchup
+- `confirm_demo`, `source_demo`, `demo_state` 조합 배지와 상태 카피 노출
+- alias 요청 ID와 canonical 표준 ID 병기
+
+4. Candidate
+- `party_demo`, `confirm_demo` 상태 배지 노출
+- 미존재 후보 ID 요청 시 `cand-jwo` 안전 fallback 렌더(404 내부패널 제거)
+
+## 3. 변경 파일
+1. `apps/web/app/page.js`
+2. `apps/web/app/search/page.js`
+3. `apps/web/app/matchups/[matchup_id]/page.js`
+4. `apps/web/app/candidates/[candidate_id]/page.js`
+5. `apps/web/app/_components/RegionalMapPanel.js`
+6. `apps/web/app/_components/demoParams.js`
+7. `apps/web/app/globals.css`
+8. `docs/05_RUNBOOK_AND_OPERATIONS.md`
+9. `develop_report/2026-02-20_issue148_visual_param_enablement_report.md`
+
+## 4. 로컬 검증
+1. 빌드
+```bash
+npm --prefix apps/web ci
+npm --prefix apps/web run build
+```
+결과: 성공
+
+2. baseline 시나리오 URL(로컬)
+- B02: `/?scope_mix=1`
+- B03: `/?selected_region=KR-11`
+- B04: `/search?demo_query=%EC%97%B0%EC%88%98%EA%B5%AD`
+- B05: `/search?demo_query=%EC%97%86%EB%8A%94%EC%A7%80%EC%97%AD%EB%AA%85`
+- B06: `/matchups/m_2026_seoul_mayor?confirm_demo=article&source_demo=article&demo_state=ready`
+- B07: `/matchups/m_2026_seoul_mayor?confirm_demo=official&source_demo=nesdc&demo_state=ready`
+- B08: `/candidates/cand-jwo?party_demo=inferred&confirm_demo=article`
+- B09: `/candidates/cand-jwo?party_demo=official&confirm_demo=official`
+- B10: `/candidates/cand-does-not-exist?party_demo=inferred&confirm_demo=official`
+
+3. 로컬 실측 결과
+- B02~B10 모두 `200`
+- B10에서 `candidate not found`/`status: 404` 패널 미노출
+- 기본 라우트(`/`, `/search`, `/matchups/m_2026_seoul_mayor`, `/candidates/cand-jwo`) 모두 `200` + RC 임시문구 미노출
+
+## 5. 공개 환경 확인 포인트(머지 후)
+1. `https://2026-deploy.vercel.app`에 동일 B02~B10 URL 적용
+2. 각 URL에서 아래 상태 노출 확인
+- Home: `scope_mix=1`, `selected_region=KR-11 -> 11-000`
+- Search: `baseline demo_query 적용`, `자동 보정`, `대체 액션`
+- Matchup: `confirm_demo=...`, `source_demo=...`, `demo_state=ready`
+- Candidate: `party_demo=...`, `confirm_demo=...`, `baseline 안전 fallback 적용`
+
+## 6. 결론
+- baseline 파라미터 시나리오(B02~B10)를 공개 웹 UI 상태로 반영했고, 기존 공개 라우트 회귀 없이 유지했다.

--- a/docs/05_RUNBOOK_AND_OPERATIONS.md
+++ b/docs/05_RUNBOOK_AND_OPERATIONS.md
@@ -335,3 +335,20 @@ scripts/qa/smoke_public_api.sh \
 5. 실패/롤백:
 - 실패 시 Vercel env를 기존 `https://2026-api-production.up.railway.app`로 즉시 복구
 - 복구 후 동일 스모크로 200 재확인
+
+## 18. 공개 웹 Baseline 파라미터 시나리오 (Issue #148)
+1. 대상 URL:
+- `https://2026-deploy.vercel.app/?scope_mix=1`
+- `https://2026-deploy.vercel.app/?selected_region=KR-11`
+- `https://2026-deploy.vercel.app/search?demo_query=%EC%97%B0%EC%88%98%EA%B5%AD`
+- `https://2026-deploy.vercel.app/search?demo_query=%EC%97%86%EB%8A%94%EC%A7%80%EC%97%AD%EB%AA%85`
+- `https://2026-deploy.vercel.app/matchups/m_2026_seoul_mayor?confirm_demo=article&source_demo=article&demo_state=ready`
+- `https://2026-deploy.vercel.app/matchups/m_2026_seoul_mayor?confirm_demo=official&source_demo=nesdc&demo_state=ready`
+- `https://2026-deploy.vercel.app/candidates/cand-jwo?party_demo=inferred&confirm_demo=article`
+- `https://2026-deploy.vercel.app/candidates/cand-jwo?party_demo=official&confirm_demo=official`
+- `https://2026-deploy.vercel.app/candidates/cand-does-not-exist?party_demo=inferred&confirm_demo=official`
+2. 판정 포인트:
+- Home: `scope_mix` 경고/배지 노출, `selected_region` 선택 상태 반영
+- Search: alias 보정(`연수국 -> 연수구`)과 empty-state 대체 액션 노출
+- Matchup: `confirm_demo`/`source_demo`/`demo_state` 배지와 상태 카피 노출
+- Candidate: `party_demo`/`confirm_demo` 배지 노출, 미존재 후보 ID는 안전 fallback으로 렌더 유지


### PR DESCRIPTION
## Summary
- 공개 웹 baseline 파라미터 시나리오(B02~B10) 실동작 반영
- Home/Search/Matchup/Candidate에 시나리오 배지/카피/상태 전이 구현
- 후보 미존재 baseline 케이스에 안전 fallback 적용(내부 404 패널 제거)
- runbook + develop report 업데이트

## Linked Issue
- Closes #148

## Report-Path
Report-Path: develop_report/2026-02-20_issue148_visual_param_enablement_report.md

## Checklist
- [x] docs 계약(필드/API/용어)과 일치
- [x] 테스트 또는 검증 로그 첨부
- [x] 보안 정보(key/secret) 미포함 확인
- [x] Report-Path 파일이 이번 PR에 포함됨
