### PR TITLE
governance: add issue label/comment contract guard

### DIFF
--- a/.github/workflows/issue-contract-guard.yml
+++ b/.github/workflows/issue-contract-guard.yml
@@ -1,0 +1,130 @@
+name: Issue Contract Guard
+
+on:
+  issues:
+    types: [opened, edited, reopened, labeled, unlabeled, closed]
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  validate-issue-contract:
+    if: github.event_name == 'issues'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate issue labels and close contract
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            if (!issue || issue.pull_request) return;
+
+            const labels = (issue.labels || []).map((l) => (typeof l === 'string' ? l : l.name));
+            const errors = [];
+            const oneOfPrefixes = ['role/', 'status/', 'priority/', 'type/'];
+
+            for (const prefix of oneOfPrefixes) {
+              const count = labels.filter((x) => x.startsWith(prefix)).length;
+              if (count !== 1) {
+                errors.push(`label cardinality violation: ${prefix} expected 1, got ${count}`);
+              }
+            }
+
+            const hasDone = labels.includes('status/done');
+            if (issue.state === 'closed') {
+              if (!hasDone) {
+                errors.push('closed issue must have status/done');
+              }
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                per_page: 100,
+              });
+              const hasQaPass = comments.some((c) => (c.body || '').includes('[QA PASS]'));
+              if (!hasQaPass) {
+                errors.push('closed+done issue requires a [QA PASS] comment');
+              }
+            } else {
+              if (hasDone) {
+                errors.push('open issue cannot have status/done');
+              }
+            }
+
+            if (errors.length > 0) {
+              const today = new Date().toISOString().slice(0, 10);
+              const autoKey = `contract-issue-${issue.number}-${today}`;
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                per_page: 100,
+              });
+              const already = comments.some((c) => (c.body || '').includes(`auto_key: ${autoKey}`));
+              if (!already) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: `[CONTRACT FAIL][ISSUE]\nauto_key: ${autoKey}\n\n- ${errors.join('\n- ')}`,
+                });
+              }
+              core.setFailed(errors.join(' | '));
+            }
+
+  validate-comment-contract:
+    if: github.event_name == 'issue_comment'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate comment required keys
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const comment = context.payload.comment;
+            if (!issue || !comment) return;
+            if (issue.pull_request) return;
+            if ((comment.user?.login || '').endsWith('[bot]')) return;
+
+            const body = comment.body || '';
+            if (body.includes('[PM AUTO]')) return;
+
+            const hasKey = (k) => new RegExp(`(^|\\n)\\s*${k}\\s*:`, 'i').test(body);
+            const errors = [];
+
+            const isPmDirective = /^\s*\[PM[^\]]*\]/i.test(body) && !body.includes('[PM AUTO]');
+            if (isPmDirective) {
+              for (const k of ['decision', 'next_status']) {
+                if (!hasKey(k)) errors.push(`PM comment missing key: ${k}:`);
+              }
+            }
+
+            const isDevelopDone = body.includes('[DEVELOP 완료 보고]');
+            if (isDevelopDone) {
+              for (const k of ['report_path', 'evidence', 'next_status']) {
+                if (!hasKey(k)) errors.push(`DEVELOP complete comment missing key: ${k}:`);
+              }
+            }
+
+            const isQaResult = body.includes('[QA PASS]') || body.includes('[QA FAIL]');
+            if (isQaResult) {
+              for (const k of ['report_path', 'evidence', 'next_status']) {
+                if (!hasKey(k)) errors.push(`QA result comment missing key: ${k}:`);
+              }
+            }
+
+            if (errors.length > 0) {
+              const today = new Date().toISOString().slice(0, 10);
+              const autoKey = `contract-comment-${issue.number}-${comment.id}-${today}`;
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `[CONTRACT FAIL][COMMENT]\nauto_key: ${autoKey}\n\n- ${errors.join('\n- ')}`,
+              });
+              core.setFailed(errors.join(' | '));
+            }

--- a/docs/11_ISSUE_COMMENT_LABEL_CONTRACT.md
+++ b/docs/11_ISSUE_COMMENT_LABEL_CONTRACT.md
@@ -1,0 +1,59 @@
+# 이슈 코멘트/라벨 계약 (Automation Contract)
+
+목적
+- PM Cycle 자동화가 오판 없이 동작하도록 이슈 라벨/코멘트 형식을 고정한다.
+
+적용 범위
+- 저장소 전체 이슈(특히 자동화 대상: PM/DEVELOP/COLLECTOR/UIUX/QA).
+
+## 1) 라벨 계약 (Cardinality = 1)
+열린 이슈/닫힌 이슈 모두 아래 4개 축을 정확히 1개씩 가진다.
+- 역할: `role/uiux | role/collector | role/develop | role/qa`
+- 상태: `status/ready | status/in-progress | status/in-review | status/in-qa | status/blocked | status/done`
+- 우선순위: `priority/p0 | priority/p1 | priority/p2`
+- 유형: `type/task | type/bug | type/chore`
+
+추가 규칙
+- `state=open`인데 `status/done`이면 위반.
+- `state=closed`면 `status/done` 필수.
+- `state=closed` + `status/done`이면 코멘트에 `[QA PASS]` 필수.
+
+## 2) 상태 전이 규칙
+기본 전이
+- `status/ready -> status/in-progress -> status/in-review -> status/in-qa -> status/done`
+
+예외
+- 외부 의존이 있을 때만 `status/blocked` 사용.
+- 차단 해소 시 즉시 원래 흐름으로 복귀.
+
+## 3) 코멘트 계약 (Machine-Readable)
+아래 코멘트는 키-값 라인을 반드시 포함한다.
+
+PM 지시 코멘트 (`[PM ...]`)
+- 필수 키: `decision:`, `next_status:`
+
+개발 완료 코멘트 (`[DEVELOP 완료 보고]`)
+- 필수 키: `report_path:`, `evidence:`, `next_status:`
+
+QA 판정 코멘트 (`[QA PASS]` 또는 `[QA FAIL]`)
+- 필수 키: `report_path:`, `evidence:`, `next_status:`
+
+자동 코멘트
+- 자동화 봇 코멘트는 `auto_key:`를 사용해 중복 게시를 방지한다.
+
+## 4) 권장 템플릿
+- `docs/templates/comments/PM_COMMAND_TEMPLATE.md`
+- `docs/templates/comments/DEVELOP_COMPLETE_TEMPLATE.md`
+- `docs/templates/comments/QA_RESULT_TEMPLATE.md`
+
+## 5) CI 검증
+워크플로
+- `.github/workflows/issue-contract-guard.yml`
+
+검증 이벤트
+- `issues` 이벤트: 라벨 cardinality / closed+done+QA PASS 검증
+- `issue_comment` 이벤트: 필수 키(`decision/report_path/evidence/next_status`) 검증
+
+운영 원칙
+- 검증 실패 시 Action은 실패한다.
+- 실패 시 이슈에 `[CONTRACT FAIL]` 안내 코멘트를 자동 남긴다(중복 방지 키 포함).

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@
 9. `08_ROLE_BASED_GIT_WORK_SYSTEM_GUIDE.md`
 10. `09_QA_TRACK_OPERATIONS.md`
 11. `10_WORKSPACE_LOCK_POLICY.md`
+12. `11_ISSUE_COMMENT_LABEL_CONTRACT.md`
 
 ## 추천 읽기 순서
 1. `00_PROJECT_OVERVIEW.md` (목표/범위/결정사항)
@@ -29,6 +30,7 @@
 9. `08_ROLE_BASED_GIT_WORK_SYSTEM_GUIDE.md` (역할별 실행 가이드)
 10. `09_QA_TRACK_OPERATIONS.md` (QA 게이트 운영 규칙)
 11. `10_WORKSPACE_LOCK_POLICY.md` (작업영역/공용파일 락 규칙)
+12. `11_ISSUE_COMMENT_LABEL_CONTRACT.md` (이슈 라벨/코멘트 자동화 계약)
 
 ## 변경 이력 규칙
 - 각 문서 상단 `문서 버전`, `최종 수정일`, `수정자`를 유지합니다.

--- a/docs/templates/comments/DEVELOP_COMPLETE_TEMPLATE.md
+++ b/docs/templates/comments/DEVELOP_COMPLETE_TEMPLATE.md
@@ -1,0 +1,7 @@
+[DEVELOP 완료 보고]
+report_path: <develop_report/..._report.md>
+evidence: <로그/아티팩트/스크린샷/액션런 링크>
+pr: <#번호 또는 URL>
+commit: <sha>
+summary: <원인 1줄 + 조치 1줄>
+next_status: <status/in-review|status/in-qa>

--- a/docs/templates/comments/PM_COMMAND_TEMPLATE.md
+++ b/docs/templates/comments/PM_COMMAND_TEMPLATE.md
@@ -1,0 +1,7 @@
+[PM 실행 지시]
+decision: <무엇을 결정/지시하는지>
+scope: <범위>
+owner: <role/uiux|role/collector|role/develop|role/qa>
+next_status: <status/in-progress|status/in-review|status/in-qa|status/blocked>
+evidence: <이슈 링크/보고서 경로/증빙 경로>
+notes: <선택>

--- a/docs/templates/comments/QA_RESULT_TEMPLATE.md
+++ b/docs/templates/comments/QA_RESULT_TEMPLATE.md
@@ -1,0 +1,15 @@
+[QA PASS]
+report_path: <QA_reports/..._report.md>
+evidence: <캡처/로그/런 링크>
+scope: <검증 범위>
+summary: <핵심 결과>
+next_status: status/done
+
+---
+
+[QA FAIL]
+report_path: <QA_reports/..._report.md>
+evidence: <캡처/로그/런 링크>
+scope: <검증 범위>
+summary: <실패 원인 1줄>
+next_status: status/in-progress


### PR DESCRIPTION
## Summary
- Add strict issue label/cardinality and comment key contract doc
- Add comment templates for PM/DEVELOP/QA
- Add Issue Contract Guard workflow for issues and issue_comment events

## Included
- docs/11_ISSUE_COMMENT_LABEL_CONTRACT.md
- docs/templates/comments/*
- .github/workflows/issue-contract-guard.yml
- docs/README.md index update