### PR TITLE
ci: fix ingest payload build PYTHONPATH

### DIFF
--- a/.github/workflows/ingest-schedule.yml
+++ b/.github/workflows/ingest-schedule.yml
@@ -37,11 +37,11 @@ jobs:
         run: |
           set -euo pipefail
           if [ -f scripts/generate_collector_live_coverage_v1_pack.py ]; then
-            .venv/bin/python scripts/generate_collector_live_coverage_v1_pack.py
+            PYTHONPATH=. .venv/bin/python scripts/generate_collector_live_coverage_v1_pack.py
             test -s data/collector_live_coverage_v1_payload.json
             echo "INGEST_INPUT_PATH=data/collector_live_coverage_v1_payload.json" >> "$GITHUB_ENV"
           elif [ -f scripts/generate_collector_sample_ingest.py ]; then
-            .venv/bin/python scripts/generate_collector_sample_ingest.py
+            PYTHONPATH=. .venv/bin/python scripts/generate_collector_sample_ingest.py
             test -s data/sample_ingest_collector_5.json
             echo "INGEST_INPUT_PATH=data/sample_ingest_collector_5.json" >> "$GITHUB_ENV"
           else


### PR DESCRIPTION
## Summary
- set `PYTHONPATH=.` when running payload build scripts in ingest schedule

## Why
- scheduled runner failed with `ModuleNotFoundError: app` while executing generator scripts
