### PR TITLE
ci: add autonomous dispatch + watchdog automation

### DIFF
--- a/.github/workflows/automation-watchdog.yml
+++ b/.github/workflows/automation-watchdog.yml
@@ -1,0 +1,102 @@
+name: Automation Watchdog
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: write
+  issues: write
+
+concurrency:
+  group: automation-watchdog
+  cancel-in-progress: false
+
+jobs:
+  watchdog:
+    runs-on: ubuntu-latest
+    env:
+      PM_CYCLE_ISSUE_NUMBER: ${{ vars.PM_CYCLE_ISSUE_NUMBER }}
+      PM_MAX_IDLE_MINUTES: ${{ vars.PM_MAX_IDLE_MINUTES }}
+      INGEST_MAX_IDLE_MINUTES: ${{ vars.INGEST_MAX_IDLE_MINUTES }}
+    steps:
+      - name: Self-heal workflow idle gaps
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const now = new Date();
+
+            const pmIdleMax = Number.parseInt(process.env.PM_MAX_IDLE_MINUTES || '70', 10);
+            const ingestIdleMax = Number.parseInt(process.env.INGEST_MAX_IDLE_MINUTES || '150', 10);
+            const pmIssueNumber = Number.parseInt(process.env.PM_CYCLE_ISSUE_NUMBER || '', 10);
+
+            async function getWorkflowByName(name) {
+              const workflows = await github.paginate(github.rest.actions.listRepoWorkflows, {
+                owner,
+                repo,
+                per_page: 100,
+              });
+              return workflows.find((w) => w.name === name) || null;
+            }
+
+            async function latestRunAgeMinutes(workflowId) {
+              const runs = await github.request('GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs', {
+                owner,
+                repo,
+                workflow_id: workflowId,
+                per_page: 1,
+              });
+              if (!runs.data.workflow_runs || runs.data.workflow_runs.length === 0) return Number.POSITIVE_INFINITY;
+              const createdAt = new Date(runs.data.workflow_runs[0].created_at);
+              return Math.floor((now - createdAt) / 60000);
+            }
+
+            async function maybeDispatch(workflowName, maxIdle, reasonTag) {
+              const wf = await getWorkflowByName(workflowName);
+              if (!wf) {
+                return { workflowName, dispatched: false, reason: 'workflow_not_found' };
+              }
+              const age = await latestRunAgeMinutes(wf.id);
+              if (age <= maxIdle) {
+                return { workflowName, dispatched: false, reason: `healthy(age=${age}m<=${maxIdle}m)` };
+              }
+
+              await github.rest.actions.createWorkflowDispatch({
+                owner,
+                repo,
+                workflow_id: wf.id,
+                ref: context.ref.replace('refs/heads/', ''),
+              });
+
+              return { workflowName, dispatched: true, reason: `${reasonTag}(age=${age}m>${maxIdle}m)` };
+            }
+
+            const pmResult = await maybeDispatch('PM Cycle', pmIdleMax, 'pm_idle_self_heal');
+            const ingestResult = await maybeDispatch('Ingest Schedule', ingestIdleMax, 'ingest_idle_self_heal');
+
+            const lines = [
+              '[PM AUTO][WATCHDOG]',
+              `auto_key: watchdog-${context.runId}`,
+              `decision: PM=${pmResult.dispatched ? 'dispatch' : 'skip'}; INGEST=${ingestResult.dispatched ? 'dispatch' : 'skip'}`,
+              'next_status: status/in-progress',
+              `evidence: PM(${pmResult.reason}); INGEST(${ingestResult.reason})`,
+            ];
+
+            if (Number.isFinite(pmIssueNumber) && pmIssueNumber > 0 && (pmResult.dispatched || ingestResult.dispatched)) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: pmIssueNumber,
+                body: lines.join('\n'),
+              });
+            }
+
+            await core.summary
+              .addHeading('Automation Watchdog Result')
+              .addRaw(`PM Cycle: ${pmResult.dispatched ? 'dispatch' : 'skip'} (${pmResult.reason})\n`)
+              .addRaw(`Ingest Schedule: ${ingestResult.dispatched ? 'dispatch' : 'skip'} (${ingestResult.reason})\n`)
+              .write();

--- a/.github/workflows/autonomous-dispatch.yml
+++ b/.github/workflows/autonomous-dispatch.yml
@@ -1,0 +1,176 @@
+name: Autonomous Dispatch
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
+    inputs:
+      max_dispatch:
+        description: "Max ready issues to dispatch in this run"
+        required: false
+        default: "2"
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+  actions: write
+
+concurrency:
+  group: autonomous-dispatch
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    env:
+      MAX_DISPATCH_INPUT: ${{ github.event.inputs.max_dispatch }}
+      AUTO_DISPATCH_MAX: ${{ vars.AUTO_DISPATCH_MAX }}
+    steps:
+      - name: Dispatch ready issues by role
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            const maxDispatch = Number.parseInt(process.env.MAX_DISPATCH_INPUT || process.env.AUTO_DISPATCH_MAX || '2', 10);
+            if (!Number.isFinite(maxDispatch) || maxDispatch <= 0) {
+              core.setFailed(`Invalid maxDispatch: ${process.env.MAX_DISPATCH_INPUT || process.env.AUTO_DISPATCH_MAX}`);
+              return;
+            }
+
+            const roleMap = {
+              'role/collector': {
+                workflow: 'ingest-schedule.yml',
+                inputs: {},
+                note: 'collector ingest schedule dispatch',
+              },
+              'role/develop': {
+                workflow: 'phase1-qa.yml',
+                inputs: { with_db: 'true', with_api: 'true' },
+                note: 'develop phase1 qa dispatch',
+              },
+              'role/uiux': {
+                workflow: 'staging-smoke.yml',
+                inputs: {},
+                note: 'uiux staging smoke dispatch',
+              },
+              'role/qa': {
+                workflow: 'qa-api-contract-suite.yml',
+                inputs: {},
+                note: 'qa api contract suite dispatch',
+              },
+            };
+
+            async function setStatus(issue, toStatusLabel) {
+              const current = (issue.labels || []).map((l) => (typeof l === 'string' ? l : l.name));
+              const next = current.filter((x) => !x.startsWith('status/'));
+              next.push(toStatusLabel);
+              await github.rest.issues.setLabels({
+                owner,
+                repo,
+                issue_number: issue.number,
+                labels: next,
+              });
+              issue.labels = next.map((name) => ({ name }));
+            }
+
+            const readyIssues = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: 'open',
+              labels: 'status/ready',
+              per_page: 100,
+            });
+
+            const candidates = readyIssues
+              .filter((issue) => !issue.pull_request)
+              .map((issue) => {
+                const labels = (issue.labels || []).map((l) => (typeof l === 'string' ? l : l.name));
+                const roles = labels.filter((x) => x.startsWith('role/'));
+                return { issue, labels, roles };
+              })
+              .filter((x) => x.roles.length === 1 && roleMap[x.roles[0]])
+              .sort((a, b) => a.issue.number - b.issue.number);
+
+            const dispatched = [];
+            const skipped = [];
+
+            for (const item of candidates) {
+              if (dispatched.length >= maxDispatch) break;
+              const issueNo = item.issue.number;
+              const role = item.roles[0];
+              const target = roleMap[role];
+              const autoKey = `autonomous-dispatch-${issueNo}-${context.runId}`;
+
+              try {
+                await setStatus(item.issue, 'status/in-progress');
+
+                await github.rest.actions.createWorkflowDispatch({
+                  owner,
+                  repo,
+                  workflow_id: target.workflow,
+                  ref: context.ref.replace('refs/heads/', ''),
+                  inputs: target.inputs,
+                });
+
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: issueNo,
+                  body: [
+                    '[PM AUTO][DISPATCH]',
+                    `auto_key: ${autoKey}`,
+                    `decision: role=${role} workflow=${target.workflow}`,
+                    'next_status: status/in-progress',
+                    `evidence: actions_dispatch=${target.note}; run_id=${context.runId}`,
+                  ].join('\n'),
+                });
+
+                dispatched.push({ issue: issueNo, role, workflow: target.workflow });
+              } catch (error) {
+                try {
+                  await setStatus(item.issue, 'status/ready');
+                } catch (_) {
+                  // noop rollback best-effort
+                }
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: issueNo,
+                  body: [
+                    '[PM AUTO][DISPATCH FAILED]',
+                    `auto_key: ${autoKey}-failed`,
+                    `decision: dispatch_error role=${role}`,
+                    'next_status: status/ready',
+                    `evidence: ${error?.message || String(error)}`,
+                  ].join('\n'),
+                });
+                skipped.push({ issue: issueNo, role, reason: error?.message || String(error) });
+              }
+            }
+
+            core.summary
+              .addHeading('Autonomous Dispatch Result')
+              .addRaw(`max_dispatch=${maxDispatch}\n`)
+              .addRaw(`ready_candidates=${candidates.length}\n`)
+              .addRaw(`dispatched=${dispatched.length}\n`)
+              .addRaw(`skipped=${skipped.length}\n\n`);
+
+            if (dispatched.length > 0) {
+              core.summary.addHeading('Dispatched', 2);
+              for (const item of dispatched) {
+                core.summary.addRaw(`- #${item.issue} (${item.role}) -> ${item.workflow}\n`);
+              }
+              core.summary.addRaw('\n');
+            }
+
+            if (skipped.length > 0) {
+              core.summary.addHeading('Skipped', 2);
+              for (const item of skipped) {
+                core.summary.addRaw(`- #${item.issue} (${item.role}) reason=${item.reason}\n`);
+              }
+            }
+
+            await core.summary.write();

--- a/docs/05_RUNBOOK_AND_OPERATIONS.md
+++ b/docs/05_RUNBOOK_AND_OPERATIONS.md
@@ -362,3 +362,23 @@ scripts/qa/smoke_public_api.sh \
 - Search: alias 보정(`연수국 -> 연수구`)과 empty-state 대체 액션 노출
 - Matchup: `confirm_demo`/`source_demo`/`demo_state` 배지와 상태 카피 노출
 - Candidate: `party_demo`/`confirm_demo` 배지 노출, 미존재 후보 ID는 안전 fallback으로 렌더 유지
+
+## 15. 무인 오케스트레이션 운영
+1. 디스패치:
+- 워크플로: `autonomous-dispatch.yml`
+- 트리거: 30분 스케줄 + 수동 실행
+- 정책: `status/ready` 이슈를 역할별 파이프라인으로 자동 전달
+
+2. 워치독:
+- 워크플로: `automation-watchdog.yml`
+- 정책: `PM Cycle`과 `Ingest Schedule` 최근 실행 간격이 임계치를 넘으면 자동 self-heal dispatch
+
+3. 기본 임계값:
+- `PM_MAX_IDLE_MINUTES=70`
+- `INGEST_MAX_IDLE_MINUTES=150`
+- `AUTO_DISPATCH_MAX=2`
+
+4. 장애 시 확인 순서:
+1. `Automation Watchdog` 최근 런 결과
+2. `Autonomous Dispatch`의 dispatched/skipped 수
+3. 대상 워크플로(`PM Cycle`, `Ingest Schedule`) 최근 런 링크 확인


### PR DESCRIPTION
## Summary
- Add `autonomous-dispatch` workflow to move ready issues to in-progress and dispatch role-mapped pipelines
- Add `automation-watchdog` workflow to self-heal PM/ingest idle gaps
- Update runbook and role guide with no-human autopilot operations

## Notes
- Dispatch is capped by `AUTO_DISPATCH_MAX` (default 2)
- Watchdog thresholds use `PM_MAX_IDLE_MINUTES` and `INGEST_MAX_IDLE_MINUTES`
- Status transitions use `setLabels` to keep label cardinality contract intact