### PR TITLE
[COLLECTOR][S2] 기사 법정필수항목 completeness 스코어링 + review_queue 라우팅

### DIFF
--- a/Collector_reports/2026-02-23_S2_기사_법정필수항목_completeness_스코어링_report.md
+++ b/Collector_reports/2026-02-23_S2_기사_법정필수항목_completeness_스코어링_report.md
@@ -1,0 +1,74 @@
+# [COLLECTOR][S2] 기사 법정필수항목 completeness 스코어링 + review_queue 라우팅 보고서 (#218)
+
+## 1) 작업 목표
+- 기사 추출 레코드에 법정 필수항목 스키마 강제 적용
+- completeness score(0~1) 계산 및 threshold 정책 적용
+- threshold 미달 케이스를 review_queue로 자동 라우팅
+- 샘플 50건 추출율/누락율 리포트 생성
+
+## 2) 구현 내용
+1. 스크립트 추가
+- `scripts/generate_collector_article_legal_completeness_v1_batch50.py`
+
+2. 강제 적용 스키마(필수 6개)
+- `sponsor`
+- `pollster`
+- `survey_period`(start/end 중 1개 이상 유효 날짜)
+- `sample_size`
+- `response_rate`
+- `margin_of_error`
+
+3. 레코드별 추가 필드
+- `legal_required_schema`
+- `legal_completeness_score`
+- `legal_filled_count`
+- `legal_required_count`
+- `legal_missing_fields`
+- `legal_invalid_fields`
+- `legal_reason_code`
+
+4. 정책
+- threshold: `< 0.8` -> review_queue candidate 생성
+- review_queue payload에 `reason_code`, `missing_fields`, `invalid_fields`, `completeness_score` 저장
+
+## 3) 산출물
+- `data/collector_article_legal_completeness_v1_batch50.json`
+- `data/collector_article_legal_completeness_v1_report.json`
+- `data/collector_article_legal_completeness_v1_review_queue_candidates.json`
+
+## 4) 검증
+실행:
+```bash
+PYTHONPATH=. /Users/gimtaehun/election2026_codex/.venv/bin/pytest -q \
+  tests/test_collector_article_legal_completeness_v1_script.py \
+  tests/test_collector_extract.py
+PYTHONPATH=. /Users/gimtaehun/election2026_codex/.venv/bin/python \
+  scripts/generate_collector_article_legal_completeness_v1_batch50.py
+```
+
+결과:
+- 테스트: `14 passed`
+- 샘플: `50건`
+- threshold 미달: `50건`
+- review_queue candidate: `50건`
+
+## 5) 샘플 50건 요약
+- 평균 completeness: `0.1667`
+- 누락율
+  - sponsor: `100%`
+  - survey_period: `100%`
+  - sample_size: `100%`
+  - response_rate: `100%`
+  - margin_of_error: `100%`
+  - pollster: `0%`
+- reason_code 분포: `MISSING_SURVEY_PERIOD=50`
+
+## 6) 완료 기준 충족 여부
+- 샘플 50건 필수항목 추출율/누락율 리포트: 충족
+- threshold 미달 review_queue 자동 생성 증빙: 충족
+
+## 7) 의사결정 필요사항
+1. 현재 bootstrap source 기준 threshold 미달이 `50/50`입니다.
+- 선택 A: threshold `0.8` 유지 + 추출기 필드 보강 우선
+- 선택 B: S2 기간 임시 threshold 완화(예: `0.5`) 후 단계적 상향
+2. `survey_period` 기준을 `end_date만 있어도 유효`로 완화할지 결정 필요(현재도 end_date 유효면 통과지만 source가 공란).

--- a/data/collector_article_legal_completeness_v1_batch50.json
+++ b/data/collector_article_legal_completeness_v1_batch50.json
@@ -1,0 +1,6166 @@
+{
+  "run_type": "collector_article_legal_completeness_v1",
+  "extractor_version": "collector-legal-completeness-v1",
+  "source_payload": "data/bootstrap_ingest_coverage_v2.json",
+  "threshold": 0.8,
+  "required_fields": [
+    "sponsor",
+    "pollster",
+    "survey_period",
+    "sample_size",
+    "response_rate",
+    "margin_of_error"
+  ],
+  "records": [
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiPEFVX3lxTE56ZzduSTFSc2FmQUxiT2wzUGswSVIzcXM2Z0Z3dHRwWTNaclBRZ3RsZTBxVUx3dXN1YWQ2NdIBWEFVX3lxTE92RlNERThyckZnRmxlb2cxbFJ5WDhQX21lS2Qxb21KSkZxb2VPWkVQVU9RYnFuWHc4dDJJX3JNdGxFQXFyVm1BamU1enZHeERjcHpkN1FPb0I",
+        "title": "서울시장 여론조사 가상대결 박주민 41.9% vs 오세훈 35.3%:서울의 소리",
+        "publisher": "amn.kr",
+        "published_at": null,
+        "raw_text": "서울시장 여론조사 가상대결 박주민 41.9% vs 오세훈 35.3%:서울의 소리 - amn.kr 서울시장 여론조사 가상대결 박주민 41.9% vs 오세훈 35.3%:서울의 소리 &nbsp;&nbsp; amn.kr 지방선거 서울 송파구청장 가상대결",
+        "raw_hash": "raw_db5b144a2a790fec"
+      },
+      "region": {
+        "region_code": "11-710",
+        "sido_name": "서울특별시",
+        "sigungu_name": "송파구",
+        "admin_level": "sigungu",
+        "parent_region_code": "11-000"
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:박주민",
+          "name_ko": "박주민",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:오세훈",
+          "name_ko": "오세훈",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_8aff3ed1d23504f8",
+        "survey_name": "서울시장 여론조사 가상대결 박주민 41.9% vs 오세훈 35.3%:서울의 소리",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "region_code": "11-710",
+        "office_type": "기초자치단체장",
+        "matchup_id": "2026_local|기초자치단체장|11-710",
+        "verified": false,
+        "source_grade": "C",
+        "legal_required_schema": {
+          "sponsor": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "pollster": {
+            "value": "미상조사기관",
+            "is_present": true,
+            "is_valid": true
+          },
+          "survey_period": {
+            "value": {
+              "survey_start_date": null,
+              "survey_end_date": null
+            },
+            "is_present": false,
+            "is_valid": false
+          },
+          "sample_size": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "response_rate": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "margin_of_error": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          }
+        },
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "legal_missing_fields": [
+          "sponsor",
+          "survey_period",
+          "sample_size",
+          "response_rate",
+          "margin_of_error"
+        ],
+        "legal_invalid_fields": [],
+        "legal_reason_code": "MISSING_SURVEY_PERIOD"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "박주민",
+          "value_raw": "41.9%",
+          "value_min": 41.9,
+          "value_max": 41.9,
+          "value_mid": 41.9,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "오세훈",
+          "value_raw": "35.3%",
+          "value_min": 35.3,
+          "value_max": 35.3,
+          "value_mid": 35.3,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiRkFVX3lxTE1OME1aSlEzR1QyUkZqa2Uza2NZOC13SnJDVnpTS3hkS0o0alBjbkRFQzVvT2RKYWJsaHBQbzgweGlRQVNIdFE",
+        "title": "[6·3 지방선거 여론조사-성남시] 민주당 성남시장 후보 적합도…김병욱 36.2%로 선두",
+        "publisher": "v.daum.net",
+        "published_at": null,
+        "raw_text": "[6·3 지방선거 여론조사-성남시] 민주당 성남시장 후보 적합도…김병욱 36.2%로 선두 - v.daum.net [6·3 지방선거 여론조사-성남시] 민주당 성남시장 후보 적합도…김병욱 36.2%로 선두 &nbsp;&nbsp; v.daum.net 지방선거 경기 성남시장 여론조사",
+        "raw_hash": "raw_adcac98f574629ab"
+      },
+      "region": {
+        "region_code": "41-130",
+        "sido_name": "경기도",
+        "sigungu_name": "성남시",
+        "admin_level": "sigungu",
+        "parent_region_code": "41-000"
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:김병욱",
+          "name_ko": "김병욱",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_1beca86ca98386bb",
+        "survey_name": "[6·3 지방선거 여론조사-성남시] 민주당 성남시장 후보 적합도…김병욱 36.2%로 선두",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "region_code": "41-130",
+        "office_type": "기초자치단체장",
+        "matchup_id": "2026_local|기초자치단체장|41-130",
+        "verified": false,
+        "source_grade": "C",
+        "legal_required_schema": {
+          "sponsor": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "pollster": {
+            "value": "미상조사기관",
+            "is_present": true,
+            "is_valid": true
+          },
+          "survey_period": {
+            "value": {
+              "survey_start_date": null,
+              "survey_end_date": null
+            },
+            "is_present": false,
+            "is_valid": false
+          },
+          "sample_size": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "response_rate": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "margin_of_error": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          }
+        },
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "legal_missing_fields": [
+          "sponsor",
+          "survey_period",
+          "sample_size",
+          "response_rate",
+          "margin_of_error"
+        ],
+        "legal_invalid_fields": [],
+        "legal_reason_code": "MISSING_SURVEY_PERIOD"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "김병욱",
+          "value_raw": "36.2%",
+          "value_min": 36.2,
+          "value_max": 36.2,
+          "value_mid": 36.2,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiS0FVX3lxTE1XanN5QjNfa1BVTERQOFFnaklucmFveWtnUkFFNEY3WWFOOHM5QVFiWEE5UmE0b252UDRDQmJWeGlfWTZTaUszdTBBSQ",
+        "title": "더불어민주당 43.3% vs 국민의힘 37.2% > 뉴스데스크",
+        "publisher": "MBC 강원영동",
+        "published_at": null,
+        "raw_text": "더불어민주당 43.3% vs 국민의힘 37.2% > 뉴스데스크 - MBC 강원영동 더불어민주당 43.3% vs 국민의힘 37.2% > 뉴스데스크 &nbsp;&nbsp; MBC 강원영동 지방선거 강원 춘천시장 지지율",
+        "raw_hash": "raw_32e17b5e7c114920"
+      },
+      "region": {
+        "region_code": "42-110",
+        "sido_name": "강원특별자치도",
+        "sigungu_name": "춘천시",
+        "admin_level": "sigungu",
+        "parent_region_code": "42-000"
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:더불어민주당",
+          "name_ko": "더불어민주당",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_69b9a07a4997e975",
+        "survey_name": "더불어민주당 43.3% vs 국민의힘 37.2% > 뉴스데스크",
+        "pollster": "MBC",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "region_code": "42-110",
+        "office_type": "기초자치단체장",
+        "matchup_id": "2026_local|기초자치단체장|42-110",
+        "verified": false,
+        "source_grade": "C",
+        "legal_required_schema": {
+          "sponsor": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "pollster": {
+            "value": "MBC",
+            "is_present": true,
+            "is_valid": true
+          },
+          "survey_period": {
+            "value": {
+              "survey_start_date": null,
+              "survey_end_date": null
+            },
+            "is_present": false,
+            "is_valid": false
+          },
+          "sample_size": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "response_rate": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "margin_of_error": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          }
+        },
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "legal_missing_fields": [
+          "sponsor",
+          "survey_period",
+          "sample_size",
+          "response_rate",
+          "margin_of_error"
+        ],
+        "legal_invalid_fields": [],
+        "legal_reason_code": "MISSING_SURVEY_PERIOD"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "더불어민주당",
+          "value_raw": "43.3%",
+          "value_min": 43.3,
+          "value_max": 43.3,
+          "value_mid": 43.3,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiSEFVX3lxTE16dW16SWM5dUtrWlZ2WUlrSk5xVGhzZmRLUUhlMldBX3RiZHNjV1k5QXF2UzRmNWwtcEZuczk1NEVyNEZPa2pKRQ",
+        "title": "20251227-28 부산시장 양자 대결, 전재수48.1% 박형준35.8%, 국제신문 의뢰, 리얼미터",
+        "publisher": "티스토리",
+        "published_at": null,
+        "raw_text": "20251227-28 부산시장 양자 대결, 전재수48.1% 박형준35.8%, 국제신문 의뢰, 리얼미터 - 티스토리 20251227-28 부산시장 양자 대결, 전재수48.1% 박형준35.8%, 국제신문 의뢰, 리얼미터 &nbsp;&nbsp; 티스토리 지방선거 전남 목포시장 가상대결",
+        "raw_hash": "raw_542041b434a64312"
+      },
+      "region": {
+        "region_code": "46-110",
+        "sido_name": "전라남도",
+        "sigungu_name": "목포시",
+        "admin_level": "sigungu",
+        "parent_region_code": "46-000"
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:전재수",
+          "name_ko": "전재수",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:박형준",
+          "name_ko": "박형준",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_350f14ce7e3668fb",
+        "survey_name": "20251227-28 부산시장 양자 대결, 전재수48.1% 박형준35.8%, 국제신문 의뢰, 리얼미터",
+        "pollster": "리얼미터",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "region_code": "46-110",
+        "office_type": "기초자치단체장",
+        "matchup_id": "2026_local|기초자치단체장|46-110",
+        "verified": false,
+        "source_grade": "C",
+        "legal_required_schema": {
+          "sponsor": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "pollster": {
+            "value": "리얼미터",
+            "is_present": true,
+            "is_valid": true
+          },
+          "survey_period": {
+            "value": {
+              "survey_start_date": null,
+              "survey_end_date": null
+            },
+            "is_present": false,
+            "is_valid": false
+          },
+          "sample_size": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "response_rate": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "margin_of_error": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          }
+        },
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "legal_missing_fields": [
+          "sponsor",
+          "survey_period",
+          "sample_size",
+          "response_rate",
+          "margin_of_error"
+        ],
+        "legal_invalid_fields": [],
+        "legal_reason_code": "MISSING_SURVEY_PERIOD"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "전재수",
+          "value_raw": "48.1%",
+          "value_min": 48.1,
+          "value_max": 48.1,
+          "value_mid": 48.1,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "박형준",
+          "value_raw": "35.8%",
+          "value_min": 35.8,
+          "value_max": 35.8,
+          "value_mid": 35.8,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiU0FVX3lxTFBwUEV3THRiRXVTbW90VDBYSGF4dzcxaHNOWUhtYWZNaUYzU0hIRVdvYjhUTERXZVJ1a3hfYlB6OHJFSkNBZXZQRUJjOGZqRVh0eUFV",
+        "title": "정원오, 서울시장 가상 대결서 오세훈 4%p 앞서",
+        "publisher": "네이트",
+        "published_at": null,
+        "raw_text": "정원오, 서울시장 가상 대결서 오세훈 4%p 앞서 - 네이트 정원오, 서울시장 가상 대결서 오세훈 4%p 앞서 &nbsp;&nbsp; 네이트 지방선거 제주 제주시장 가상대결",
+        "raw_hash": "raw_8d7a7d4be1e8a9a6"
+      },
+      "region": {
+        "region_code": "50-110",
+        "sido_name": "제주특별자치도",
+        "sigungu_name": "제주시",
+        "admin_level": "sigungu",
+        "parent_region_code": "50-000"
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:오세훈",
+          "name_ko": "오세훈",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_8c8010fe1c12852a",
+        "survey_name": "정원오, 서울시장 가상 대결서 오세훈 4%p 앞서",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "region_code": "50-110",
+        "office_type": "기초자치단체장",
+        "matchup_id": "2026_local|기초자치단체장|50-110",
+        "verified": false,
+        "source_grade": "C",
+        "legal_required_schema": {
+          "sponsor": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "pollster": {
+            "value": "미상조사기관",
+            "is_present": true,
+            "is_valid": true
+          },
+          "survey_period": {
+            "value": {
+              "survey_start_date": null,
+              "survey_end_date": null
+            },
+            "is_present": false,
+            "is_valid": false
+          },
+          "sample_size": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "response_rate": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "margin_of_error": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          }
+        },
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "legal_missing_fields": [
+          "sponsor",
+          "survey_period",
+          "sample_size",
+          "response_rate",
+          "margin_of_error"
+        ],
+        "legal_invalid_fields": [],
+        "legal_reason_code": "MISSING_SURVEY_PERIOD"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "오세훈",
+          "value_raw": "4%",
+          "value_min": 4.0,
+          "value_max": 4.0,
+          "value_mid": 4.0,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiUkFVX3lxTE5pY25MWDNpREthWURTQ2FuWkRMXzUybF9NVkN2MG93Vzk2bm1KbXBpbFB3ZV85SzVMNlBWT0E5bDJsQlBfZVJYb1B2TDhJRDIzMVE",
+        "title": "부산 사상구청장 가상대결…서태경 38.1%·이대훈 24.7%·조병길 13.2%",
+        "publisher": "노컷뉴스",
+        "published_at": null,
+        "raw_text": "부산 사상구청장 가상대결…서태경 38.1%·이대훈 24.7%·조병길 13.2% - 노컷뉴스 부산 사상구청장 가상대결…서태경 38.1%·이대훈 24.7%·조병길 13.2% &nbsp;&nbsp; 노컷뉴스 지방선거 부산 사상구청장 여론조사",
+        "raw_hash": "raw_4f75a7518f13f9c9"
+      },
+      "region": {
+        "region_code": "26-530",
+        "sido_name": "부산광역시",
+        "sigungu_name": "사상구",
+        "admin_level": "sigungu",
+        "parent_region_code": "26-000"
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:서태경",
+          "name_ko": "서태경",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:이대훈",
+          "name_ko": "이대훈",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:조병길",
+          "name_ko": "조병길",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_28eb3ac87760e5d3",
+        "survey_name": "부산 사상구청장 가상대결…서태경 38.1%·이대훈 24.7%·조병길 13.2%",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "region_code": "26-530",
+        "office_type": "기초자치단체장",
+        "matchup_id": "2026_local|기초자치단체장|26-530",
+        "verified": false,
+        "source_grade": "C",
+        "legal_required_schema": {
+          "sponsor": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "pollster": {
+            "value": "미상조사기관",
+            "is_present": true,
+            "is_valid": true
+          },
+          "survey_period": {
+            "value": {
+              "survey_start_date": null,
+              "survey_end_date": null
+            },
+            "is_present": false,
+            "is_valid": false
+          },
+          "sample_size": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "response_rate": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "margin_of_error": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          }
+        },
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "legal_missing_fields": [
+          "sponsor",
+          "survey_period",
+          "sample_size",
+          "response_rate",
+          "margin_of_error"
+        ],
+        "legal_invalid_fields": [],
+        "legal_reason_code": "MISSING_SURVEY_PERIOD"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "서태경",
+          "value_raw": "38.1%",
+          "value_min": 38.1,
+          "value_max": 38.1,
+          "value_mid": 38.1,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "이대훈",
+          "value_raw": "24.7%",
+          "value_min": 24.7,
+          "value_max": 24.7,
+          "value_mid": 24.7,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "조병길",
+          "value_raw": "13.2%",
+          "value_min": 13.2,
+          "value_max": 13.2,
+          "value_mid": 13.2,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiVEFVX3lxTE4yc3BiSVh6NlJkbmVadjh4eWFleUJ2M0tYYTdkQ2pLRVhPR2dzRnNhR1lpNGZsd21XeWwwQ09nSXR1YjNBTnd2U05PY1oyaFZfOXNDMQ",
+        "title": "[뉴스1전북 여론조사] 전주시장 적합도…우범기 31%·조지훈 18.8%",
+        "publisher": "뉴스1",
+        "published_at": null,
+        "raw_text": "[뉴스1전북 여론조사] 전주시장 적합도…우범기 31%·조지훈 18.8% - 뉴스1 [뉴스1전북 여론조사] 전주시장 적합도…우범기 31%·조지훈 18.8% &nbsp;&nbsp; 뉴스1 지방선거 전북 전주시장 여론조사",
+        "raw_hash": "raw_e3c6db3ef38baa12"
+      },
+      "region": {
+        "region_code": "45-110",
+        "sido_name": "전북특별자치도",
+        "sigungu_name": "전주시",
+        "admin_level": "sigungu",
+        "parent_region_code": "45-000"
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:우범기",
+          "name_ko": "우범기",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:조지훈",
+          "name_ko": "조지훈",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_1b304a647ade54cf",
+        "survey_name": "[뉴스1전북 여론조사] 전주시장 적합도…우범기 31%·조지훈 18.8%",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "region_code": "45-110",
+        "office_type": "기초자치단체장",
+        "matchup_id": "2026_local|기초자치단체장|45-110",
+        "verified": false,
+        "source_grade": "C",
+        "legal_required_schema": {
+          "sponsor": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "pollster": {
+            "value": "미상조사기관",
+            "is_present": true,
+            "is_valid": true
+          },
+          "survey_period": {
+            "value": {
+              "survey_start_date": null,
+              "survey_end_date": null
+            },
+            "is_present": false,
+            "is_valid": false
+          },
+          "sample_size": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "response_rate": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "margin_of_error": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          }
+        },
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "legal_missing_fields": [
+          "sponsor",
+          "survey_period",
+          "sample_size",
+          "response_rate",
+          "margin_of_error"
+        ],
+        "legal_invalid_fields": [],
+        "legal_reason_code": "MISSING_SURVEY_PERIOD"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "우범기",
+          "value_raw": "31%",
+          "value_min": 31.0,
+          "value_max": 31.0,
+          "value_mid": 31.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "조지훈",
+          "value_raw": "18.8%",
+          "value_min": 18.8,
+          "value_max": 18.8,
+          "value_mid": 18.8,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiVkFVX3lxTE1xNE1xVGxjX19tSnp3NGNENUJuR0I4Q01HNUN3UkVNdEpUaUxGcVQ2RlNCaTR0MTdnOVQtNXNjckg2M3dmbzRyYkFUNTRxR0NJYkszbnZ3",
+        "title": "허태정 43.6% 이장우 42.0%…대전시장 1.6%P차 초박빙 [지방선거 여론조사]",
+        "publisher": "중앙일보",
+        "published_at": null,
+        "raw_text": "허태정 43.6% 이장우 42.0%…대전시장 1.6%P차 초박빙 [지방선거 여론조사] - 중앙일보 허태정 43.6% 이장우 42.0%…대전시장 1.6%P차 초박빙 [지방선거 여론조사] &nbsp;&nbsp; 중앙일보 지방선거 충남 천안시장 지지율",
+        "raw_hash": "raw_529f77a4908e23b4"
+      },
+      "region": {
+        "region_code": "44-130",
+        "sido_name": "충청남도",
+        "sigungu_name": "천안시",
+        "admin_level": "sigungu",
+        "parent_region_code": "44-000"
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:허태정",
+          "name_ko": "허태정",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:이장우",
+          "name_ko": "이장우",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:대전시장",
+          "name_ko": "대전시장",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_9210db1b70c7c97e",
+        "survey_name": "허태정 43.6% 이장우 42.0%…대전시장 1.6%P차 초박빙 [지방선거 여론조사]",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "region_code": "44-130",
+        "office_type": "기초자치단체장",
+        "matchup_id": "2026_local|기초자치단체장|44-130",
+        "verified": false,
+        "source_grade": "C",
+        "legal_required_schema": {
+          "sponsor": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "pollster": {
+            "value": "미상조사기관",
+            "is_present": true,
+            "is_valid": true
+          },
+          "survey_period": {
+            "value": {
+              "survey_start_date": null,
+              "survey_end_date": null
+            },
+            "is_present": false,
+            "is_valid": false
+          },
+          "sample_size": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "response_rate": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "margin_of_error": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          }
+        },
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "legal_missing_fields": [
+          "sponsor",
+          "survey_period",
+          "sample_size",
+          "response_rate",
+          "margin_of_error"
+        ],
+        "legal_invalid_fields": [],
+        "legal_reason_code": "MISSING_SURVEY_PERIOD"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "허태정",
+          "value_raw": "43.6%",
+          "value_min": 43.6,
+          "value_max": 43.6,
+          "value_mid": 43.6,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "이장우",
+          "value_raw": "42.0%",
+          "value_min": 42.0,
+          "value_max": 42.0,
+          "value_mid": 42.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "대전시장",
+          "value_raw": "1.6%",
+          "value_min": 1.6,
+          "value_max": 1.6,
+          "value_mid": 1.6,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiW0FVX3lxTE1YVHBLX2ZkX1Z1Ry1IZnRBUklqRVY1X0x1RnlVbHUtaXl6eEkyRTVUVkhaS0JIU1hhTUlJRFlLVlFXenVMdUxYMk1WTGdNQVNiSEFFbTMwcTBEUlE",
+        "title": "[6.1 지방선거 여론조사_인천광역시 교육감] 도성훈 28% vs 최계운 26.7%",
+        "publisher": "경기일보",
+        "published_at": null,
+        "raw_text": "[6.1 지방선거 여론조사_인천광역시 교육감] 도성훈 28% vs 최계운 26.7% - 경기일보 [6.1 지방선거 여론조사_인천광역시 교육감] 도성훈 28% vs 최계운 26.7% &nbsp;&nbsp; 경기일보 지방선거 인천 연수구청장 지지율",
+        "raw_hash": "raw_b3017f7b8d7839f1"
+      },
+      "region": {
+        "region_code": "28-450",
+        "sido_name": "인천광역시",
+        "sigungu_name": "연수구",
+        "admin_level": "sigungu",
+        "parent_region_code": "28-000"
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:도성훈",
+          "name_ko": "도성훈",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:최계운",
+          "name_ko": "최계운",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_019a0a0e22089be2",
+        "survey_name": "[6.1 지방선거 여론조사_인천광역시 교육감] 도성훈 28% vs 최계운 26.7%",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "region_code": "28-450",
+        "office_type": "기초자치단체장",
+        "matchup_id": "2026_local|기초자치단체장|28-450",
+        "verified": false,
+        "source_grade": "C",
+        "legal_required_schema": {
+          "sponsor": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "pollster": {
+            "value": "미상조사기관",
+            "is_present": true,
+            "is_valid": true
+          },
+          "survey_period": {
+            "value": {
+              "survey_start_date": null,
+              "survey_end_date": null
+            },
+            "is_present": false,
+            "is_valid": false
+          },
+          "sample_size": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "response_rate": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "margin_of_error": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          }
+        },
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "legal_missing_fields": [
+          "sponsor",
+          "survey_period",
+          "sample_size",
+          "response_rate",
+          "margin_of_error"
+        ],
+        "legal_invalid_fields": [],
+        "legal_reason_code": "MISSING_SURVEY_PERIOD"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "도성훈",
+          "value_raw": "28%",
+          "value_min": 28.0,
+          "value_max": 28.0,
+          "value_mid": 28.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "최계운",
+          "value_raw": "26.7%",
+          "value_min": 26.7,
+          "value_max": 26.7,
+          "value_mid": 26.7,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiW0FVX3lxTFA1OHEzY1prQ3RCa2F2Z3VvbGNBQjRTZWp1YktvUlBwek9IYVJOaDNJc0ZkbWxGQkFoUEpUeHZFTHExa1dydlZuVU9pWWdFR3lzZGgyekY2TEh3SjQ",
+        "title": "[경남 여론조사]② KBS창원 여론조사…홍남표 40.1%·허성무 29.9%…10.2%p 격차",
+        "publisher": "KBS 뉴스",
+        "published_at": null,
+        "raw_text": "[경남 여론조사]② KBS창원 여론조사…홍남표 40.1%·허성무 29.9%…10.2%p 격차 - KBS 뉴스 [경남 여론조사]② KBS창원 여론조사…홍남표 40.1%·허성무 29.9%…10.2%p 격차 &nbsp;&nbsp; KBS 뉴스 지방선거 경남 창원시장 여론조사",
+        "raw_hash": "raw_acc85d4ee74ff5a1"
+      },
+      "region": {
+        "region_code": "48-110",
+        "sido_name": "경상남도",
+        "sigungu_name": "창원시",
+        "admin_level": "sigungu",
+        "parent_region_code": "48-000"
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:홍남표",
+          "name_ko": "홍남표",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:허성무",
+          "name_ko": "허성무",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_c2a8e80898e2eb78",
+        "survey_name": "[경남 여론조사]② KBS창원 여론조사…홍남표 40.1%·허성무 29.9%…10.2%p 격차",
+        "pollster": "KBS",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "region_code": "48-110",
+        "office_type": "기초자치단체장",
+        "matchup_id": "2026_local|기초자치단체장|48-110",
+        "verified": false,
+        "source_grade": "C",
+        "legal_required_schema": {
+          "sponsor": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "pollster": {
+            "value": "KBS",
+            "is_present": true,
+            "is_valid": true
+          },
+          "survey_period": {
+            "value": {
+              "survey_start_date": null,
+              "survey_end_date": null
+            },
+            "is_present": false,
+            "is_valid": false
+          },
+          "sample_size": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "response_rate": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "margin_of_error": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          }
+        },
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "legal_missing_fields": [
+          "sponsor",
+          "survey_period",
+          "sample_size",
+          "response_rate",
+          "margin_of_error"
+        ],
+        "legal_invalid_fields": [],
+        "legal_reason_code": "MISSING_SURVEY_PERIOD"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "홍남표",
+          "value_raw": "40.1%",
+          "value_min": 40.1,
+          "value_max": 40.1,
+          "value_mid": 40.1,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "허성무",
+          "value_raw": "29.9%",
+          "value_min": 29.9,
+          "value_max": 29.9,
+          "value_mid": 29.9,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiWEFVX3lxTFA3QzZLYmNnQUdGcE5xeUZTWjBlaWFTbXc5Rl81a0xVY0FQTXlzZWthcG81dGRldDZHcTRTdDZDSVp0d1hiMlhKcmtmM2FkYUFSb2RHNzhEN3M",
+        "title": "[N2여론조사] 김병욱 적합도·지지도 모두 1위...가상대결도 김병욱 31.8% vs 박승호 26.6%",
+        "publisher": "뉴스투데이",
+        "published_at": null,
+        "raw_text": "[N2여론조사] 김병욱 적합도·지지도 모두 1위...가상대결도 김병욱 31.8% vs 박승호 26.6% - 뉴스투데이 [N2여론조사] 김병욱 적합도·지지도 모두 1위...가상대결도 김병욱 31.8% vs 박승호 26.6% &nbsp;&nbsp; 뉴스투데이 지방선거 경북 포항시장 여론조사",
+        "raw_hash": "raw_952cf9b8884e404f"
+      },
+      "region": {
+        "region_code": "47-110",
+        "sido_name": "경상북도",
+        "sigungu_name": "포항시",
+        "admin_level": "sigungu",
+        "parent_region_code": "47-000"
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:김병욱",
+          "name_ko": "김병욱",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:박승호",
+          "name_ko": "박승호",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_2abffbb597220668",
+        "survey_name": "[N2여론조사] 김병욱 적합도·지지도 모두 1위...가상대결도 김병욱 31.8% vs 박승호 26.6%",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "region_code": "47-110",
+        "office_type": "기초자치단체장",
+        "matchup_id": "2026_local|기초자치단체장|47-110",
+        "verified": false,
+        "source_grade": "C",
+        "legal_required_schema": {
+          "sponsor": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "pollster": {
+            "value": "미상조사기관",
+            "is_present": true,
+            "is_valid": true
+          },
+          "survey_period": {
+            "value": {
+              "survey_start_date": null,
+              "survey_end_date": null
+            },
+            "is_present": false,
+            "is_valid": false
+          },
+          "sample_size": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "response_rate": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "margin_of_error": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          }
+        },
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "legal_missing_fields": [
+          "sponsor",
+          "survey_period",
+          "sample_size",
+          "response_rate",
+          "margin_of_error"
+        ],
+        "legal_invalid_fields": [],
+        "legal_reason_code": "MISSING_SURVEY_PERIOD"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "김병욱",
+          "value_raw": "31.8%",
+          "value_min": 31.8,
+          "value_max": 31.8,
+          "value_mid": 31.8,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "박승호",
+          "value_raw": "26.6%",
+          "value_min": 26.6,
+          "value_max": 26.6,
+          "value_mid": 26.6,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMia0FVX3lxTE9CQWZnOGdZdzdGYWtINXdjeHZTdncxLWlEY251LWVMd3ZNbGZwRlQ3YksyT3FqVGl0M0U5VFZHX2d5clFZWlBLS2R4U2VmRjRZdnpnSkdfZ3pJamQ1X0p0aUllVFJxdC12LS1z",
+        "title": "'충북도지사 지지도' 김영환 10% 오차범위 내 1위... 2위와 단 1% 차",
+        "publisher": "BBS불교방송",
+        "published_at": null,
+        "raw_text": "'충북도지사 지지도' 김영환 10% 오차범위 내 1위... 2위와 단 1% 차 - BBS불교방송 '충북도지사 지지도' 김영환 10% 오차범위 내 1위... 2위와 단 1% 차 &nbsp;&nbsp; BBS불교방송 지방선거 충북 청주시장 지지율",
+        "raw_hash": "raw_1a9f108edab9ca43"
+      },
+      "region": {
+        "region_code": "43-110",
+        "sido_name": "충청북도",
+        "sigungu_name": "청주시",
+        "admin_level": "sigungu",
+        "parent_region_code": "43-000"
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:김영환",
+          "name_ko": "김영환",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_a8a990474f6b1bc2",
+        "survey_name": "'충북도지사 지지도' 김영환 10% 오차범위 내 1위... 2위와 단 1% 차",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "region_code": "43-110",
+        "office_type": "기초자치단체장",
+        "matchup_id": "2026_local|기초자치단체장|43-110",
+        "verified": false,
+        "source_grade": "C",
+        "legal_required_schema": {
+          "sponsor": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "pollster": {
+            "value": "미상조사기관",
+            "is_present": true,
+            "is_valid": true
+          },
+          "survey_period": {
+            "value": {
+              "survey_start_date": null,
+              "survey_end_date": null
+            },
+            "is_present": false,
+            "is_valid": false
+          },
+          "sample_size": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "response_rate": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "margin_of_error": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          }
+        },
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "legal_missing_fields": [
+          "sponsor",
+          "survey_period",
+          "sample_size",
+          "response_rate",
+          "margin_of_error"
+        ],
+        "legal_invalid_fields": [],
+        "legal_reason_code": "MISSING_SURVEY_PERIOD"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "김영환",
+          "value_raw": "10%",
+          "value_min": 10.0,
+          "value_max": 10.0,
+          "value_mid": 10.0,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiUEFVX3lxTE04cmc5WjRBVFV2THhIaW9GbXFtVXdIdnktSXdUc2Znb08yZ0xfalBmNElQVWdTd3AwOHRRMXpXSktQOEppVmVkWnFreUNHc3Rv",
+        "title": "[속보]서울시장? 오세훈 26.0%·정원오 16.4%·박주민 14.7%-여론조사공정",
+        "publisher": "문화일보",
+        "published_at": null,
+        "raw_text": "[속보]서울시장? 오세훈 26.0%·정원오 16.4%·박주민 14.7%-여론조사공정 - 문화일보 [속보]서울시장? 오세훈 26.0%·정원오 16.4%·박주민 14.7%-여론조사공정 &nbsp;&nbsp; 문화일보 지방선거 서울 종로구청장 지지율",
+        "raw_hash": "raw_cb4e718738b1ac19"
+      },
+      "region": {
+        "region_code": "11-110",
+        "sido_name": "서울특별시",
+        "sigungu_name": "종로구",
+        "admin_level": "sigungu",
+        "parent_region_code": "11-000"
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:오세훈",
+          "name_ko": "오세훈",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:정원오",
+          "name_ko": "정원오",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:박주민",
+          "name_ko": "박주민",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_570a0e3cef2d44c8",
+        "survey_name": "[속보]서울시장? 오세훈 26.0%·정원오 16.4%·박주민 14.7%-여론조사공정",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "region_code": "11-110",
+        "office_type": "기초자치단체장",
+        "matchup_id": "2026_local|기초자치단체장|11-110",
+        "verified": false,
+        "source_grade": "C",
+        "legal_required_schema": {
+          "sponsor": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "pollster": {
+            "value": "미상조사기관",
+            "is_present": true,
+            "is_valid": true
+          },
+          "survey_period": {
+            "value": {
+              "survey_start_date": null,
+              "survey_end_date": null
+            },
+            "is_present": false,
+            "is_valid": false
+          },
+          "sample_size": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "response_rate": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "margin_of_error": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          }
+        },
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "legal_missing_fields": [
+          "sponsor",
+          "survey_period",
+          "sample_size",
+          "response_rate",
+          "margin_of_error"
+        ],
+        "legal_invalid_fields": [],
+        "legal_reason_code": "MISSING_SURVEY_PERIOD"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "오세훈",
+          "value_raw": "26.0%",
+          "value_min": 26.0,
+          "value_max": 26.0,
+          "value_mid": 26.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "정원오",
+          "value_raw": "16.4%",
+          "value_min": 16.4,
+          "value_max": 16.4,
+          "value_mid": 16.4,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "박주민",
+          "value_raw": "14.7%",
+          "value_min": 14.7,
+          "value_max": 14.7,
+          "value_mid": 14.7,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiY0FVX3lxTE9fRTUxSnA0YUFrVFI0eThGODJwTHY0N3BuaTdhc3dPVVozOHo0LUlRc1BFZV9zU2FqdjltUDBRWFJWeGV4aERjbUtZZGVrcHJ3QXpGa2Z2UlBMVUZxZThwaDFTSQ",
+        "title": "[여론조사] 전재수 46.7% vs 박형준 38.4%…오차 범위 밖 우세",
+        "publisher": "쿠키뉴스",
+        "published_at": null,
+        "raw_text": "[여론조사] 전재수 46.7% vs 박형준 38.4%…오차 범위 밖 우세 - 쿠키뉴스 [여론조사] 전재수 46.7% vs 박형준 38.4%…오차 범위 밖 우세 &nbsp;&nbsp; 쿠키뉴스 지방선거 부산 해운대구청장 여론조사",
+        "raw_hash": "raw_090eb4414a0dbdad"
+      },
+      "region": {
+        "region_code": "26-350",
+        "sido_name": "부산광역시",
+        "sigungu_name": "해운대구",
+        "admin_level": "sigungu",
+        "parent_region_code": "26-000"
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:전재수",
+          "name_ko": "전재수",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:박형준",
+          "name_ko": "박형준",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_1b4cc75fe542165c",
+        "survey_name": "[여론조사] 전재수 46.7% vs 박형준 38.4%…오차 범위 밖 우세",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "region_code": "26-350",
+        "office_type": "기초자치단체장",
+        "matchup_id": "2026_local|기초자치단체장|26-350",
+        "verified": false,
+        "source_grade": "C",
+        "legal_required_schema": {
+          "sponsor": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "pollster": {
+            "value": "미상조사기관",
+            "is_present": true,
+            "is_valid": true
+          },
+          "survey_period": {
+            "value": {
+              "survey_start_date": null,
+              "survey_end_date": null
+            },
+            "is_present": false,
+            "is_valid": false
+          },
+          "sample_size": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "response_rate": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "margin_of_error": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          }
+        },
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "legal_missing_fields": [
+          "sponsor",
+          "survey_period",
+          "sample_size",
+          "response_rate",
+          "margin_of_error"
+        ],
+        "legal_invalid_fields": [],
+        "legal_reason_code": "MISSING_SURVEY_PERIOD"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "전재수",
+          "value_raw": "46.7%",
+          "value_min": 46.7,
+          "value_max": 46.7,
+          "value_mid": 46.7,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "박형준",
+          "value_raw": "38.4%",
+          "value_min": 38.4,
+          "value_max": 38.4,
+          "value_mid": 38.4,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiYEFVX3lxTE84MVZyNUFHanNWTWdid08zcWtzLU85bk5aSEw4UGFKemNqQi1LWVczWHpEZnN2TlA5a0MzbnJPckJwcFh5QTdSSThCdWluamkxa1plSWRmMEtEbV9UWS1VcNIBeEFVX3lxTE05VmZpdG9KYk1FVlRnS3JRazhQR285LWJZb3d1QlBVeDNTQ24zZXB6elkxZEJfQ2EwNWpLcGJTWmZCZEVidWN0dTI4MVI4WVhUUEVrLUVncmxMZG1pRUhGZUZISURDQ1NjbHNTZVVXN2d5N2dRWEpwdg",
+        "title": "수원시장 선호도 민주 이재준 42% '1위'…국힘 '혼전'",
+        "publisher": "뉴시스",
+        "published_at": null,
+        "raw_text": "수원시장 선호도 민주 이재준 42% '1위'…국힘 '혼전' - 뉴시스 수원시장 선호도 민주 이재준 42% '1위'…국힘 '혼전' &nbsp;&nbsp; 뉴시스 지방선거 경기 수원시장 여론조사",
+        "raw_hash": "raw_11dabaa43643e7df"
+      },
+      "region": {
+        "region_code": "41-110",
+        "sido_name": "경기도",
+        "sigungu_name": "수원시",
+        "admin_level": "sigungu",
+        "parent_region_code": "41-000"
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:이재준",
+          "name_ko": "이재준",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_e2bc30a4e716291f",
+        "survey_name": "수원시장 선호도 민주 이재준 42% '1위'…국힘 '혼전'",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "region_code": "41-110",
+        "office_type": "기초자치단체장",
+        "matchup_id": "2026_local|기초자치단체장|41-110",
+        "verified": false,
+        "source_grade": "C",
+        "legal_required_schema": {
+          "sponsor": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "pollster": {
+            "value": "미상조사기관",
+            "is_present": true,
+            "is_valid": true
+          },
+          "survey_period": {
+            "value": {
+              "survey_start_date": null,
+              "survey_end_date": null
+            },
+            "is_present": false,
+            "is_valid": false
+          },
+          "sample_size": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "response_rate": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "margin_of_error": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          }
+        },
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "legal_missing_fields": [
+          "sponsor",
+          "survey_period",
+          "sample_size",
+          "response_rate",
+          "margin_of_error"
+        ],
+        "legal_invalid_fields": [],
+        "legal_reason_code": "MISSING_SURVEY_PERIOD"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "이재준",
+          "value_raw": "42%",
+          "value_min": 42.0,
+          "value_max": 42.0,
+          "value_mid": 42.0,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiZ0FVX3lxTE1aQmVGVVEtN1o4dG1VcG04WTZGem9Vb3lxRXRfaTlONjBiVXJ4YVotTUhYX2xCWExqblNidjlhdVlGWmltVllxQmhGazRpMjhSc1pjQmVZNUNMLU92MVpOWDJpZ1Qtb0k",
+        "title": "[지선특집조사/울산] 김상욱 45.0% 김두겸 34.0%",
+        "publisher": "서귀포방송",
+        "published_at": null,
+        "raw_text": "[지선특집조사/울산] 김상욱 45.0% 김두겸 34.0% - 서귀포방송 [지선특집조사/울산] 김상욱 45.0% 김두겸 34.0% &nbsp;&nbsp; 서귀포방송 지방선거 제주 서귀포시장 지지율",
+        "raw_hash": "raw_08866debcab7b37b"
+      },
+      "region": {
+        "region_code": "50-130",
+        "sido_name": "제주특별자치도",
+        "sigungu_name": "서귀포시",
+        "admin_level": "sigungu",
+        "parent_region_code": "50-000"
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:김상욱",
+          "name_ko": "김상욱",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:김두겸",
+          "name_ko": "김두겸",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_9961c9bafbda6f30",
+        "survey_name": "[지선특집조사/울산] 김상욱 45.0% 김두겸 34.0%",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "region_code": "50-130",
+        "office_type": "기초자치단체장",
+        "matchup_id": "2026_local|기초자치단체장|50-130",
+        "verified": false,
+        "source_grade": "C",
+        "legal_required_schema": {
+          "sponsor": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "pollster": {
+            "value": "미상조사기관",
+            "is_present": true,
+            "is_valid": true
+          },
+          "survey_period": {
+            "value": {
+              "survey_start_date": null,
+              "survey_end_date": null
+            },
+            "is_present": false,
+            "is_valid": false
+          },
+          "sample_size": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "response_rate": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "margin_of_error": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          }
+        },
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "legal_missing_fields": [
+          "sponsor",
+          "survey_period",
+          "sample_size",
+          "response_rate",
+          "margin_of_error"
+        ],
+        "legal_invalid_fields": [],
+        "legal_reason_code": "MISSING_SURVEY_PERIOD"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "김상욱",
+          "value_raw": "45.0%",
+          "value_min": 45.0,
+          "value_max": 45.0,
+          "value_mid": 45.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "김두겸",
+          "value_raw": "34.0%",
+          "value_min": 34.0,
+          "value_max": 34.0,
+          "value_mid": 34.0,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMia0FVX3lxTFA5eUxUeHFPUUVBcW1vVWREb3kwSExyai1SNXpPMDR3XzJRRGNweURmYmJNbnY5dnFOR2xSYWpzNVdfZGxMVTFVRTQtR1p4b0cwSUFCblB6dkpJN2puUXdXd1dtZFNOUWpXQUJ30gFvQVVfeXFMTWY2cndSUFMzV3lBNTZmVHY0ODZ2Yzc3NndTYzFXNTZpa1pneWpaMmJmczRRRzlRM3N5TTMyVkJvbHc1OU5OZV9QM1Jmc2tJcVlRamd4Y0wyNkhManFxNDRuemUzM0NBRG5BR0pvdkdV",
+        "title": "[2022 지방선거] 인천 서구청장 여론조사 김종인 40.2% vs 강범석 38.5%",
+        "publisher": "포커스인천",
+        "published_at": null,
+        "raw_text": "[2022 지방선거] 인천 서구청장 여론조사 김종인 40.2% vs 강범석 38.5% - 포커스인천 [2022 지방선거] 인천 서구청장 여론조사 김종인 40.2% vs 강범석 38.5% &nbsp;&nbsp; 포커스인천 지방선거 인천 서구청장 여론조사",
+        "raw_hash": "raw_9191f93acb72d627"
+      },
+      "region": {
+        "region_code": "28-650",
+        "sido_name": "인천광역시",
+        "sigungu_name": "서구",
+        "admin_level": "sigungu",
+        "parent_region_code": "28-000"
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:김종인",
+          "name_ko": "김종인",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:강범석",
+          "name_ko": "강범석",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_eb296d307d9f189a",
+        "survey_name": "[2022 지방선거] 인천 서구청장 여론조사 김종인 40.2% vs 강범석 38.5%",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "region_code": "28-650",
+        "office_type": "기초자치단체장",
+        "matchup_id": "2026_local|기초자치단체장|28-650",
+        "verified": false,
+        "source_grade": "C",
+        "legal_required_schema": {
+          "sponsor": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "pollster": {
+            "value": "미상조사기관",
+            "is_present": true,
+            "is_valid": true
+          },
+          "survey_period": {
+            "value": {
+              "survey_start_date": null,
+              "survey_end_date": null
+            },
+            "is_present": false,
+            "is_valid": false
+          },
+          "sample_size": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "response_rate": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "margin_of_error": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          }
+        },
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "legal_missing_fields": [
+          "sponsor",
+          "survey_period",
+          "sample_size",
+          "response_rate",
+          "margin_of_error"
+        ],
+        "legal_invalid_fields": [],
+        "legal_reason_code": "MISSING_SURVEY_PERIOD"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "김종인",
+          "value_raw": "40.2%",
+          "value_min": 40.2,
+          "value_max": 40.2,
+          "value_mid": 40.2,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "강범석",
+          "value_raw": "38.5%",
+          "value_min": 38.5,
+          "value_max": 38.5,
+          "value_mid": 38.5,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMib0FVX3lxTE5ybFpja3JUNExzVm5vSVFzR19wX1ZZZGVSWWxXYWJnUmpyaXMxdExpRVFQM1pjVDhYSEFZVFJ3M0djek8tNml5NXlGTjlLN3lncEhfMENxUGw2dHB3RTYzMU50T1F6MEQxMFBfSUgzWdIBc0FVX3lxTE0xS0dybzFlb0o2bUgtdHdRTHNFTE5IbVNIRzRBQ1NBa1ZfUGkyTHFfc2ZsNnFsajZhZ1RWaXI1NlE2cEV1eHpyTWI2LUQwWTVRdDVkeFVnMDBqR3RuTU1kSWdRQzlpOER6d2Voc2tVNlRBX1U",
+        "title": "김동연 47.5%, 김은혜 44.8%…2.7%p 차 오차범위 내 접전[시사저널 여론조사]",
+        "publisher": "시사저널",
+        "published_at": null,
+        "raw_text": "김동연 47.5%, 김은혜 44.8%…2.7%p 차 오차범위 내 접전[시사저널 여론조사] - 시사저널 김동연 47.5%, 김은혜 44.8%…2.7%p 차 오차범위 내 접전[시사저널 여론조사] &nbsp;&nbsp; 시사저널 지방선거 경기 안산시장 가상대결",
+        "raw_hash": "raw_331221fa7655f1de"
+      },
+      "region": {
+        "region_code": "41-270",
+        "sido_name": "경기도",
+        "sigungu_name": "안산시",
+        "admin_level": "sigungu",
+        "parent_region_code": "41-000"
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:김동연",
+          "name_ko": "김동연",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:김은혜",
+          "name_ko": "김은혜",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_5425934b495c835e",
+        "survey_name": "김동연 47.5%, 김은혜 44.8%…2.7%p 차 오차범위 내 접전[시사저널 여론조사]",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "region_code": "41-270",
+        "office_type": "기초자치단체장",
+        "matchup_id": "2026_local|기초자치단체장|41-270",
+        "verified": false,
+        "source_grade": "C",
+        "legal_required_schema": {
+          "sponsor": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "pollster": {
+            "value": "미상조사기관",
+            "is_present": true,
+            "is_valid": true
+          },
+          "survey_period": {
+            "value": {
+              "survey_start_date": null,
+              "survey_end_date": null
+            },
+            "is_present": false,
+            "is_valid": false
+          },
+          "sample_size": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "response_rate": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "margin_of_error": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          }
+        },
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "legal_missing_fields": [
+          "sponsor",
+          "survey_period",
+          "sample_size",
+          "response_rate",
+          "margin_of_error"
+        ],
+        "legal_invalid_fields": [],
+        "legal_reason_code": "MISSING_SURVEY_PERIOD"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "김동연",
+          "value_raw": "47.5%",
+          "value_min": 47.5,
+          "value_max": 47.5,
+          "value_mid": 47.5,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "김은혜",
+          "value_raw": "44.8%",
+          "value_min": 44.8,
+          "value_max": 44.8,
+          "value_mid": 44.8,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMibkFVX3lxTE9tU29Yc0dzaDhTR3BHUFNsaTdhb3h6N3Z2b3M4eEFxVHBtZzYwU3BrZV9DdEdNSWoxZV8wWk1lanEwRk4yLTJucFpwNnBZQ3hZdUNfNFNWOG1SVGdRc21qZjVVY3p0UFR2NHoycjRR0gFyQVVfeXFMUDc1RnNZaFhKeVE1NXMwbUtWSDJNMmYxWWJGY09Ea1Bxb191UlRiblBVWXhwRzNRT1JIWFRuME5DeF9YTjBjRHNOOE1WMFRWVWN5Nlo3U3d2OUVlX2ZzSVJ3bTRTQ3ZjWGRGdExlQTdnV2x3",
+        "title": "[2026지방선거] 부산시장, 전재수 43.4-박형준 32.3%, 전재수 43.8%-김도읍33.2%...다자대결 전재수26.8% 선두",
+        "publisher": "폴리뉴스 Polinews",
+        "published_at": null,
+        "raw_text": "[2026지방선거] 부산시장, 전재수 43.4-박형준 32.3%, 전재수 43.8%-김도읍33.2%...다자대결 전재수26.8% 선두 - 폴리뉴스 Polinews [2026지방선거] 부산시장, 전재수 43.4-박형준 32.3%, 전재수 43.8%-김도읍33.2%...다자대결 전재수26.8% 선두 &nbsp;&nbsp; 폴리뉴스 Polinews 지방선거 부산 기장군수 여론조사",
+        "raw_hash": "raw_4cd6b2e755f5deb4"
+      },
+      "region": {
+        "region_code": "26-710",
+        "sido_name": "부산광역시",
+        "sigungu_name": "기장군",
+        "admin_level": "sigungu",
+        "parent_region_code": "26-000"
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:박형준",
+          "name_ko": "박형준",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:전재수",
+          "name_ko": "전재수",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:김도읍",
+          "name_ko": "김도읍",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_b61d10f49a5d5fdd",
+        "survey_name": "[2026지방선거] 부산시장, 전재수 43.4-박형준 32.3%, 전재수 43.8%-김도읍33.2%...다자대결 전재수26.8% 선두",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "region_code": "26-710",
+        "office_type": "기초자치단체장",
+        "matchup_id": "2026_local|기초자치단체장|26-710",
+        "verified": false,
+        "source_grade": "C",
+        "legal_required_schema": {
+          "sponsor": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "pollster": {
+            "value": "미상조사기관",
+            "is_present": true,
+            "is_valid": true
+          },
+          "survey_period": {
+            "value": {
+              "survey_start_date": null,
+              "survey_end_date": null
+            },
+            "is_present": false,
+            "is_valid": false
+          },
+          "sample_size": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "response_rate": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "margin_of_error": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          }
+        },
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "legal_missing_fields": [
+          "sponsor",
+          "survey_period",
+          "sample_size",
+          "response_rate",
+          "margin_of_error"
+        ],
+        "legal_invalid_fields": [],
+        "legal_reason_code": "MISSING_SURVEY_PERIOD"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "박형준",
+          "value_raw": "32.3%",
+          "value_min": 32.3,
+          "value_max": 32.3,
+          "value_mid": 32.3,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "전재수",
+          "value_raw": "43.8%",
+          "value_min": 43.8,
+          "value_max": 43.8,
+          "value_mid": 43.8,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "김도읍",
+          "value_raw": "33.2%",
+          "value_min": 33.2,
+          "value_max": 33.2,
+          "value_mid": 33.2,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "전재수",
+          "value_raw": "26.8%",
+          "value_min": 26.8,
+          "value_max": 26.8,
+          "value_mid": 26.8,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMic0FVX3lxTE0wV2NwN2ZtUDhIZERpUXBQWUhsOVVCVjVPcVVac3ZLMVZaM29nYWltbVBTU1VjNkV2NnlVaVQzSi1jOE1QUkVyWUpwT3l3dlYyM1BjMEt4VlFiUF93QjZ0V3F2d3BxV3NsSFJaRjVhTHpWR2s",
+        "title": "[조원씨앤아이] 서울시장 가상 1대1 대결, 정원오 40.1% vs 오세훈 37.5%",
+        "publisher": "비즈니스포스트",
+        "published_at": null,
+        "raw_text": "[조원씨앤아이] 서울시장 가상 1대1 대결, 정원오 40.1% vs 오세훈 37.5% - 비즈니스포스트 [조원씨앤아이] 서울시장 가상 1대1 대결, 정원오 40.1% vs 오세훈 37.5% &nbsp;&nbsp; 비즈니스포스트 지방선거 서울 관악구청장 가상대결",
+        "raw_hash": "raw_40aea209c2185d8c"
+      },
+      "region": {
+        "region_code": "11-620",
+        "sido_name": "서울특별시",
+        "sigungu_name": "관악구",
+        "admin_level": "sigungu",
+        "parent_region_code": "11-000"
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:정원오",
+          "name_ko": "정원오",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:오세훈",
+          "name_ko": "오세훈",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_4a3cfc6a5b3dc73a",
+        "survey_name": "[조원씨앤아이] 서울시장 가상 1대1 대결, 정원오 40.1% vs 오세훈 37.5%",
+        "pollster": "조원씨앤아이",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "region_code": "11-620",
+        "office_type": "기초자치단체장",
+        "matchup_id": "2026_local|기초자치단체장|11-620",
+        "verified": false,
+        "source_grade": "C",
+        "legal_required_schema": {
+          "sponsor": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "pollster": {
+            "value": "조원씨앤아이",
+            "is_present": true,
+            "is_valid": true
+          },
+          "survey_period": {
+            "value": {
+              "survey_start_date": null,
+              "survey_end_date": null
+            },
+            "is_present": false,
+            "is_valid": false
+          },
+          "sample_size": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "response_rate": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "margin_of_error": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          }
+        },
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "legal_missing_fields": [
+          "sponsor",
+          "survey_period",
+          "sample_size",
+          "response_rate",
+          "margin_of_error"
+        ],
+        "legal_invalid_fields": [],
+        "legal_reason_code": "MISSING_SURVEY_PERIOD"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "정원오",
+          "value_raw": "40.1%",
+          "value_min": 40.1,
+          "value_max": 40.1,
+          "value_mid": 40.1,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "오세훈",
+          "value_raw": "37.5%",
+          "value_min": 37.5,
+          "value_max": 37.5,
+          "value_mid": 37.5,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMib0FVX3lxTE96eDNvQlc1VXBmcUFkcDNCRnFMTUVvTTBCTWhuOE40d0JaSUNhMDV0RGtVLWdnNkMyNWZQdTJ0YkVrVXhUMU5aUW5yM1Q1VzBJV2tkNm5yclE5dExzV0paY0t0YTRWc0d3TkRfUzh0QQ",
+        "title": "[오산시장 여론조사] 국힘 이권재 47.2% vs 민주 장인수 32.4%",
+        "publisher": "중부일보",
+        "published_at": null,
+        "raw_text": "[오산시장 여론조사] 국힘 이권재 47.2% vs 민주 장인수 32.4% - 중부일보 [오산시장 여론조사] 국힘 이권재 47.2% vs 민주 장인수 32.4% &nbsp;&nbsp; 중부일보 지방선거 경기 용인시장 가상대결",
+        "raw_hash": "raw_4175753803010bee"
+      },
+      "region": {
+        "region_code": "41-460",
+        "sido_name": "경기도",
+        "sigungu_name": "용인시",
+        "admin_level": "sigungu",
+        "parent_region_code": "41-000"
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:이권재",
+          "name_ko": "이권재",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:장인수",
+          "name_ko": "장인수",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_6490a50035ace1dd",
+        "survey_name": "[오산시장 여론조사] 국힘 이권재 47.2% vs 민주 장인수 32.4%",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "region_code": "41-460",
+        "office_type": "기초자치단체장",
+        "matchup_id": "2026_local|기초자치단체장|41-460",
+        "verified": false,
+        "source_grade": "C",
+        "legal_required_schema": {
+          "sponsor": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "pollster": {
+            "value": "미상조사기관",
+            "is_present": true,
+            "is_valid": true
+          },
+          "survey_period": {
+            "value": {
+              "survey_start_date": null,
+              "survey_end_date": null
+            },
+            "is_present": false,
+            "is_valid": false
+          },
+          "sample_size": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "response_rate": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "margin_of_error": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          }
+        },
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "legal_missing_fields": [
+          "sponsor",
+          "survey_period",
+          "sample_size",
+          "response_rate",
+          "margin_of_error"
+        ],
+        "legal_invalid_fields": [],
+        "legal_reason_code": "MISSING_SURVEY_PERIOD"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "이권재",
+          "value_raw": "47.2%",
+          "value_min": 47.2,
+          "value_max": 47.2,
+          "value_mid": 47.2,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "장인수",
+          "value_raw": "32.4%",
+          "value_min": 32.4,
+          "value_max": 32.4,
+          "value_mid": 32.4,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiSEFVX3lxTFA1aXhpamJBU3lNS2NSMUJzLXFLS3hPR3JiYkJXaEFORTZVVXBwaUoxWXhNTzJFSXFrVXFuaURLZkZxWndxMHRSNA",
+        "title": "20260119-21 가상 양자대결, 김민석48.6% vs 오세훈32.6%, 김민석51.2% vs 나경원27.4%, 박주민45.3% vs 오세훈32.4%, 박주민46.9% vs 나경원28.1%, 정원오45.3% vs 오세훈32.1%, 정원오45.9% vs 나경원27.5%, 여론조사꽃",
+        "publisher": "티스토리",
+        "published_at": null,
+        "raw_text": "20260119-21 가상 양자대결, 김민석48.6% vs 오세훈32.6%, 김민석51.2% vs 나경원27.4%, 박주민45.3% vs 오세훈32.4%, 박주민46.9% vs 나경원28.1%, 정원오45.3% vs 오세훈32.1%, 정원오45.9% vs 나경원27.5%, 여론조사꽃 - 티스토리 20260119-21 가상 양자대결, 김민석48.6% vs 오세훈32.6%, 김민석51.2% vs 나경원27.4%, 박주민45.3% vs 오세훈32.4%, 박주민46.9% vs 나경원28.1%, 정원오45.3% vs 오세훈32.1%, 정원오45.9% vs 나경원27.5%, 여론조사꽃 &nbsp;&nbsp; 티스토리 지방선거 서울 강남구청장 가상대결",
+        "raw_hash": "raw_a8ac8041e4fff692"
+      },
+      "region": {
+        "region_code": "11-680",
+        "sido_name": "서울특별시",
+        "sigungu_name": "강남구",
+        "admin_level": "sigungu",
+        "parent_region_code": "11-000"
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:김민석",
+          "name_ko": "김민석",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:오세훈",
+          "name_ko": "오세훈",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:나경원",
+          "name_ko": "나경원",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:박주민",
+          "name_ko": "박주민",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:정원오",
+          "name_ko": "정원오",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_4f65234aef2f2255",
+        "survey_name": "20260119-21 가상 양자대결, 김민석48.6% vs 오세훈32.6%, 김민석51.2% vs 나경원27.4%, 박주민45.3% vs 오세훈32.4%, 박주민46.9% vs 나경원28.1%, 정원오45.3% vs 오세훈32.1%, 정원오45.9% vs 나경원27.5%, 여론조사꽃",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "region_code": "11-680",
+        "office_type": "기초자치단체장",
+        "matchup_id": "2026_local|기초자치단체장|11-680",
+        "verified": false,
+        "source_grade": "C",
+        "legal_required_schema": {
+          "sponsor": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "pollster": {
+            "value": "미상조사기관",
+            "is_present": true,
+            "is_valid": true
+          },
+          "survey_period": {
+            "value": {
+              "survey_start_date": null,
+              "survey_end_date": null
+            },
+            "is_present": false,
+            "is_valid": false
+          },
+          "sample_size": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "response_rate": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "margin_of_error": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          }
+        },
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "legal_missing_fields": [
+          "sponsor",
+          "survey_period",
+          "sample_size",
+          "response_rate",
+          "margin_of_error"
+        ],
+        "legal_invalid_fields": [],
+        "legal_reason_code": "MISSING_SURVEY_PERIOD"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "김민석",
+          "value_raw": "48.6%",
+          "value_min": 48.6,
+          "value_max": 48.6,
+          "value_mid": 48.6,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "오세훈",
+          "value_raw": "32.6%",
+          "value_min": 32.6,
+          "value_max": 32.6,
+          "value_mid": 32.6,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "김민석",
+          "value_raw": "51.2%",
+          "value_min": 51.2,
+          "value_max": 51.2,
+          "value_mid": 51.2,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "나경원",
+          "value_raw": "27.4%",
+          "value_min": 27.4,
+          "value_max": 27.4,
+          "value_mid": 27.4,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "박주민",
+          "value_raw": "45.3%",
+          "value_min": 45.3,
+          "value_max": 45.3,
+          "value_mid": 45.3,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "오세훈",
+          "value_raw": "32.4%",
+          "value_min": 32.4,
+          "value_max": 32.4,
+          "value_mid": 32.4,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "박주민",
+          "value_raw": "46.9%",
+          "value_min": 46.9,
+          "value_max": 46.9,
+          "value_mid": 46.9,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "나경원",
+          "value_raw": "28.1%",
+          "value_min": 28.1,
+          "value_max": 28.1,
+          "value_mid": 28.1,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "정원오",
+          "value_raw": "45.3%",
+          "value_min": 45.3,
+          "value_max": 45.3,
+          "value_mid": 45.3,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "오세훈",
+          "value_raw": "32.1%",
+          "value_min": 32.1,
+          "value_max": 32.1,
+          "value_mid": 32.1,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "정원오",
+          "value_raw": "45.9%",
+          "value_min": 45.9,
+          "value_max": 45.9,
+          "value_mid": 45.9,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "나경원",
+          "value_raw": "27.5%",
+          "value_min": 27.5,
+          "value_max": 27.5,
+          "value_mid": 27.5,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMic0FVX3lxTFB6SWZjTVVtenBZRko1RTBSUVZfQndNcmQ4cnc0UlZhVDNSY3IxaHBENmFZSTlyMS14cGtFN1dqYXEzc1g1QzR1T2NVY0RHNTNhTjRNWGFZSWZ3UHRsREdhckhpLWRXTDRtZ19fMUcyMXdFdmfSAXdBVV95cUxQTUxjaThUSlAyWHdHTE11aTRTVTdVUmFvNlZLMlo0M25tWXRTNzRYUDRQV05BSVhqR20xY1lJSHVVZVlVZVhXZnBkSThmbWZuZmNDX2R3NGdzZjBPWXN2OThJZ2dreHFWQ3l0TFZDUl9iN1pYbWE0bw",
+        "title": "[스트레이트뉴스 여론조사] 의정부시장 김원기 21.7% vs 김동근 21.6% '초접전'",
+        "publisher": "스트레이트뉴스",
+        "published_at": null,
+        "raw_text": "[스트레이트뉴스 여론조사] 의정부시장 김원기 21.7% vs 김동근 21.6% '초접전' - 스트레이트뉴스 [스트레이트뉴스 여론조사] 의정부시장 김원기 21.7% vs 김동근 21.6% '초접전' &nbsp;&nbsp; 스트레이트뉴스 지방선거 경기 부천시장 여론조사",
+        "raw_hash": "raw_131b2fb08f8cae22"
+      },
+      "region": {
+        "region_code": "41-190",
+        "sido_name": "경기도",
+        "sigungu_name": "부천시",
+        "admin_level": "sigungu",
+        "parent_region_code": "41-000"
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:김원기",
+          "name_ko": "김원기",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:김동근",
+          "name_ko": "김동근",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_28b652315fffc54c",
+        "survey_name": "[스트레이트뉴스 여론조사] 의정부시장 김원기 21.7% vs 김동근 21.6% '초접전'",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "region_code": "41-190",
+        "office_type": "기초자치단체장",
+        "matchup_id": "2026_local|기초자치단체장|41-190",
+        "verified": false,
+        "source_grade": "C",
+        "legal_required_schema": {
+          "sponsor": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "pollster": {
+            "value": "미상조사기관",
+            "is_present": true,
+            "is_valid": true
+          },
+          "survey_period": {
+            "value": {
+              "survey_start_date": null,
+              "survey_end_date": null
+            },
+            "is_present": false,
+            "is_valid": false
+          },
+          "sample_size": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "response_rate": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "margin_of_error": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          }
+        },
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "legal_missing_fields": [
+          "sponsor",
+          "survey_period",
+          "sample_size",
+          "response_rate",
+          "margin_of_error"
+        ],
+        "legal_invalid_fields": [],
+        "legal_reason_code": "MISSING_SURVEY_PERIOD"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "김원기",
+          "value_raw": "21.7%",
+          "value_min": 21.7,
+          "value_max": 21.7,
+          "value_mid": 21.7,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "김동근",
+          "value_raw": "21.6%",
+          "value_min": 21.6,
+          "value_max": 21.6,
+          "value_mid": 21.6,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMicEFVX3lxTE5SVTdnNi1DU3hFdmF1S3ZjbHdidU9tOVktNE1TZ095c2hMdmMxODNHckNxd0ZSQjVtYUZHeVg0TExGUU1jUUotdTFRUUJRZldLb1BSeTFueGhSM1p2WURuZnBUa3JHLVh3Q3FCcXJhdnM",
+        "title": "[6·3 지방선거 여론조사-시흥시] 시흥시장 임병택 27.3%-김윤식 22.3%…오차 내 박빙",
+        "publisher": "인천일보",
+        "published_at": null,
+        "raw_text": "[6·3 지방선거 여론조사-시흥시] 시흥시장 임병택 27.3%-김윤식 22.3%…오차 내 박빙 - 인천일보 [6·3 지방선거 여론조사-시흥시] 시흥시장 임병택 27.3%-김윤식 22.3%…오차 내 박빙 &nbsp;&nbsp; 인천일보 지방선거 경기 시흥시장 여론조사",
+        "raw_hash": "raw_61fe2996ee056e11"
+      },
+      "region": {
+        "region_code": "41-390",
+        "sido_name": "경기도",
+        "sigungu_name": "시흥시",
+        "admin_level": "sigungu",
+        "parent_region_code": "41-000"
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:임병택",
+          "name_ko": "임병택",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:김윤식",
+          "name_ko": "김윤식",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_f02b9da293d85f45",
+        "survey_name": "[6·3 지방선거 여론조사-시흥시] 시흥시장 임병택 27.3%-김윤식 22.3%…오차 내 박빙",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "region_code": "41-390",
+        "office_type": "기초자치단체장",
+        "matchup_id": "2026_local|기초자치단체장|41-390",
+        "verified": false,
+        "source_grade": "C",
+        "legal_required_schema": {
+          "sponsor": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "pollster": {
+            "value": "미상조사기관",
+            "is_present": true,
+            "is_valid": true
+          },
+          "survey_period": {
+            "value": {
+              "survey_start_date": null,
+              "survey_end_date": null
+            },
+            "is_present": false,
+            "is_valid": false
+          },
+          "sample_size": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "response_rate": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "margin_of_error": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          }
+        },
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "legal_missing_fields": [
+          "sponsor",
+          "survey_period",
+          "sample_size",
+          "response_rate",
+          "margin_of_error"
+        ],
+        "legal_invalid_fields": [],
+        "legal_reason_code": "MISSING_SURVEY_PERIOD"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "임병택",
+          "value_raw": "27.3%",
+          "value_min": 27.3,
+          "value_max": 27.3,
+          "value_mid": 27.3,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "김윤식",
+          "value_raw": "22.3%",
+          "value_min": 22.3,
+          "value_max": 22.3,
+          "value_mid": 22.3,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiTkFVX3lxTE9xeU1ObnV5dzM5NTF2eURUelNNWFlTcVNlR3RpSU4xNFVUWXdBQi1ZbzRIcl83ZUNnOTVxS1o5a1MzSlNzRGQzMS16R2kwQQ",
+        "title": "[춘천시장 여론조사] 육동한 33.2% vs 정광열 17.1% ::::: 기사",
+        "publisher": "춘천MBC",
+        "published_at": null,
+        "raw_text": "[춘천시장 여론조사] 육동한 33.2% vs 정광열 17.1% ::::: 기사 - 춘천MBC [춘천시장 여론조사] 육동한 33.2% vs 정광열 17.1% ::::: 기사 &nbsp;&nbsp; 춘천MBC 지방선거 강원 춘천시장 여론조사",
+        "raw_hash": "raw_7548f1fa62fa6dae"
+      },
+      "region": {
+        "region_code": "42-110",
+        "sido_name": "강원특별자치도",
+        "sigungu_name": "춘천시",
+        "admin_level": "sigungu",
+        "parent_region_code": "42-000"
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:육동한",
+          "name_ko": "육동한",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:정광열",
+          "name_ko": "정광열",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_0f7b70cba187620c",
+        "survey_name": "[춘천시장 여론조사] 육동한 33.2% vs 정광열 17.1% ::::: 기사",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "region_code": "42-110",
+        "office_type": "기초자치단체장",
+        "matchup_id": "2026_local|기초자치단체장|42-110",
+        "verified": false,
+        "source_grade": "C",
+        "legal_required_schema": {
+          "sponsor": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "pollster": {
+            "value": "미상조사기관",
+            "is_present": true,
+            "is_valid": true
+          },
+          "survey_period": {
+            "value": {
+              "survey_start_date": null,
+              "survey_end_date": null
+            },
+            "is_present": false,
+            "is_valid": false
+          },
+          "sample_size": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "response_rate": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "margin_of_error": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          }
+        },
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "legal_missing_fields": [
+          "sponsor",
+          "survey_period",
+          "sample_size",
+          "response_rate",
+          "margin_of_error"
+        ],
+        "legal_invalid_fields": [],
+        "legal_reason_code": "MISSING_SURVEY_PERIOD"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "육동한",
+          "value_raw": "33.2%",
+          "value_min": 33.2,
+          "value_max": 33.2,
+          "value_mid": 33.2,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "정광열",
+          "value_raw": "17.1%",
+          "value_min": 17.1,
+          "value_max": 17.1,
+          "value_mid": 17.1,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiVEFVX3lxTFBZZ1NjWTBJb2VFbmV1alZ0WXY5bnBzVEFrWEItMG92enpSQkpTNGtMVy12X21uUS1mUnJTeWdTM29sSHE0VGpiWjVFMXBQb3ZoR1BhbNIBWEFVX3lxTE9NRzItMGNnM3VFdmFFWHFsc2VOUU5nVXZld3BYOV9JNFZZeEZDUFlkeE9ueFZzRkN5d3NsMjBnYkg4NmVCQXIwYUZYZGp2TUxOaVdmc3VaLUs",
+        "title": "[6·1 지선 여론조사] 전북지사- 송하진 23.6% 오차범위밖 우세",
+        "publisher": "전북일보 인터넷신문",
+        "published_at": null,
+        "raw_text": "[6·1 지선 여론조사] 전북지사- 송하진 23.6% 오차범위밖 우세 - 전북일보 인터넷신문 [6·1 지선 여론조사] 전북지사- 송하진 23.6% 오차범위밖 우세 &nbsp;&nbsp; 전북일보 인터넷신문 지방선거 전북 전주시장 가상대결",
+        "raw_hash": "raw_de434067d2f144cc"
+      },
+      "region": {
+        "region_code": "45-110",
+        "sido_name": "전북특별자치도",
+        "sigungu_name": "전주시",
+        "admin_level": "sigungu",
+        "parent_region_code": "45-000"
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:송하진",
+          "name_ko": "송하진",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_ca72aacb9b35270c",
+        "survey_name": "[6·1 지선 여론조사] 전북지사- 송하진 23.6% 오차범위밖 우세",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "region_code": "45-110",
+        "office_type": "기초자치단체장",
+        "matchup_id": "2026_local|기초자치단체장|45-110",
+        "verified": false,
+        "source_grade": "C",
+        "legal_required_schema": {
+          "sponsor": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "pollster": {
+            "value": "미상조사기관",
+            "is_present": true,
+            "is_valid": true
+          },
+          "survey_period": {
+            "value": {
+              "survey_start_date": null,
+              "survey_end_date": null
+            },
+            "is_present": false,
+            "is_valid": false
+          },
+          "sample_size": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "response_rate": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "margin_of_error": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          }
+        },
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "legal_missing_fields": [
+          "sponsor",
+          "survey_period",
+          "sample_size",
+          "response_rate",
+          "margin_of_error"
+        ],
+        "legal_invalid_fields": [],
+        "legal_reason_code": "MISSING_SURVEY_PERIOD"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "송하진",
+          "value_raw": "23.6%",
+          "value_min": 23.6,
+          "value_max": 23.6,
+          "value_mid": 23.6,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiWkFVX3lxTFBtSUU5RVB3VnZEMDRzWUpNamxPNXk4WHpVR29KVVE2MDYtSFMxTTh5UWIxZ0dfcUlUVVZhVVhyYjlPeHNoYTdzam0tY2d0YUZibGRESW9MSXNoQQ",
+        "title": "[국힘 포항시장 지지도 조사] 김병욱 15.8% 박승호 14.9% 공원식 10.9% 박용선 10.5%",
+        "publisher": "경북매일",
+        "published_at": null,
+        "raw_text": "[국힘 포항시장 지지도 조사] 김병욱 15.8% 박승호 14.9% 공원식 10.9% 박용선 10.5% - 경북매일 [국힘 포항시장 지지도 조사] 김병욱 15.8% 박승호 14.9% 공원식 10.9% 박용선 10.5% &nbsp;&nbsp; 경북매일 지방선거 경북 포항시장 여론조사",
+        "raw_hash": "raw_d29d3eb6ad55711d"
+      },
+      "region": {
+        "region_code": "47-110",
+        "sido_name": "경상북도",
+        "sigungu_name": "포항시",
+        "admin_level": "sigungu",
+        "parent_region_code": "47-000"
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:김병욱",
+          "name_ko": "김병욱",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:박승호",
+          "name_ko": "박승호",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:공원식",
+          "name_ko": "공원식",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:박용선",
+          "name_ko": "박용선",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_452db4024c0a564f",
+        "survey_name": "[국힘 포항시장 지지도 조사] 김병욱 15.8% 박승호 14.9% 공원식 10.9% 박용선 10.5%",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "region_code": "47-110",
+        "office_type": "기초자치단체장",
+        "matchup_id": "2026_local|기초자치단체장|47-110",
+        "verified": false,
+        "source_grade": "C",
+        "legal_required_schema": {
+          "sponsor": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "pollster": {
+            "value": "미상조사기관",
+            "is_present": true,
+            "is_valid": true
+          },
+          "survey_period": {
+            "value": {
+              "survey_start_date": null,
+              "survey_end_date": null
+            },
+            "is_present": false,
+            "is_valid": false
+          },
+          "sample_size": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "response_rate": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "margin_of_error": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          }
+        },
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "legal_missing_fields": [
+          "sponsor",
+          "survey_period",
+          "sample_size",
+          "response_rate",
+          "margin_of_error"
+        ],
+        "legal_invalid_fields": [],
+        "legal_reason_code": "MISSING_SURVEY_PERIOD"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "김병욱",
+          "value_raw": "15.8%",
+          "value_min": 15.8,
+          "value_max": 15.8,
+          "value_mid": 15.8,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "박승호",
+          "value_raw": "14.9%",
+          "value_min": 14.9,
+          "value_max": 14.9,
+          "value_mid": 14.9,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "공원식",
+          "value_raw": "10.9%",
+          "value_min": 10.9,
+          "value_max": 10.9,
+          "value_mid": 10.9,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "박용선",
+          "value_raw": "10.5%",
+          "value_min": 10.5,
+          "value_max": 10.5,
+          "value_mid": 10.5,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMimwFBVV95cUxPMjFRclBzZnhwdWlFY1l1QU1aRHNzem5UM0kzSW9LQjVldFNHeGg5ajlkZ1MycDYzek5RbWFTLVl5RjFlTlBLSzV4LXR1M1VmdTR3akpvTEp0SkFaR3h3Q0lIdEhDR0VkOFNJRWZEYXYtNEJGcHhuTEJOTG5zSEItZG04UWNUM2JsZUJsLUJnNXZYZExjSjRfQk0wQQ",
+        "title": "[서울시장 후보 지지도] 정원오 30.8%-박주민 13.1%...정 49.0%-오 37.2%, 박 48.2%-오 35.2% - 오마이뉴스",
+        "publisher": "오마이뉴스",
+        "published_at": null,
+        "raw_text": "[서울시장 후보 지지도] 정원오 30.8%-박주민 13.1%...정 49.0%-오 37.2%, 박 48.2%-오 35.2% - 오마이뉴스 - 오마이뉴스 [서울시장 후보 지지도] 정원오 30.8%-박주민 13.1%...정 49.0%-오 37.2%, 박 48.2%-오 35.2% - 오마이뉴스 &nbsp;&nbsp; 오마이뉴스 지방선거 경기 고양시장 가상대결",
+        "raw_hash": "raw_89023a85926c8685"
+      },
+      "region": {
+        "region_code": "41-280",
+        "sido_name": "경기도",
+        "sigungu_name": "고양시",
+        "admin_level": "sigungu",
+        "parent_region_code": "41-000"
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:정원오",
+          "name_ko": "정원오",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:박주민",
+          "name_ko": "박주민",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_abb740f7fe640154",
+        "survey_name": "[서울시장 후보 지지도] 정원오 30.8%-박주민 13.1%...정 49.0%-오 37.2%, 박 48.2%-오 35.2% - 오마이뉴스",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "region_code": "41-280",
+        "office_type": "기초자치단체장",
+        "matchup_id": "2026_local|기초자치단체장|41-280",
+        "verified": false,
+        "source_grade": "C",
+        "legal_required_schema": {
+          "sponsor": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "pollster": {
+            "value": "미상조사기관",
+            "is_present": true,
+            "is_valid": true
+          },
+          "survey_period": {
+            "value": {
+              "survey_start_date": null,
+              "survey_end_date": null
+            },
+            "is_present": false,
+            "is_valid": false
+          },
+          "sample_size": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "response_rate": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "margin_of_error": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          }
+        },
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "legal_missing_fields": [
+          "sponsor",
+          "survey_period",
+          "sample_size",
+          "response_rate",
+          "margin_of_error"
+        ],
+        "legal_invalid_fields": [],
+        "legal_reason_code": "MISSING_SURVEY_PERIOD"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "정원오",
+          "value_raw": "30.8%",
+          "value_min": 30.8,
+          "value_max": 30.8,
+          "value_mid": 30.8,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "박주민",
+          "value_raw": "13.1%",
+          "value_min": 13.1,
+          "value_max": 13.1,
+          "value_mid": 13.1,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiYEFVX3lxTE1uRzhOaDNwa3IwZzl2RUdGNFZpdFVuU09Nd1VQS1F0UVZtLUdqOG5XcXNsNGxfb0gwRmllS2FxbVU5THN1ai1WLXRHVUxOY0ZzT2syakVYb3E3ME1Md05Dbw",
+        "title": "강성휘 30.5% 오차범위 밖 선두…전경선 20.7% [KBC 전남 목포시장 여론조사]",
+        "publisher": "KBC광주방송",
+        "published_at": null,
+        "raw_text": "강성휘 30.5% 오차범위 밖 선두…전경선 20.7% [KBC 전남 목포시장 여론조사] - KBC광주방송 강성휘 30.5% 오차범위 밖 선두…전경선 20.7% [KBC 전남 목포시장 여론조사] &nbsp;&nbsp; KBC광주방송 지방선거 전남 목포시장 여론조사",
+        "raw_hash": "raw_c95deb0caea61493"
+      },
+      "region": {
+        "region_code": "46-110",
+        "sido_name": "전라남도",
+        "sigungu_name": "목포시",
+        "admin_level": "sigungu",
+        "parent_region_code": "46-000"
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:강성휘",
+          "name_ko": "강성휘",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:전경선",
+          "name_ko": "전경선",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_4466ab3585586751",
+        "survey_name": "강성휘 30.5% 오차범위 밖 선두…전경선 20.7% [KBC 전남 목포시장 여론조사]",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "region_code": "46-110",
+        "office_type": "기초자치단체장",
+        "matchup_id": "2026_local|기초자치단체장|46-110",
+        "verified": false,
+        "source_grade": "C",
+        "legal_required_schema": {
+          "sponsor": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "pollster": {
+            "value": "미상조사기관",
+            "is_present": true,
+            "is_valid": true
+          },
+          "survey_period": {
+            "value": {
+              "survey_start_date": null,
+              "survey_end_date": null
+            },
+            "is_present": false,
+            "is_valid": false
+          },
+          "sample_size": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "response_rate": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "margin_of_error": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          }
+        },
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "legal_missing_fields": [
+          "sponsor",
+          "survey_period",
+          "sample_size",
+          "response_rate",
+          "margin_of_error"
+        ],
+        "legal_invalid_fields": [],
+        "legal_reason_code": "MISSING_SURVEY_PERIOD"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "강성휘",
+          "value_raw": "30.5%",
+          "value_min": 30.5,
+          "value_max": 30.5,
+          "value_mid": 30.5,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "전경선",
+          "value_raw": "20.7%",
+          "value_min": 20.7,
+          "value_max": 20.7,
+          "value_mid": 20.7,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiYEFVX3lxTE4xWmdDbjdTOGNqY2Nrb3YxZXBuWGI3Wk5JVHpPVkVXMGpTbFhJcFdwNE9YdW91SG5OcmREWmVsU2hHYXJraEFsZmRfbUU1X2plYktaZWsta096RmNLSXlwbA",
+        "title": "(지선 여론조사)⑥통합단체장 가상대결, 강훈식 41.7% 대 이장우 21.7%",
+        "publisher": "뉴스토마토",
+        "published_at": null,
+        "raw_text": "(지선 여론조사)⑥통합단체장 가상대결, 강훈식 41.7% 대 이장우 21.7% - 뉴스토마토 (지선 여론조사)⑥통합단체장 가상대결, 강훈식 41.7% 대 이장우 21.7% &nbsp;&nbsp; 뉴스토마토 지방선거 충남 천안시장 가상대결",
+        "raw_hash": "raw_00ec9ce719ecd48b"
+      },
+      "region": {
+        "region_code": "44-130",
+        "sido_name": "충청남도",
+        "sigungu_name": "천안시",
+        "admin_level": "sigungu",
+        "parent_region_code": "44-000"
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:강훈식",
+          "name_ko": "강훈식",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:이장우",
+          "name_ko": "이장우",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_99f136b9a635fd9c",
+        "survey_name": "(지선 여론조사)⑥통합단체장 가상대결, 강훈식 41.7% 대 이장우 21.7%",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "region_code": "44-130",
+        "office_type": "기초자치단체장",
+        "matchup_id": "2026_local|기초자치단체장|44-130",
+        "verified": false,
+        "source_grade": "C",
+        "legal_required_schema": {
+          "sponsor": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "pollster": {
+            "value": "미상조사기관",
+            "is_present": true,
+            "is_valid": true
+          },
+          "survey_period": {
+            "value": {
+              "survey_start_date": null,
+              "survey_end_date": null
+            },
+            "is_present": false,
+            "is_valid": false
+          },
+          "sample_size": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "response_rate": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "margin_of_error": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          }
+        },
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "legal_missing_fields": [
+          "sponsor",
+          "survey_period",
+          "sample_size",
+          "response_rate",
+          "margin_of_error"
+        ],
+        "legal_invalid_fields": [],
+        "legal_reason_code": "MISSING_SURVEY_PERIOD"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "강훈식",
+          "value_raw": "41.7%",
+          "value_min": 41.7,
+          "value_max": 41.7,
+          "value_mid": 41.7,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "이장우",
+          "value_raw": "21.7%",
+          "value_min": 21.7,
+          "value_max": 21.7,
+          "value_mid": 21.7,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiakFVX3lxTE4wZGZXMFVLN3J2UHp3azQ4QXo3djlLTlpYQW5IQTdBMjRzSVJvWTlXRGVWNDZITi14WEp1ZDR2N2w5M0NVeEt5d0UzTjAtcmM2c0g2NVk2QWNMNGRzUjBVa2hISHY4UUJhZWfSAW5BVV95cUxOT3ZlMFB2VWxXNDBzVEdEazZHdWdfZkN5MkJ6a1N3TTVCM3ZZb0hnRXZDenhhMi1uZnVBYkp2UnVVN0Nld1BFTWIzMUpjekNvcFRnZGQyVTNBanowNFFiN3FVYWRxZ09OTnB1MHRhZw",
+        "title": "[중부매일 여론조사] 민주당 전 지역 앞서… 청주 상당 41.5% 가장 높아",
+        "publisher": "중부매일",
+        "published_at": null,
+        "raw_text": "[중부매일 여론조사] 민주당 전 지역 앞서… 청주 상당 41.5% 가장 높아 - 중부매일 [중부매일 여론조사] 민주당 전 지역 앞서… 청주 상당 41.5% 가장 높아 &nbsp;&nbsp; 중부매일 지방선거 충북 청주시장 여론조사",
+        "raw_hash": "raw_7577914114efb2da"
+      },
+      "region": {
+        "region_code": "43-110",
+        "sido_name": "충청북도",
+        "sigungu_name": "청주시",
+        "admin_level": "sigungu",
+        "parent_region_code": "43-000"
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:상당",
+          "name_ko": "상당",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_95b0381df82f842f",
+        "survey_name": "[중부매일 여론조사] 민주당 전 지역 앞서… 청주 상당 41.5% 가장 높아",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "region_code": "43-110",
+        "office_type": "기초자치단체장",
+        "matchup_id": "2026_local|기초자치단체장|43-110",
+        "verified": false,
+        "source_grade": "C",
+        "legal_required_schema": {
+          "sponsor": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "pollster": {
+            "value": "미상조사기관",
+            "is_present": true,
+            "is_valid": true
+          },
+          "survey_period": {
+            "value": {
+              "survey_start_date": null,
+              "survey_end_date": null
+            },
+            "is_present": false,
+            "is_valid": false
+          },
+          "sample_size": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "response_rate": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "margin_of_error": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          }
+        },
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "legal_missing_fields": [
+          "sponsor",
+          "survey_period",
+          "sample_size",
+          "response_rate",
+          "margin_of_error"
+        ],
+        "legal_invalid_fields": [],
+        "legal_reason_code": "MISSING_SURVEY_PERIOD"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "상당",
+          "value_raw": "41.5%",
+          "value_min": 41.5,
+          "value_max": 41.5,
+          "value_mid": 41.5,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiZkFVX3lxTE9KVFFNaktfaGhib2ktZi1kU1BDdFRFNkpkMjU3V0ZvbS1ZcUlCTGtPeV9xZWdvVlNzLUFpUi11aEpDSThtRFJ6eU15ZTFDdENobTNHeGJkdHhBWmtTWEpvS2R4dzlkUQ",
+        "title": "부산시장 후보 가상 대결…전재수 40%·박형준 30%",
+        "publisher": "KBS 뉴스",
+        "published_at": null,
+        "raw_text": "부산시장 후보 가상 대결…전재수 40%·박형준 30% - KBS 뉴스 부산시장 후보 가상 대결…전재수 40%·박형준 30% &nbsp;&nbsp; KBS 뉴스 지방선거 경남 창원시장 가상대결",
+        "raw_hash": "raw_4e673a5652bd2ba7"
+      },
+      "region": {
+        "region_code": "48-110",
+        "sido_name": "경상남도",
+        "sigungu_name": "창원시",
+        "admin_level": "sigungu",
+        "parent_region_code": "48-000"
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:전재수",
+          "name_ko": "전재수",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:박형준",
+          "name_ko": "박형준",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_ab61646857088d53",
+        "survey_name": "부산시장 후보 가상 대결…전재수 40%·박형준 30%",
+        "pollster": "KBS",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "region_code": "48-110",
+        "office_type": "기초자치단체장",
+        "matchup_id": "2026_local|기초자치단체장|48-110",
+        "verified": false,
+        "source_grade": "C",
+        "legal_required_schema": {
+          "sponsor": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "pollster": {
+            "value": "KBS",
+            "is_present": true,
+            "is_valid": true
+          },
+          "survey_period": {
+            "value": {
+              "survey_start_date": null,
+              "survey_end_date": null
+            },
+            "is_present": false,
+            "is_valid": false
+          },
+          "sample_size": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "response_rate": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "margin_of_error": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          }
+        },
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "legal_missing_fields": [
+          "sponsor",
+          "survey_period",
+          "sample_size",
+          "response_rate",
+          "margin_of_error"
+        ],
+        "legal_invalid_fields": [],
+        "legal_reason_code": "MISSING_SURVEY_PERIOD"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "전재수",
+          "value_raw": "40%",
+          "value_min": 40.0,
+          "value_max": 40.0,
+          "value_mid": 40.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "박형준",
+          "value_raw": "30%",
+          "value_min": 30.0,
+          "value_max": 30.0,
+          "value_mid": 30.0,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMic0FVX3lxTE9vcmhfUVFoYXhYSWFsbW5HLXRFRnhxZDNyWXJKMWJFR05sVUIzVTFtN21TTTBldU5GWVFXa1BjVDk3YTRJNDlaQTJnOXhxQmpwT1dIaW9GSEF3NzBLZnIwZG44TGZvbzVwbEo3RFhjek81M3M",
+        "title": "[여론조사] 차기 제주도지사 지지도, '김한규 19% vs 오영훈 11%'",
+        "publisher": "헤드라인제주",
+        "published_at": null,
+        "raw_text": "[여론조사] 차기 제주도지사 지지도, '김한규 19% vs 오영훈 11%' - 헤드라인제주 [여론조사] 차기 제주도지사 지지도, '김한규 19% vs 오영훈 11%' &nbsp;&nbsp; 헤드라인제주 지방선거 제주 제주시장 지지율",
+        "raw_hash": "raw_cdc46d25d7df3018"
+      },
+      "region": {
+        "region_code": "50-110",
+        "sido_name": "제주특별자치도",
+        "sigungu_name": "제주시",
+        "admin_level": "sigungu",
+        "parent_region_code": "50-000"
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:김한규",
+          "name_ko": "김한규",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:오영훈",
+          "name_ko": "오영훈",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_d665019db527a0c8",
+        "survey_name": "[여론조사] 차기 제주도지사 지지도, '김한규 19% vs 오영훈 11%'",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "region_code": "50-110",
+        "office_type": "기초자치단체장",
+        "matchup_id": "2026_local|기초자치단체장|50-110",
+        "verified": false,
+        "source_grade": "C",
+        "legal_required_schema": {
+          "sponsor": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "pollster": {
+            "value": "미상조사기관",
+            "is_present": true,
+            "is_valid": true
+          },
+          "survey_period": {
+            "value": {
+              "survey_start_date": null,
+              "survey_end_date": null
+            },
+            "is_present": false,
+            "is_valid": false
+          },
+          "sample_size": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "response_rate": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "margin_of_error": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          }
+        },
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "legal_missing_fields": [
+          "sponsor",
+          "survey_period",
+          "sample_size",
+          "response_rate",
+          "margin_of_error"
+        ],
+        "legal_invalid_fields": [],
+        "legal_reason_code": "MISSING_SURVEY_PERIOD"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "김한규",
+          "value_raw": "19%",
+          "value_min": 19.0,
+          "value_max": 19.0,
+          "value_mid": 19.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "오영훈",
+          "value_raw": "11%",
+          "value_min": 11.0,
+          "value_max": 11.0,
+          "value_mid": 11.0,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMicEFVX3lxTE9TYVNqLXN0aW1lemlIME05b25KX09HNFYydlg1Zk9iaUgyZ2kwcG12b0tTVHRtSEZNVTBoRm1xYS1zMlVCQzZaSnVYZjJlWjNZSkI2cUZlUVZ4TlY1M1BJUUFLd09UV2hiV0taaERtbi0",
+        "title": "[여론조사] 인천시장 양자대결 박찬대 51.2%, 유정복 37.1% 오차 밖 앞서",
+        "publisher": "인천투데이",
+        "published_at": null,
+        "raw_text": "[여론조사] 인천시장 양자대결 박찬대 51.2%, 유정복 37.1% 오차 밖 앞서 - 인천투데이 [여론조사] 인천시장 양자대결 박찬대 51.2%, 유정복 37.1% 오차 밖 앞서 &nbsp;&nbsp; 인천투데이 지방선거 인천 연수구청장 여론조사",
+        "raw_hash": "raw_b0e1a45d89cbf8ad"
+      },
+      "region": {
+        "region_code": "28-450",
+        "sido_name": "인천광역시",
+        "sigungu_name": "연수구",
+        "admin_level": "sigungu",
+        "parent_region_code": "28-000"
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:박찬대",
+          "name_ko": "박찬대",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:유정복",
+          "name_ko": "유정복",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_8dc5d149038ab97c",
+        "survey_name": "[여론조사] 인천시장 양자대결 박찬대 51.2%, 유정복 37.1% 오차 밖 앞서",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "region_code": "28-450",
+        "office_type": "기초자치단체장",
+        "matchup_id": "2026_local|기초자치단체장|28-450",
+        "verified": false,
+        "source_grade": "C",
+        "legal_required_schema": {
+          "sponsor": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "pollster": {
+            "value": "미상조사기관",
+            "is_present": true,
+            "is_valid": true
+          },
+          "survey_period": {
+            "value": {
+              "survey_start_date": null,
+              "survey_end_date": null
+            },
+            "is_present": false,
+            "is_valid": false
+          },
+          "sample_size": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "response_rate": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "margin_of_error": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          }
+        },
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "legal_missing_fields": [
+          "sponsor",
+          "survey_period",
+          "sample_size",
+          "response_rate",
+          "margin_of_error"
+        ],
+        "legal_invalid_fields": [],
+        "legal_reason_code": "MISSING_SURVEY_PERIOD"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "박찬대",
+          "value_raw": "51.2%",
+          "value_min": 51.2,
+          "value_max": 51.2,
+          "value_mid": 51.2,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "유정복",
+          "value_raw": "37.1%",
+          "value_min": 37.1,
+          "value_max": 37.1,
+          "value_mid": 37.1,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMia0FVX3lxTE5rV1JFMFR0SkxfYlpaYkdnX1NtV1prMG9wSnV5aXRzZjJyMUVVWTg4cGx6NE45QlQ4RXE0anZDcWFwdGc1VldURDk5RENTcnRkQ2g4RjdfTDFYQkJhWkYtOFROWUZVZldWOFlF",
+        "title": "1%p에 숨은 민심의 향배… 공주시장 선거 ‘실리 투표’ 좌우",
+        "publisher": "디트NEWS24",
+        "published_at": null,
+        "raw_text": "1%p에 숨은 민심의 향배… 공주시장 선거 ‘실리 투표’ 좌우 - 디트NEWS24 1%p에 숨은 민심의 향배… 공주시장 선거 ‘실리 투표’ 좌우 &nbsp;&nbsp; 디트NEWS24 지방선거 충남 천안시장 가상대결",
+        "raw_hash": "raw_a78b5b6f9735f416"
+      },
+      "region": {
+        "region_code": "44-130",
+        "sido_name": "충청남도",
+        "sigungu_name": "천안시",
+        "admin_level": "sigungu",
+        "parent_region_code": "44-000"
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:가상대결",
+          "name_ko": "가상대결",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_abd5a820705a0c85",
+        "survey_name": "1%p에 숨은 민심의 향배… 공주시장 선거 ‘실리 투표’ 좌우",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "region_code": "44-130",
+        "office_type": "기초자치단체장",
+        "matchup_id": "2026_local|기초자치단체장|44-130",
+        "verified": false,
+        "source_grade": "C",
+        "legal_required_schema": {
+          "sponsor": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "pollster": {
+            "value": "미상조사기관",
+            "is_present": true,
+            "is_valid": true
+          },
+          "survey_period": {
+            "value": {
+              "survey_start_date": null,
+              "survey_end_date": null
+            },
+            "is_present": false,
+            "is_valid": false
+          },
+          "sample_size": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "response_rate": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "margin_of_error": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          }
+        },
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "legal_missing_fields": [
+          "sponsor",
+          "survey_period",
+          "sample_size",
+          "response_rate",
+          "margin_of_error"
+        ],
+        "legal_invalid_fields": [],
+        "legal_reason_code": "MISSING_SURVEY_PERIOD"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "가상대결",
+          "value_raw": "1%",
+          "value_min": 1.0,
+          "value_max": 1.0,
+          "value_mid": 1.0,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMia0FVX3lxTE9RaTBaY1Qtc1A4RUlBQjJsSTZ4RnFfejV3MWlyZ1hhdFFBNjBQZGxCRzFTQVdMZlBhM0FjYnJCVDFQYVdiQzg3cHprdlRqT2RkbEpQTlk5S2VnaGZKS0pneTJZbDhZVF9mYlJr",
+        "title": "목포시장 적합도 3%이내 초접전…박홍률 18%·강성휘 16%·배종호 15%",
+        "publisher": "프레시안",
+        "published_at": null,
+        "raw_text": "목포시장 적합도 3%이내 초접전…박홍률 18%·강성휘 16%·배종호 15% - 프레시안 목포시장 적합도 3%이내 초접전…박홍률 18%·강성휘 16%·배종호 15% &nbsp;&nbsp; 프레시안 지방선거 전남 목포시장 여론조사",
+        "raw_hash": "raw_620a971f46d55a1a"
+      },
+      "region": {
+        "region_code": "46-110",
+        "sido_name": "전라남도",
+        "sigungu_name": "목포시",
+        "admin_level": "sigungu",
+        "parent_region_code": "46-000"
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:적합도",
+          "name_ko": "적합도",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:박홍률",
+          "name_ko": "박홍률",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:강성휘",
+          "name_ko": "강성휘",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:배종호",
+          "name_ko": "배종호",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_267a35b25c0310e6",
+        "survey_name": "목포시장 적합도 3%이내 초접전…박홍률 18%·강성휘 16%·배종호 15%",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "region_code": "46-110",
+        "office_type": "기초자치단체장",
+        "matchup_id": "2026_local|기초자치단체장|46-110",
+        "verified": false,
+        "source_grade": "C",
+        "legal_required_schema": {
+          "sponsor": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "pollster": {
+            "value": "미상조사기관",
+            "is_present": true,
+            "is_valid": true
+          },
+          "survey_period": {
+            "value": {
+              "survey_start_date": null,
+              "survey_end_date": null
+            },
+            "is_present": false,
+            "is_valid": false
+          },
+          "sample_size": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "response_rate": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "margin_of_error": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          }
+        },
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "legal_missing_fields": [
+          "sponsor",
+          "survey_period",
+          "sample_size",
+          "response_rate",
+          "margin_of_error"
+        ],
+        "legal_invalid_fields": [],
+        "legal_reason_code": "MISSING_SURVEY_PERIOD"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "적합도",
+          "value_raw": "3%",
+          "value_min": 3.0,
+          "value_max": 3.0,
+          "value_mid": 3.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "박홍률",
+          "value_raw": "18%",
+          "value_min": 18.0,
+          "value_max": 18.0,
+          "value_mid": 18.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "강성휘",
+          "value_raw": "16%",
+          "value_min": 16.0,
+          "value_max": 16.0,
+          "value_mid": 16.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "배종호",
+          "value_raw": "15%",
+          "value_min": 15.0,
+          "value_max": 15.0,
+          "value_mid": 15.0,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiakFVX3lxTE96dFJCbG1saGdROTh2XzBiTC1JWmVadFNRNkxGc3hsUk1ObDBHR3ZUUTJIclZGWVRxejZpNVlmeXU3WEJfZDduTU1DaWNyLVBXVFNBb2JNcDhQbmFENEtaVXFJZUdiLUx3OFE",
+        "title": "[전북제일신문 여론조사] 전주시장 선거, 우범기 26.2% vs 조지훈 20.2%… ‘오차범위 내 접전’",
+        "publisher": "전북제일신문",
+        "published_at": null,
+        "raw_text": "[전북제일신문 여론조사] 전주시장 선거, 우범기 26.2% vs 조지훈 20.2%… ‘오차범위 내 접전’ - 전북제일신문 [전북제일신문 여론조사] 전주시장 선거, 우범기 26.2% vs 조지훈 20.2%… ‘오차범위 내 접전’ &nbsp;&nbsp; 전북제일신문 지방선거 전북 전주시장 여론조사",
+        "raw_hash": "raw_d9bbb998e5887cd4"
+      },
+      "region": {
+        "region_code": "45-110",
+        "sido_name": "전북특별자치도",
+        "sigungu_name": "전주시",
+        "admin_level": "sigungu",
+        "parent_region_code": "45-000"
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:우범기",
+          "name_ko": "우범기",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:조지훈",
+          "name_ko": "조지훈",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_ca5a62c853918c7d",
+        "survey_name": "[전북제일신문 여론조사] 전주시장 선거, 우범기 26.2% vs 조지훈 20.2%… ‘오차범위 내 접전’",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "region_code": "45-110",
+        "office_type": "기초자치단체장",
+        "matchup_id": "2026_local|기초자치단체장|45-110",
+        "verified": false,
+        "source_grade": "C",
+        "legal_required_schema": {
+          "sponsor": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "pollster": {
+            "value": "미상조사기관",
+            "is_present": true,
+            "is_valid": true
+          },
+          "survey_period": {
+            "value": {
+              "survey_start_date": null,
+              "survey_end_date": null
+            },
+            "is_present": false,
+            "is_valid": false
+          },
+          "sample_size": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "response_rate": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "margin_of_error": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          }
+        },
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "legal_missing_fields": [
+          "sponsor",
+          "survey_period",
+          "sample_size",
+          "response_rate",
+          "margin_of_error"
+        ],
+        "legal_invalid_fields": [],
+        "legal_reason_code": "MISSING_SURVEY_PERIOD"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "우범기",
+          "value_raw": "26.2%",
+          "value_min": 26.2,
+          "value_max": 26.2,
+          "value_mid": 26.2,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "조지훈",
+          "value_raw": "20.2%",
+          "value_min": 20.2,
+          "value_max": 20.2,
+          "value_mid": 20.2,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMib0FVX3lxTE9hSmNUcHRHczB6dUJMb1dQdVFGWURiZkwtT185Z3NPREM2SEhhUVR3em40MC1Bb1RrWVQ0QW5EcFRrWDNMMDlUamF6WG5jMEpPYTdyQWE0alFkVlBrUDNEN1BlRHNfaEx2UG5sZ3lIc9IBc0FVX3lxTFBpckNUaTJsNWJoWTF2VWswYXp2cEVCSDBkLXRhekxwR3NldGhTZ1dNLUYtRDRQVDZ4NnhhUmRESkc1ek1EbEVKNmlDVEZjZGg3V1Y0OWtvNm8xZ1BUYnNzajIwVTVwME9Db0NNUzJEQVMyekE",
+        "title": "청주시장 여야 선거 '안개 정국'…부동층 60% 4개 구별 민심은",
+        "publisher": "충청뉴스라인",
+        "published_at": null,
+        "raw_text": "청주시장 여야 선거 '안개 정국'…부동층 60% 4개 구별 민심은 - 충청뉴스라인 청주시장 여야 선거 '안개 정국'…부동층 60% 4개 구별 민심은 &nbsp;&nbsp; 충청뉴스라인 지방선거 충북 청주시장 지지율",
+        "raw_hash": "raw_fb41a3d763a9c561"
+      },
+      "region": {
+        "region_code": "43-110",
+        "sido_name": "충청북도",
+        "sigungu_name": "청주시",
+        "admin_level": "sigungu",
+        "parent_region_code": "43-000"
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:부동층",
+          "name_ko": "부동층",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_10bff193dbeab2c2",
+        "survey_name": "청주시장 여야 선거 '안개 정국'…부동층 60% 4개 구별 민심은",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "region_code": "43-110",
+        "office_type": "기초자치단체장",
+        "matchup_id": "2026_local|기초자치단체장|43-110",
+        "verified": false,
+        "source_grade": "C",
+        "legal_required_schema": {
+          "sponsor": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "pollster": {
+            "value": "미상조사기관",
+            "is_present": true,
+            "is_valid": true
+          },
+          "survey_period": {
+            "value": {
+              "survey_start_date": null,
+              "survey_end_date": null
+            },
+            "is_present": false,
+            "is_valid": false
+          },
+          "sample_size": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "response_rate": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "margin_of_error": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          }
+        },
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "legal_missing_fields": [
+          "sponsor",
+          "survey_period",
+          "sample_size",
+          "response_rate",
+          "margin_of_error"
+        ],
+        "legal_invalid_fields": [],
+        "legal_reason_code": "MISSING_SURVEY_PERIOD"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "부동층",
+          "value_raw": "60%",
+          "value_min": 60.0,
+          "value_max": 60.0,
+          "value_mid": 60.0,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMibEFVX3lxTFB4a1kyeXpHZGEwQUQ2TlBXMkVhdFlmVVMzNzE4Y280SUVtQThUb2t0ZkVCVnAtTW81emxZLUpLb3BfdVV4MFgyX3ZPZ29xSndCdlBMSUJ6OGNnMlNzTFk3U3NmMWFiZDNNd1FoXw",
+        "title": "[6.3 지방선거, 경산시] 국민의힘 경산시장 후보 지지도, 조현일 40.8%, 유윤선 12.7%, 이철식 7.5%",
+        "publisher": "everynews.co.kr",
+        "published_at": null,
+        "raw_text": "[6.3 지방선거, 경산시] 국민의힘 경산시장 후보 지지도, 조현일 40.8%, 유윤선 12.7%, 이철식 7.5% - everynews.co.kr [6.3 지방선거, 경산시] 국민의힘 경산시장 후보 지지도, 조현일 40.8%, 유윤선 12.7%, 이철식 7.5% &nbsp;&nbsp; everynews.co.kr 지방선거 경북 포항시장 가상대결",
+        "raw_hash": "raw_7c132993d72fc40c"
+      },
+      "region": {
+        "region_code": "47-110",
+        "sido_name": "경상북도",
+        "sigungu_name": "포항시",
+        "admin_level": "sigungu",
+        "parent_region_code": "47-000"
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:조현일",
+          "name_ko": "조현일",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:유윤선",
+          "name_ko": "유윤선",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:이철식",
+          "name_ko": "이철식",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_9d3ae556e5c1176c",
+        "survey_name": "[6.3 지방선거, 경산시] 국민의힘 경산시장 후보 지지도, 조현일 40.8%, 유윤선 12.7%, 이철식 7.5%",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "region_code": "47-110",
+        "office_type": "기초자치단체장",
+        "matchup_id": "2026_local|기초자치단체장|47-110",
+        "verified": false,
+        "source_grade": "C",
+        "legal_required_schema": {
+          "sponsor": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "pollster": {
+            "value": "미상조사기관",
+            "is_present": true,
+            "is_valid": true
+          },
+          "survey_period": {
+            "value": {
+              "survey_start_date": null,
+              "survey_end_date": null
+            },
+            "is_present": false,
+            "is_valid": false
+          },
+          "sample_size": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "response_rate": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "margin_of_error": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          }
+        },
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "legal_missing_fields": [
+          "sponsor",
+          "survey_period",
+          "sample_size",
+          "response_rate",
+          "margin_of_error"
+        ],
+        "legal_invalid_fields": [],
+        "legal_reason_code": "MISSING_SURVEY_PERIOD"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "조현일",
+          "value_raw": "40.8%",
+          "value_min": 40.8,
+          "value_max": 40.8,
+          "value_mid": 40.8,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "유윤선",
+          "value_raw": "12.7%",
+          "value_min": 12.7,
+          "value_max": 12.7,
+          "value_mid": 12.7,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "이철식",
+          "value_raw": "7.5%",
+          "value_min": 7.5,
+          "value_max": 7.5,
+          "value_mid": 7.5,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMibkFVX3lxTE13dHFYekJqODh4ZWhRMXJsM3JGNmRfUWlfM1ZBSVAteTZMVUZDZkJkUGRMbXhUbmRJaFBuUzZZVkVUVTd4ODlPeUpESDU5dVNTVjJnbjZBRERlZEVqMVhDSDgzWDFyU21RclBhdFV30gFyQVVfeXFMT0ZhbmdvTTVUd1ZYWEhLVFJ4RUVsZnkxWFNKUnFHLXAtbEFRbHRlLVZET0lHRTY0V0dQSWVuYl9vSjlBRnZ5UEw1LXVxdW9FNXgtUnlsV2xYWGgzSHZfS291RnNaUXJNMkg0cUM2UnhUUzRR",
+        "title": "[2026지방선거] 경남지사, 가상대결 민주당 김경수 38.1%, 국힘 박완수 38.3%로 초접전",
+        "publisher": "폴리뉴스 Polinews",
+        "published_at": null,
+        "raw_text": "[2026지방선거] 경남지사, 가상대결 민주당 김경수 38.1%, 국힘 박완수 38.3%로 초접전 - 폴리뉴스 Polinews [2026지방선거] 경남지사, 가상대결 민주당 김경수 38.1%, 국힘 박완수 38.3%로 초접전 &nbsp;&nbsp; 폴리뉴스 Polinews 지방선거 경남 창원시장 가상대결",
+        "raw_hash": "raw_444d6d624175cd7d"
+      },
+      "region": {
+        "region_code": "48-110",
+        "sido_name": "경상남도",
+        "sigungu_name": "창원시",
+        "admin_level": "sigungu",
+        "parent_region_code": "48-000"
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:김경수",
+          "name_ko": "김경수",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:박완수",
+          "name_ko": "박완수",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_dce561b2d5190dbd",
+        "survey_name": "[2026지방선거] 경남지사, 가상대결 민주당 김경수 38.1%, 국힘 박완수 38.3%로 초접전",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "region_code": "48-110",
+        "office_type": "기초자치단체장",
+        "matchup_id": "2026_local|기초자치단체장|48-110",
+        "verified": false,
+        "source_grade": "C",
+        "legal_required_schema": {
+          "sponsor": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "pollster": {
+            "value": "미상조사기관",
+            "is_present": true,
+            "is_valid": true
+          },
+          "survey_period": {
+            "value": {
+              "survey_start_date": null,
+              "survey_end_date": null
+            },
+            "is_present": false,
+            "is_valid": false
+          },
+          "sample_size": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "response_rate": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "margin_of_error": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          }
+        },
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "legal_missing_fields": [
+          "sponsor",
+          "survey_period",
+          "sample_size",
+          "response_rate",
+          "margin_of_error"
+        ],
+        "legal_invalid_fields": [],
+        "legal_reason_code": "MISSING_SURVEY_PERIOD"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "김경수",
+          "value_raw": "38.1%",
+          "value_min": 38.1,
+          "value_max": 38.1,
+          "value_mid": 38.1,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "박완수",
+          "value_raw": "38.3%",
+          "value_min": 38.3,
+          "value_max": 38.3,
+          "value_mid": 38.3,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMid0FVX3lxTE1LVDNVWnh6TjVlamhFRnMyT0ZWUzFMYnFSaXdlTTRQeHlQMk5pVTVpaGlCT2l3WDhvanhKRDYtTnJ1NE5CaVZWUW1oSTNCZXFlbEpyY3JRd0U1WDhxUi16cTc5bWdUaDdwWVpReTg3bG5hbGFiMG9r",
+        "title": "[강원도지사] 이광재 49.5%-김진태 37.0%...우상호 46.3%-김진태 38.1%",
+        "publisher": "오마이뉴스",
+        "published_at": null,
+        "raw_text": "[강원도지사] 이광재 49.5%-김진태 37.0%...우상호 46.3%-김진태 38.1% - 오마이뉴스 [강원도지사] 이광재 49.5%-김진태 37.0%...우상호 46.3%-김진태 38.1% &nbsp;&nbsp; 오마이뉴스 지방선거 강원 춘천시장 가상대결",
+        "raw_hash": "raw_112f9d6489caecef"
+      },
+      "region": {
+        "region_code": "42-110",
+        "sido_name": "강원특별자치도",
+        "sigungu_name": "춘천시",
+        "admin_level": "sigungu",
+        "parent_region_code": "42-000"
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:이광재",
+          "name_ko": "이광재",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:김진태",
+          "name_ko": "김진태",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:우상호",
+          "name_ko": "우상호",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_e1bbab6ef90f2035",
+        "survey_name": "[강원도지사] 이광재 49.5%-김진태 37.0%...우상호 46.3%-김진태 38.1%",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "region_code": "42-110",
+        "office_type": "기초자치단체장",
+        "matchup_id": "2026_local|기초자치단체장|42-110",
+        "verified": false,
+        "source_grade": "C",
+        "legal_required_schema": {
+          "sponsor": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "pollster": {
+            "value": "미상조사기관",
+            "is_present": true,
+            "is_valid": true
+          },
+          "survey_period": {
+            "value": {
+              "survey_start_date": null,
+              "survey_end_date": null
+            },
+            "is_present": false,
+            "is_valid": false
+          },
+          "sample_size": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "response_rate": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "margin_of_error": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          }
+        },
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "legal_missing_fields": [
+          "sponsor",
+          "survey_period",
+          "sample_size",
+          "response_rate",
+          "margin_of_error"
+        ],
+        "legal_invalid_fields": [],
+        "legal_reason_code": "MISSING_SURVEY_PERIOD"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "이광재",
+          "value_raw": "49.5%",
+          "value_min": 49.5,
+          "value_max": 49.5,
+          "value_mid": 49.5,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "김진태",
+          "value_raw": "37.0%",
+          "value_min": 37.0,
+          "value_max": 37.0,
+          "value_mid": 37.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "우상호",
+          "value_raw": "46.3%",
+          "value_min": 46.3,
+          "value_max": 46.3,
+          "value_mid": 46.3,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "김진태",
+          "value_raw": "38.1%",
+          "value_min": 38.1,
+          "value_max": 38.1,
+          "value_mid": 38.1,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMic0FVX3lxTFBVYXlraGpwNnV1cG03cUptT1RVMzh5djQtUlhTaUU4TGl2RDROODE3d0ZNNWFOV2hIQ0Zib2NhS0tfT3J4QlZ6N0d4V1hDbENQbUhRM29zQklsRTZJMnN1Wksxem5QRnRUSXlRdFh4VDBRU2vSAXdBVV95cUxQdTgzNm1GNUxYZUkxMHBaX1VQWnp5ZXJGZExxMm8xVVlyeGlWcWxlYV9RVGJTWi1VOGljVzdFeUxVM3FqcGs1OWM5d043MWxibldsQm5aaWF1MDlYdDlkaUdQT0JVSXpGSnRMTXRrUjZNeEFtdUh2UQ",
+        "title": "'40% 벽'에 막힌 박형준… 전재수, 양자대결 8.3%p 앞서",
+        "publisher": "시사매거진",
+        "published_at": null,
+        "raw_text": "'40% 벽'에 막힌 박형준… 전재수, 양자대결 8.3%p 앞서 - 시사매거진 '40% 벽'에 막힌 박형준… 전재수, 양자대결 8.3%p 앞서 &nbsp;&nbsp; 시사매거진 지방선거 부산 해운대구청장 여론조사",
+        "raw_hash": "raw_4f9259fcba691920"
+      },
+      "region": {
+        "region_code": "26-350",
+        "sido_name": "부산광역시",
+        "sigungu_name": "해운대구",
+        "admin_level": "sigungu",
+        "parent_region_code": "26-000"
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:양자대결",
+          "name_ko": "양자대결",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_d341b16da9bbd2f8",
+        "survey_name": "'40% 벽'에 막힌 박형준… 전재수, 양자대결 8.3%p 앞서",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "region_code": "26-350",
+        "office_type": "기초자치단체장",
+        "matchup_id": "2026_local|기초자치단체장|26-350",
+        "verified": false,
+        "source_grade": "C",
+        "legal_required_schema": {
+          "sponsor": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "pollster": {
+            "value": "미상조사기관",
+            "is_present": true,
+            "is_valid": true
+          },
+          "survey_period": {
+            "value": {
+              "survey_start_date": null,
+              "survey_end_date": null
+            },
+            "is_present": false,
+            "is_valid": false
+          },
+          "sample_size": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "response_rate": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "margin_of_error": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          }
+        },
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "legal_missing_fields": [
+          "sponsor",
+          "survey_period",
+          "sample_size",
+          "response_rate",
+          "margin_of_error"
+        ],
+        "legal_invalid_fields": [],
+        "legal_reason_code": "MISSING_SURVEY_PERIOD"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "양자대결",
+          "value_raw": "8.3%",
+          "value_min": 8.3,
+          "value_max": 8.3,
+          "value_mid": 8.3,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiX0FVX3lxTE9JS21CZlgydEwySXlWd2dLR01aYkt0TEk1d1lwMldvbmREQXgxM0lrU3pIRlE4Q2J1dUxGSGlVSnZMeTNnYzZYRXlrYmRiQk1HUExPR3l2NnRzbktSU21n",
+        "title": "동구 임택 37.7%·서구 김이강 27.6%…내년 지선 광주 자치구 첫 여론조사",
+        "publisher": "뉴스1",
+        "published_at": null,
+        "raw_text": "동구 임택 37.7%·서구 김이강 27.6%…내년 지선 광주 자치구 첫 여론조사 - 뉴스1 동구 임택 37.7%·서구 김이강 27.6%…내년 지선 광주 자치구 첫 여론조사 &nbsp;&nbsp; 뉴스1 지방선거 인천 서구청장 여론조사",
+        "raw_hash": "raw_4c7157215a7d7722"
+      },
+      "region": {
+        "region_code": "28-650",
+        "sido_name": "인천광역시",
+        "sigungu_name": "서구",
+        "admin_level": "sigungu",
+        "parent_region_code": "28-000"
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:임택",
+          "name_ko": "임택",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:김이강",
+          "name_ko": "김이강",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_7ccfac81c4403bf6",
+        "survey_name": "동구 임택 37.7%·서구 김이강 27.6%…내년 지선 광주 자치구 첫 여론조사",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "region_code": "28-650",
+        "office_type": "기초자치단체장",
+        "matchup_id": "2026_local|기초자치단체장|28-650",
+        "verified": false,
+        "source_grade": "C",
+        "legal_required_schema": {
+          "sponsor": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "pollster": {
+            "value": "미상조사기관",
+            "is_present": true,
+            "is_valid": true
+          },
+          "survey_period": {
+            "value": {
+              "survey_start_date": null,
+              "survey_end_date": null
+            },
+            "is_present": false,
+            "is_valid": false
+          },
+          "sample_size": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "response_rate": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "margin_of_error": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          }
+        },
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "legal_missing_fields": [
+          "sponsor",
+          "survey_period",
+          "sample_size",
+          "response_rate",
+          "margin_of_error"
+        ],
+        "legal_invalid_fields": [],
+        "legal_reason_code": "MISSING_SURVEY_PERIOD"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "임택",
+          "value_raw": "37.7%",
+          "value_min": 37.7,
+          "value_max": 37.7,
+          "value_mid": 37.7,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "김이강",
+          "value_raw": "27.6%",
+          "value_min": 27.6,
+          "value_max": 27.6,
+          "value_mid": 27.6,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiZ0FVX3lxTE5jQVU3NlFQUjVHVWJZOHpLUzNzOVlhNlBHVWpidkpNc3ZHcmN3VzgxZjZHLUhMbFFwNHRFR2FTSFltVUZYZ3NRTlBaTlNHT2d0eGtXNE9uYm5PX3pyTU5tVzh0Um04ME0",
+        "title": "[여론조사] 내년 지방 선거, 여당 지지 58.5% 야당 36.2%",
+        "publisher": "서귀포방송",
+        "published_at": null,
+        "raw_text": "[여론조사] 내년 지방 선거, 여당 지지 58.5% 야당 36.2% - 서귀포방송 [여론조사] 내년 지방 선거, 여당 지지 58.5% 야당 36.2% &nbsp;&nbsp; 서귀포방송 지방선거 제주 서귀포시장 여론조사",
+        "raw_hash": "raw_2fd2261ed36b1d7e"
+      },
+      "region": {
+        "region_code": "50-130",
+        "sido_name": "제주특별자치도",
+        "sigungu_name": "서귀포시",
+        "admin_level": "sigungu",
+        "parent_region_code": "50-000"
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:지지",
+          "name_ko": "지지",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_a02b7812d9a92751",
+        "survey_name": "[여론조사] 내년 지방 선거, 여당 지지 58.5% 야당 36.2%",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "region_code": "50-130",
+        "office_type": "기초자치단체장",
+        "matchup_id": "2026_local|기초자치단체장|50-130",
+        "verified": false,
+        "source_grade": "C",
+        "legal_required_schema": {
+          "sponsor": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "pollster": {
+            "value": "미상조사기관",
+            "is_present": true,
+            "is_valid": true
+          },
+          "survey_period": {
+            "value": {
+              "survey_start_date": null,
+              "survey_end_date": null
+            },
+            "is_present": false,
+            "is_valid": false
+          },
+          "sample_size": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "response_rate": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "margin_of_error": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          }
+        },
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "legal_missing_fields": [
+          "sponsor",
+          "survey_period",
+          "sample_size",
+          "response_rate",
+          "margin_of_error"
+        ],
+        "legal_invalid_fields": [],
+        "legal_reason_code": "MISSING_SURVEY_PERIOD"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "지지",
+          "value_raw": "58.5%",
+          "value_min": 58.5,
+          "value_max": 58.5,
+          "value_mid": 58.5,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMie0FVX3lxTE5oMVdrbXRkWnZ3el9Rdm9lUDFMXzFyLV84MGlNWHdKWkNDcUc5MjVrQWNyQ3h0Rml5TjFoVjU4YTR1ejRMbzltMXNoX0x6ektuVF90dHJkbnVwV1J5d2RvZ0FOcWc2cFI4MEZ3dnFQcGU0OXlIbmxSU0s1OA",
+        "title": "[지방선거 여론조사] 천안시장 양자대결… 박상돈 47.0% vs 한태선 40.3% '오차 내'",
+        "publisher": "뉴데일리",
+        "published_at": null,
+        "raw_text": "[지방선거 여론조사] 천안시장 양자대결… 박상돈 47.0% vs 한태선 40.3% '오차 내' - 뉴데일리 [지방선거 여론조사] 천안시장 양자대결… 박상돈 47.0% vs 한태선 40.3% '오차 내' &nbsp;&nbsp; 뉴데일리 지방선거 충남 천안시장 가상대결",
+        "raw_hash": "raw_e6ec28628e595ec7"
+      },
+      "region": {
+        "region_code": "44-130",
+        "sido_name": "충청남도",
+        "sigungu_name": "천안시",
+        "admin_level": "sigungu",
+        "parent_region_code": "44-000"
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:박상돈",
+          "name_ko": "박상돈",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:한태선",
+          "name_ko": "한태선",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_160d17843ca5cf29",
+        "survey_name": "[지방선거 여론조사] 천안시장 양자대결… 박상돈 47.0% vs 한태선 40.3% '오차 내'",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "region_code": "44-130",
+        "office_type": "기초자치단체장",
+        "matchup_id": "2026_local|기초자치단체장|44-130",
+        "verified": false,
+        "source_grade": "C",
+        "legal_required_schema": {
+          "sponsor": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "pollster": {
+            "value": "미상조사기관",
+            "is_present": true,
+            "is_valid": true
+          },
+          "survey_period": {
+            "value": {
+              "survey_start_date": null,
+              "survey_end_date": null
+            },
+            "is_present": false,
+            "is_valid": false
+          },
+          "sample_size": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "response_rate": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "margin_of_error": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          }
+        },
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "legal_missing_fields": [
+          "sponsor",
+          "survey_period",
+          "sample_size",
+          "response_rate",
+          "margin_of_error"
+        ],
+        "legal_invalid_fields": [],
+        "legal_reason_code": "MISSING_SURVEY_PERIOD"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "박상돈",
+          "value_raw": "47.0%",
+          "value_min": 47.0,
+          "value_max": 47.0,
+          "value_mid": 47.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "한태선",
+          "value_raw": "40.3%",
+          "value_min": 40.3,
+          "value_max": 40.3,
+          "value_mid": 40.3,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiwwJBVV95cUxQX2VpWjVZelZWb1FuMWhYSV91QmZPa2ZtZ0NsbU0xN3FyVW9MbjVxOHRqRjYzMm1jNjFCNUduVXJ4TWF2UDFZVUdjLXk4YXl1YmpXaUJ1Y2l5WTBmUGpESWlfV1Zoai16Rncyc2JLenVFM0ZYNU1fbXdvcS0yTV9VT3JjelAxZi1KYTFZNjU5U2NkeUlTNlVmVXVDbk4zR3FZa2FPT2ZZcjdZQ0VlNWYwZHF4WldiYnBIdk1FSWFDYkQ1RW1mOWtLRHRKNUxxR05wS3JkQ0ctYkJCZnRfS2hpMEl3N3pPSVN5YzRXb0M4bkk5VXFxZEx4X0Z6bXE1dlRQMERjblQzNEswSkU3YS1vc201OExYS19DUFEzZE45UWFpeDlRaDdRY3FnWktaRnZXbmNtRWphY1QtTGNGcUU3WWRVVQ",
+        "title": "제9회 전국동시지방선거, 경북 영천시장 후보 적합도, 최기문 26.6%선두.. 국민의힘 후보로는 김병삼, 박영환 등 고른 지지율",
+        "publisher": "리얼미터",
+        "published_at": null,
+        "raw_text": "제9회 전국동시지방선거, 경북 영천시장 후보 적합도, 최기문 26.6%선두.. 국민의힘 후보로는 김병삼, 박영환 등 고른 지지율 - 리얼미터 제9회 전국동시지방선거, 경북 영천시장 후보 적합도, 최기문 26.6%선두.. 국민의힘 후보로는 김병삼, 박영환 등 고른 지지율 &nbsp;&nbsp; 리얼미터 지방선거 경북 포항시장 가상대결",
+        "raw_hash": "raw_9ffd05e947ccd457"
+      },
+      "region": {
+        "region_code": "47-110",
+        "sido_name": "경상북도",
+        "sigungu_name": "포항시",
+        "admin_level": "sigungu",
+        "parent_region_code": "47-000"
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:최기문",
+          "name_ko": "최기문",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_3b751ae1d39aae53",
+        "survey_name": "제9회 전국동시지방선거, 경북 영천시장 후보 적합도, 최기문 26.6%선두.. 국민의힘 후보로는 김병삼, 박영환 등 고른 지지율",
+        "pollster": "리얼미터",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "region_code": "47-110",
+        "office_type": "기초자치단체장",
+        "matchup_id": "2026_local|기초자치단체장|47-110",
+        "verified": false,
+        "source_grade": "C",
+        "legal_required_schema": {
+          "sponsor": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "pollster": {
+            "value": "리얼미터",
+            "is_present": true,
+            "is_valid": true
+          },
+          "survey_period": {
+            "value": {
+              "survey_start_date": null,
+              "survey_end_date": null
+            },
+            "is_present": false,
+            "is_valid": false
+          },
+          "sample_size": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "response_rate": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "margin_of_error": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          }
+        },
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "legal_missing_fields": [
+          "sponsor",
+          "survey_period",
+          "sample_size",
+          "response_rate",
+          "margin_of_error"
+        ],
+        "legal_invalid_fields": [],
+        "legal_reason_code": "MISSING_SURVEY_PERIOD"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "최기문",
+          "value_raw": "26.6%",
+          "value_min": 26.6,
+          "value_max": 26.6,
+          "value_mid": 26.6,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiRkFVX3lxTE1fR1ZSZ0UtYi1yXzhrY2E2RG0zSVY1emdGY2d1X0E2MFhoMFJzWmdxdHVGc01SVVAtWXBRTFB1TF9HOWtKcHc",
+        "title": "[KBS여론조사]④ 목포시장 후보 3명 접전…노관규 27% 정기명 14%",
+        "publisher": "v.daum.net",
+        "published_at": null,
+        "raw_text": "[KBS여론조사]④ 목포시장 후보 3명 접전…노관규 27% 정기명 14% - v.daum.net [KBS여론조사]④ 목포시장 후보 3명 접전…노관규 27% 정기명 14% &nbsp;&nbsp; v.daum.net 지방선거 전남 목포시장 여론조사",
+        "raw_hash": "raw_24bd981d24947133"
+      },
+      "region": {
+        "region_code": "46-110",
+        "sido_name": "전라남도",
+        "sigungu_name": "목포시",
+        "admin_level": "sigungu",
+        "parent_region_code": "46-000"
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:노관규",
+          "name_ko": "노관규",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:정기명",
+          "name_ko": "정기명",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_92b3ae667ed44a57",
+        "survey_name": "[KBS여론조사]④ 목포시장 후보 3명 접전…노관규 27% 정기명 14%",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "region_code": "46-110",
+        "office_type": "기초자치단체장",
+        "matchup_id": "2026_local|기초자치단체장|46-110",
+        "verified": false,
+        "source_grade": "C",
+        "legal_required_schema": {
+          "sponsor": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "pollster": {
+            "value": "미상조사기관",
+            "is_present": true,
+            "is_valid": true
+          },
+          "survey_period": {
+            "value": {
+              "survey_start_date": null,
+              "survey_end_date": null
+            },
+            "is_present": false,
+            "is_valid": false
+          },
+          "sample_size": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "response_rate": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "margin_of_error": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          }
+        },
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "legal_missing_fields": [
+          "sponsor",
+          "survey_period",
+          "sample_size",
+          "response_rate",
+          "margin_of_error"
+        ],
+        "legal_invalid_fields": [],
+        "legal_reason_code": "MISSING_SURVEY_PERIOD"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "노관규",
+          "value_raw": "27%",
+          "value_min": 27.0,
+          "value_max": 27.0,
+          "value_mid": 27.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "정기명",
+          "value_raw": "14%",
+          "value_min": 14.0,
+          "value_max": 14.0,
+          "value_mid": 14.0,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiVEFVX3lxTE9Md3dtcUxnNEdfenIxX3BmVFpvcTFXWDZSOF92eHY2cXMyWnRyZlJnUF92c29fNVRHNEhHSUV0QzNDbVJmVFVlSmFPQktaVHF1ckkxWA",
+        "title": "[뉴스1전북 여론조사] 내년 전주시장 적합도…우범기 19.4%·임정엽 19.2%",
+        "publisher": "뉴스1",
+        "published_at": null,
+        "raw_text": "[뉴스1전북 여론조사] 내년 전주시장 적합도…우범기 19.4%·임정엽 19.2% - 뉴스1 [뉴스1전북 여론조사] 내년 전주시장 적합도…우범기 19.4%·임정엽 19.2% &nbsp;&nbsp; 뉴스1 지방선거 전북 전주시장 여론조사",
+        "raw_hash": "raw_7fcd3dba34ce7ea5"
+      },
+      "region": {
+        "region_code": "45-110",
+        "sido_name": "전북특별자치도",
+        "sigungu_name": "전주시",
+        "admin_level": "sigungu",
+        "parent_region_code": "45-000"
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:우범기",
+          "name_ko": "우범기",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:임정엽",
+          "name_ko": "임정엽",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_83b190c9d54487cf",
+        "survey_name": "[뉴스1전북 여론조사] 내년 전주시장 적합도…우범기 19.4%·임정엽 19.2%",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "region_code": "45-110",
+        "office_type": "기초자치단체장",
+        "matchup_id": "2026_local|기초자치단체장|45-110",
+        "verified": false,
+        "source_grade": "C",
+        "legal_required_schema": {
+          "sponsor": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "pollster": {
+            "value": "미상조사기관",
+            "is_present": true,
+            "is_valid": true
+          },
+          "survey_period": {
+            "value": {
+              "survey_start_date": null,
+              "survey_end_date": null
+            },
+            "is_present": false,
+            "is_valid": false
+          },
+          "sample_size": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "response_rate": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "margin_of_error": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          }
+        },
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "legal_missing_fields": [
+          "sponsor",
+          "survey_period",
+          "sample_size",
+          "response_rate",
+          "margin_of_error"
+        ],
+        "legal_invalid_fields": [],
+        "legal_reason_code": "MISSING_SURVEY_PERIOD"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "우범기",
+          "value_raw": "19.4%",
+          "value_min": 19.4,
+          "value_max": 19.4,
+          "value_mid": 19.4,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "임정엽",
+          "value_raw": "19.2%",
+          "value_min": 19.2,
+          "value_max": 19.2,
+          "value_mid": 19.2,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMimwFBVV95cUxOQ2VPMzZEc2hfMTg4U1JTREtmUFZ2N1dLR25UYzVyelk2RkJNMUxFSFpqSzBBYnZkcjROR19VX2N5MVE4QWh4ZWFtUWU2QTFiN293clhINkplVlFrbndmanNRb2ljVUlaWGJlTFhsLXZlWUM0RjZTTkM1OGhmbGJsVnBiRllQM2dESGN2OGVucG8tSmkxeXZkNWtYaw",
+        "title": "[충북도지사 후보 지지도] 신용한 22.7%, 노영민 14.9%... 김영환 지사와 대결, 모두 우세",
+        "publisher": "오마이뉴스",
+        "published_at": null,
+        "raw_text": "[충북도지사 후보 지지도] 신용한 22.7%, 노영민 14.9%... 김영환 지사와 대결, 모두 우세 - 오마이뉴스 [충북도지사 후보 지지도] 신용한 22.7%, 노영민 14.9%... 김영환 지사와 대결, 모두 우세 &nbsp;&nbsp; 오마이뉴스 지방선거 충북 청주시장 가상대결",
+        "raw_hash": "raw_c4c7d0cacadd7eae"
+      },
+      "region": {
+        "region_code": "43-110",
+        "sido_name": "충청북도",
+        "sigungu_name": "청주시",
+        "admin_level": "sigungu",
+        "parent_region_code": "43-000"
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:신용한",
+          "name_ko": "신용한",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:노영민",
+          "name_ko": "노영민",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_13d822a5fd33a42a",
+        "survey_name": "[충북도지사 후보 지지도] 신용한 22.7%, 노영민 14.9%... 김영환 지사와 대결, 모두 우세",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "region_code": "43-110",
+        "office_type": "기초자치단체장",
+        "matchup_id": "2026_local|기초자치단체장|43-110",
+        "verified": false,
+        "source_grade": "C",
+        "legal_required_schema": {
+          "sponsor": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "pollster": {
+            "value": "미상조사기관",
+            "is_present": true,
+            "is_valid": true
+          },
+          "survey_period": {
+            "value": {
+              "survey_start_date": null,
+              "survey_end_date": null
+            },
+            "is_present": false,
+            "is_valid": false
+          },
+          "sample_size": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "response_rate": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "margin_of_error": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          }
+        },
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "legal_missing_fields": [
+          "sponsor",
+          "survey_period",
+          "sample_size",
+          "response_rate",
+          "margin_of_error"
+        ],
+        "legal_invalid_fields": [],
+        "legal_reason_code": "MISSING_SURVEY_PERIOD"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "신용한",
+          "value_raw": "22.7%",
+          "value_min": 22.7,
+          "value_max": 22.7,
+          "value_mid": 22.7,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "노영민",
+          "value_raw": "14.9%",
+          "value_min": 14.9,
+          "value_max": 14.9,
+          "value_mid": 14.9,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiWkFVX3lxTE1BM2JoVG1qT3VaUG1Jd2xrb2ZWWVIyd0Q2VF80TjlORUhoODQ0RkVvOUZMTHdET3gzd29KV0ZNdXRzWnptRGlpTm80d2FSbFFGb3B2ajI1TkRzQdIBWEFVX3lxTE1vM2pwWUw4VVA5Mzd1MTk5dEQ2TlRETUhURnlFWjhQU2hXXzdlajJCXzIyUktYSW1HeDVWNXBldDd3a0ladWFCM2ZOakZ5QU9MZklhdi10cjE",
+        "title": "서울시장 가상대결서 정원오 45.2%·오세훈 38.1%...오차범위 밖",
+        "publisher": "아주경제",
+        "published_at": null,
+        "raw_text": "서울시장 가상대결서 정원오 45.2%·오세훈 38.1%...오차범위 밖 - 아주경제 서울시장 가상대결서 정원오 45.2%·오세훈 38.1%...오차범위 밖 &nbsp;&nbsp; 아주경제 지방선거 서울 종로구청장 가상대결",
+        "raw_hash": "raw_4019897e2ba2c8a4"
+      },
+      "region": {
+        "region_code": "11-110",
+        "sido_name": "서울특별시",
+        "sigungu_name": "종로구",
+        "admin_level": "sigungu",
+        "parent_region_code": "11-000"
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:정원오",
+          "name_ko": "정원오",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:오세훈",
+          "name_ko": "오세훈",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_d0980e8b742d5af7",
+        "survey_name": "서울시장 가상대결서 정원오 45.2%·오세훈 38.1%...오차범위 밖",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "region_code": "11-110",
+        "office_type": "기초자치단체장",
+        "matchup_id": "2026_local|기초자치단체장|11-110",
+        "verified": false,
+        "source_grade": "C",
+        "legal_required_schema": {
+          "sponsor": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "pollster": {
+            "value": "미상조사기관",
+            "is_present": true,
+            "is_valid": true
+          },
+          "survey_period": {
+            "value": {
+              "survey_start_date": null,
+              "survey_end_date": null
+            },
+            "is_present": false,
+            "is_valid": false
+          },
+          "sample_size": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "response_rate": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          },
+          "margin_of_error": {
+            "value": null,
+            "is_present": false,
+            "is_valid": false
+          }
+        },
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "legal_missing_fields": [
+          "sponsor",
+          "survey_period",
+          "sample_size",
+          "response_rate",
+          "margin_of_error"
+        ],
+        "legal_invalid_fields": [],
+        "legal_reason_code": "MISSING_SURVEY_PERIOD"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "정원오",
+          "value_raw": "45.2%",
+          "value_min": 45.2,
+          "value_max": 45.2,
+          "value_mid": 45.2,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "오세훈",
+          "value_raw": "38.1%",
+          "value_min": 38.1,
+          "value_max": 38.1,
+          "value_mid": 38.1,
+          "is_missing": false
+        }
+      ]
+    }
+  ]
+}

--- a/data/collector_article_legal_completeness_v1_report.json
+++ b/data/collector_article_legal_completeness_v1_report.json
@@ -1,0 +1,92 @@
+{
+  "run_type": "collector_article_legal_completeness_v1",
+  "source_path": "data/bootstrap_ingest_coverage_v2.json",
+  "sample_size": 50,
+  "required_fields": [
+    "sponsor",
+    "pollster",
+    "survey_period",
+    "sample_size",
+    "response_rate",
+    "margin_of_error"
+  ],
+  "threshold": 0.8,
+  "completeness": {
+    "avg_score": 0.1667,
+    "min_score": 0.1667,
+    "max_score": 0.1667,
+    "threshold_miss_count": 50,
+    "threshold_miss_rate": 1.0
+  },
+  "field_rates": {
+    "sponsor": {
+      "present_count": 0,
+      "present_rate": 0.0,
+      "valid_count": 0,
+      "valid_rate": 0.0,
+      "missing_count": 50,
+      "missing_rate": 1.0,
+      "invalid_count": 0,
+      "invalid_rate": 0.0
+    },
+    "pollster": {
+      "present_count": 50,
+      "present_rate": 1.0,
+      "valid_count": 50,
+      "valid_rate": 1.0,
+      "missing_count": 0,
+      "missing_rate": 0.0,
+      "invalid_count": 0,
+      "invalid_rate": 0.0
+    },
+    "survey_period": {
+      "present_count": 0,
+      "present_rate": 0.0,
+      "valid_count": 0,
+      "valid_rate": 0.0,
+      "missing_count": 50,
+      "missing_rate": 1.0,
+      "invalid_count": 0,
+      "invalid_rate": 0.0
+    },
+    "sample_size": {
+      "present_count": 0,
+      "present_rate": 0.0,
+      "valid_count": 0,
+      "valid_rate": 0.0,
+      "missing_count": 50,
+      "missing_rate": 1.0,
+      "invalid_count": 0,
+      "invalid_rate": 0.0
+    },
+    "response_rate": {
+      "present_count": 0,
+      "present_rate": 0.0,
+      "valid_count": 0,
+      "valid_rate": 0.0,
+      "missing_count": 50,
+      "missing_rate": 1.0,
+      "invalid_count": 0,
+      "invalid_rate": 0.0
+    },
+    "margin_of_error": {
+      "present_count": 0,
+      "present_rate": 0.0,
+      "valid_count": 0,
+      "valid_rate": 0.0,
+      "missing_count": 50,
+      "missing_rate": 1.0,
+      "invalid_count": 0,
+      "invalid_rate": 0.0
+    }
+  },
+  "reason_code_counts": {
+    "MISSING_SURVEY_PERIOD": 50
+  },
+  "review_queue_candidate_count": 50,
+  "acceptance_checks": {
+    "sample_size_eq_50": true,
+    "threshold_miss_review_queue_synced": true,
+    "has_missing_or_abnormal_cases": true
+  }
+}

--- a/data/collector_article_legal_completeness_v1_review_queue_candidates.json
+++ b/data/collector_article_legal_completeness_v1_review_queue_candidates.json
@@ -1,0 +1,1252 @@
+[
+  {
+    "id": "rvq_6f17aabcbb91b809",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_8aff3ed1d23504f8",
+    "issue_type": "extract_error",
+    "stage": "legal_completeness_v1",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "required legal fields completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMiPEFVX3lxTE56ZzduSTFSc2FmQUxiT2wzUGswSVIzcXM2Z0Z3dHRwWTNaclBRZ3RsZTBxVUx3dXN1YWQ2NdIBWEFVX3lxTE92RlNERThyckZnRmxlb2cxbFJ5WDhQX21lS2Qxb21KSkZxb2VPWkVQVU9RYnFuWHc4dDJJX3JNdGxFQXFyVm1BamU1enZHeERjcHpkN1FPb0I",
+    "payload": {
+      "completeness_score": 0.1667,
+      "threshold": 0.8,
+      "reason_code": "MISSING_SURVEY_PERIOD",
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ],
+      "invalid_fields": []
+    },
+    "status": "pending",
+    "created_at": "2026-02-23T10:16:15.436231+00:00"
+  },
+  {
+    "id": "rvq_7d8d6aaabeb771b6",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_1beca86ca98386bb",
+    "issue_type": "extract_error",
+    "stage": "legal_completeness_v1",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "required legal fields completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMiRkFVX3lxTE1OME1aSlEzR1QyUkZqa2Uza2NZOC13SnJDVnpTS3hkS0o0alBjbkRFQzVvT2RKYWJsaHBQbzgweGlRQVNIdFE",
+    "payload": {
+      "completeness_score": 0.1667,
+      "threshold": 0.8,
+      "reason_code": "MISSING_SURVEY_PERIOD",
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ],
+      "invalid_fields": []
+    },
+    "status": "pending",
+    "created_at": "2026-02-23T10:16:15.436693+00:00"
+  },
+  {
+    "id": "rvq_5adb1ce9b0f67e8f",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_69b9a07a4997e975",
+    "issue_type": "extract_error",
+    "stage": "legal_completeness_v1",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "required legal fields completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMiS0FVX3lxTE1XanN5QjNfa1BVTERQOFFnaklucmFveWtnUkFFNEY3WWFOOHM5QVFiWEE5UmE0b252UDRDQmJWeGlfWTZTaUszdTBBSQ",
+    "payload": {
+      "completeness_score": 0.1667,
+      "threshold": 0.8,
+      "reason_code": "MISSING_SURVEY_PERIOD",
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ],
+      "invalid_fields": []
+    },
+    "status": "pending",
+    "created_at": "2026-02-23T10:16:15.436713+00:00"
+  },
+  {
+    "id": "rvq_66d521a6f5eb45e7",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_350f14ce7e3668fb",
+    "issue_type": "extract_error",
+    "stage": "legal_completeness_v1",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "required legal fields completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMiSEFVX3lxTE16dW16SWM5dUtrWlZ2WUlrSk5xVGhzZmRLUUhlMldBX3RiZHNjV1k5QXF2UzRmNWwtcEZuczk1NEVyNEZPa2pKRQ",
+    "payload": {
+      "completeness_score": 0.1667,
+      "threshold": 0.8,
+      "reason_code": "MISSING_SURVEY_PERIOD",
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ],
+      "invalid_fields": []
+    },
+    "status": "pending",
+    "created_at": "2026-02-23T10:16:15.436727+00:00"
+  },
+  {
+    "id": "rvq_05a54c33775d7adb",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_8c8010fe1c12852a",
+    "issue_type": "extract_error",
+    "stage": "legal_completeness_v1",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "required legal fields completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMiU0FVX3lxTFBwUEV3THRiRXVTbW90VDBYSGF4dzcxaHNOWUhtYWZNaUYzU0hIRVdvYjhUTERXZVJ1a3hfYlB6OHJFSkNBZXZQRUJjOGZqRVh0eUFV",
+    "payload": {
+      "completeness_score": 0.1667,
+      "threshold": 0.8,
+      "reason_code": "MISSING_SURVEY_PERIOD",
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ],
+      "invalid_fields": []
+    },
+    "status": "pending",
+    "created_at": "2026-02-23T10:16:15.436741+00:00"
+  },
+  {
+    "id": "rvq_3692881a454af579",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_28eb3ac87760e5d3",
+    "issue_type": "extract_error",
+    "stage": "legal_completeness_v1",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "required legal fields completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMiUkFVX3lxTE5pY25MWDNpREthWURTQ2FuWkRMXzUybF9NVkN2MG93Vzk2bm1KbXBpbFB3ZV85SzVMNlBWT0E5bDJsQlBfZVJYb1B2TDhJRDIzMVE",
+    "payload": {
+      "completeness_score": 0.1667,
+      "threshold": 0.8,
+      "reason_code": "MISSING_SURVEY_PERIOD",
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ],
+      "invalid_fields": []
+    },
+    "status": "pending",
+    "created_at": "2026-02-23T10:16:15.436752+00:00"
+  },
+  {
+    "id": "rvq_0681e39f2a9de947",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_1b304a647ade54cf",
+    "issue_type": "extract_error",
+    "stage": "legal_completeness_v1",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "required legal fields completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMiVEFVX3lxTE4yc3BiSVh6NlJkbmVadjh4eWFleUJ2M0tYYTdkQ2pLRVhPR2dzRnNhR1lpNGZsd21XeWwwQ09nSXR1YjNBTnd2U05PY1oyaFZfOXNDMQ",
+    "payload": {
+      "completeness_score": 0.1667,
+      "threshold": 0.8,
+      "reason_code": "MISSING_SURVEY_PERIOD",
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ],
+      "invalid_fields": []
+    },
+    "status": "pending",
+    "created_at": "2026-02-23T10:16:15.436762+00:00"
+  },
+  {
+    "id": "rvq_1e776c7f0cdfc129",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_9210db1b70c7c97e",
+    "issue_type": "extract_error",
+    "stage": "legal_completeness_v1",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "required legal fields completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMiVkFVX3lxTE1xNE1xVGxjX19tSnp3NGNENUJuR0I4Q01HNUN3UkVNdEpUaUxGcVQ2RlNCaTR0MTdnOVQtNXNjckg2M3dmbzRyYkFUNTRxR0NJYkszbnZ3",
+    "payload": {
+      "completeness_score": 0.1667,
+      "threshold": 0.8,
+      "reason_code": "MISSING_SURVEY_PERIOD",
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ],
+      "invalid_fields": []
+    },
+    "status": "pending",
+    "created_at": "2026-02-23T10:16:15.436772+00:00"
+  },
+  {
+    "id": "rvq_2cb8c1269377ae0a",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_019a0a0e22089be2",
+    "issue_type": "extract_error",
+    "stage": "legal_completeness_v1",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "required legal fields completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMiW0FVX3lxTE1YVHBLX2ZkX1Z1Ry1IZnRBUklqRVY1X0x1RnlVbHUtaXl6eEkyRTVUVkhaS0JIU1hhTUlJRFlLVlFXenVMdUxYMk1WTGdNQVNiSEFFbTMwcTBEUlE",
+    "payload": {
+      "completeness_score": 0.1667,
+      "threshold": 0.8,
+      "reason_code": "MISSING_SURVEY_PERIOD",
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ],
+      "invalid_fields": []
+    },
+    "status": "pending",
+    "created_at": "2026-02-23T10:16:15.436782+00:00"
+  },
+  {
+    "id": "rvq_681eec807587f866",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_c2a8e80898e2eb78",
+    "issue_type": "extract_error",
+    "stage": "legal_completeness_v1",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "required legal fields completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMiW0FVX3lxTFA1OHEzY1prQ3RCa2F2Z3VvbGNBQjRTZWp1YktvUlBwek9IYVJOaDNJc0ZkbWxGQkFoUEpUeHZFTHExa1dydlZuVU9pWWdFR3lzZGgyekY2TEh3SjQ",
+    "payload": {
+      "completeness_score": 0.1667,
+      "threshold": 0.8,
+      "reason_code": "MISSING_SURVEY_PERIOD",
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ],
+      "invalid_fields": []
+    },
+    "status": "pending",
+    "created_at": "2026-02-23T10:16:15.436792+00:00"
+  },
+  {
+    "id": "rvq_4ada7b4622f4b46b",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_2abffbb597220668",
+    "issue_type": "extract_error",
+    "stage": "legal_completeness_v1",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "required legal fields completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMiWEFVX3lxTFA3QzZLYmNnQUdGcE5xeUZTWjBlaWFTbXc5Rl81a0xVY0FQTXlzZWthcG81dGRldDZHcTRTdDZDSVp0d1hiMlhKcmtmM2FkYUFSb2RHNzhEN3M",
+    "payload": {
+      "completeness_score": 0.1667,
+      "threshold": 0.8,
+      "reason_code": "MISSING_SURVEY_PERIOD",
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ],
+      "invalid_fields": []
+    },
+    "status": "pending",
+    "created_at": "2026-02-23T10:16:15.436801+00:00"
+  },
+  {
+    "id": "rvq_f27e17d68352d3ba",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_a8a990474f6b1bc2",
+    "issue_type": "extract_error",
+    "stage": "legal_completeness_v1",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "required legal fields completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMia0FVX3lxTE9CQWZnOGdZdzdGYWtINXdjeHZTdncxLWlEY251LWVMd3ZNbGZwRlQ3YksyT3FqVGl0M0U5VFZHX2d5clFZWlBLS2R4U2VmRjRZdnpnSkdfZ3pJamQ1X0p0aUllVFJxdC12LS1z",
+    "payload": {
+      "completeness_score": 0.1667,
+      "threshold": 0.8,
+      "reason_code": "MISSING_SURVEY_PERIOD",
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ],
+      "invalid_fields": []
+    },
+    "status": "pending",
+    "created_at": "2026-02-23T10:16:15.436812+00:00"
+  },
+  {
+    "id": "rvq_e6f58bfd600f54dd",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_570a0e3cef2d44c8",
+    "issue_type": "extract_error",
+    "stage": "legal_completeness_v1",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "required legal fields completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMiUEFVX3lxTE04cmc5WjRBVFV2THhIaW9GbXFtVXdIdnktSXdUc2Znb08yZ0xfalBmNElQVWdTd3AwOHRRMXpXSktQOEppVmVkWnFreUNHc3Rv",
+    "payload": {
+      "completeness_score": 0.1667,
+      "threshold": 0.8,
+      "reason_code": "MISSING_SURVEY_PERIOD",
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ],
+      "invalid_fields": []
+    },
+    "status": "pending",
+    "created_at": "2026-02-23T10:16:15.436823+00:00"
+  },
+  {
+    "id": "rvq_08051115c58906df",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_1b4cc75fe542165c",
+    "issue_type": "extract_error",
+    "stage": "legal_completeness_v1",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "required legal fields completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMiY0FVX3lxTE9fRTUxSnA0YUFrVFI0eThGODJwTHY0N3BuaTdhc3dPVVozOHo0LUlRc1BFZV9zU2FqdjltUDBRWFJWeGV4aERjbUtZZGVrcHJ3QXpGa2Z2UlBMVUZxZThwaDFTSQ",
+    "payload": {
+      "completeness_score": 0.1667,
+      "threshold": 0.8,
+      "reason_code": "MISSING_SURVEY_PERIOD",
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ],
+      "invalid_fields": []
+    },
+    "status": "pending",
+    "created_at": "2026-02-23T10:16:15.436832+00:00"
+  },
+  {
+    "id": "rvq_ab3927feaab6b5b0",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_e2bc30a4e716291f",
+    "issue_type": "extract_error",
+    "stage": "legal_completeness_v1",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "required legal fields completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMiYEFVX3lxTE84MVZyNUFHanNWTWdid08zcWtzLU85bk5aSEw4UGFKemNqQi1LWVczWHpEZnN2TlA5a0MzbnJPckJwcFh5QTdSSThCdWluamkxa1plSWRmMEtEbV9UWS1VcNIBeEFVX3lxTE05VmZpdG9KYk1FVlRnS3JRazhQR285LWJZb3d1QlBVeDNTQ24zZXB6elkxZEJfQ2EwNWpLcGJTWmZCZEVidWN0dTI4MVI4WVhUUEVrLUVncmxMZG1pRUhGZUZISURDQ1NjbHNTZVVXN2d5N2dRWEpwdg",
+    "payload": {
+      "completeness_score": 0.1667,
+      "threshold": 0.8,
+      "reason_code": "MISSING_SURVEY_PERIOD",
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ],
+      "invalid_fields": []
+    },
+    "status": "pending",
+    "created_at": "2026-02-23T10:16:15.436841+00:00"
+  },
+  {
+    "id": "rvq_30d51290a4c0080c",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_9961c9bafbda6f30",
+    "issue_type": "extract_error",
+    "stage": "legal_completeness_v1",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "required legal fields completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMiZ0FVX3lxTE1aQmVGVVEtN1o4dG1VcG04WTZGem9Vb3lxRXRfaTlONjBiVXJ4YVotTUhYX2xCWExqblNidjlhdVlGWmltVllxQmhGazRpMjhSc1pjQmVZNUNMLU92MVpOWDJpZ1Qtb0k",
+    "payload": {
+      "completeness_score": 0.1667,
+      "threshold": 0.8,
+      "reason_code": "MISSING_SURVEY_PERIOD",
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ],
+      "invalid_fields": []
+    },
+    "status": "pending",
+    "created_at": "2026-02-23T10:16:15.436850+00:00"
+  },
+  {
+    "id": "rvq_4cbe49d937c6ae6b",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_eb296d307d9f189a",
+    "issue_type": "extract_error",
+    "stage": "legal_completeness_v1",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "required legal fields completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMia0FVX3lxTFA5eUxUeHFPUUVBcW1vVWREb3kwSExyai1SNXpPMDR3XzJRRGNweURmYmJNbnY5dnFOR2xSYWpzNVdfZGxMVTFVRTQtR1p4b0cwSUFCblB6dkpJN2puUXdXd1dtZFNOUWpXQUJ30gFvQVVfeXFMTWY2cndSUFMzV3lBNTZmVHY0ODZ2Yzc3NndTYzFXNTZpa1pneWpaMmJmczRRRzlRM3N5TTMyVkJvbHc1OU5OZV9QM1Jmc2tJcVlRamd4Y0wyNkhManFxNDRuemUzM0NBRG5BR0pvdkdV",
+    "payload": {
+      "completeness_score": 0.1667,
+      "threshold": 0.8,
+      "reason_code": "MISSING_SURVEY_PERIOD",
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ],
+      "invalid_fields": []
+    },
+    "status": "pending",
+    "created_at": "2026-02-23T10:16:15.436860+00:00"
+  },
+  {
+    "id": "rvq_48bd53b180ea6b99",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_5425934b495c835e",
+    "issue_type": "extract_error",
+    "stage": "legal_completeness_v1",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "required legal fields completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMib0FVX3lxTE5ybFpja3JUNExzVm5vSVFzR19wX1ZZZGVSWWxXYWJnUmpyaXMxdExpRVFQM1pjVDhYSEFZVFJ3M0djek8tNml5NXlGTjlLN3lncEhfMENxUGw2dHB3RTYzMU50T1F6MEQxMFBfSUgzWdIBc0FVX3lxTE0xS0dybzFlb0o2bUgtdHdRTHNFTE5IbVNIRzRBQ1NBa1ZfUGkyTHFfc2ZsNnFsajZhZ1RWaXI1NlE2cEV1eHpyTWI2LUQwWTVRdDVkeFVnMDBqR3RuTU1kSWdRQzlpOER6d2Voc2tVNlRBX1U",
+    "payload": {
+      "completeness_score": 0.1667,
+      "threshold": 0.8,
+      "reason_code": "MISSING_SURVEY_PERIOD",
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ],
+      "invalid_fields": []
+    },
+    "status": "pending",
+    "created_at": "2026-02-23T10:16:15.436870+00:00"
+  },
+  {
+    "id": "rvq_a023d9369606aba0",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_b61d10f49a5d5fdd",
+    "issue_type": "extract_error",
+    "stage": "legal_completeness_v1",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "required legal fields completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMibkFVX3lxTE9tU29Yc0dzaDhTR3BHUFNsaTdhb3h6N3Z2b3M4eEFxVHBtZzYwU3BrZV9DdEdNSWoxZV8wWk1lanEwRk4yLTJucFpwNnBZQ3hZdUNfNFNWOG1SVGdRc21qZjVVY3p0UFR2NHoycjRR0gFyQVVfeXFMUDc1RnNZaFhKeVE1NXMwbUtWSDJNMmYxWWJGY09Ea1Bxb191UlRiblBVWXhwRzNRT1JIWFRuME5DeF9YTjBjRHNOOE1WMFRWVWN5Nlo3U3d2OUVlX2ZzSVJ3bTRTQ3ZjWGRGdExlQTdnV2x3",
+    "payload": {
+      "completeness_score": 0.1667,
+      "threshold": 0.8,
+      "reason_code": "MISSING_SURVEY_PERIOD",
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ],
+      "invalid_fields": []
+    },
+    "status": "pending",
+    "created_at": "2026-02-23T10:16:15.436879+00:00"
+  },
+  {
+    "id": "rvq_2b5c8b3893f15849",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_4a3cfc6a5b3dc73a",
+    "issue_type": "extract_error",
+    "stage": "legal_completeness_v1",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "required legal fields completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMic0FVX3lxTE0wV2NwN2ZtUDhIZERpUXBQWUhsOVVCVjVPcVVac3ZLMVZaM29nYWltbVBTU1VjNkV2NnlVaVQzSi1jOE1QUkVyWUpwT3l3dlYyM1BjMEt4VlFiUF93QjZ0V3F2d3BxV3NsSFJaRjVhTHpWR2s",
+    "payload": {
+      "completeness_score": 0.1667,
+      "threshold": 0.8,
+      "reason_code": "MISSING_SURVEY_PERIOD",
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ],
+      "invalid_fields": []
+    },
+    "status": "pending",
+    "created_at": "2026-02-23T10:16:15.436888+00:00"
+  },
+  {
+    "id": "rvq_ae761544cbc1874f",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_6490a50035ace1dd",
+    "issue_type": "extract_error",
+    "stage": "legal_completeness_v1",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "required legal fields completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMib0FVX3lxTE96eDNvQlc1VXBmcUFkcDNCRnFMTUVvTTBCTWhuOE40d0JaSUNhMDV0RGtVLWdnNkMyNWZQdTJ0YkVrVXhUMU5aUW5yM1Q1VzBJV2tkNm5yclE5dExzV0paY0t0YTRWc0d3TkRfUzh0QQ",
+    "payload": {
+      "completeness_score": 0.1667,
+      "threshold": 0.8,
+      "reason_code": "MISSING_SURVEY_PERIOD",
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ],
+      "invalid_fields": []
+    },
+    "status": "pending",
+    "created_at": "2026-02-23T10:16:15.436897+00:00"
+  },
+  {
+    "id": "rvq_f83bc3ed1e27f29f",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_4f65234aef2f2255",
+    "issue_type": "extract_error",
+    "stage": "legal_completeness_v1",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "required legal fields completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMiSEFVX3lxTFA1aXhpamJBU3lNS2NSMUJzLXFLS3hPR3JiYkJXaEFORTZVVXBwaUoxWXhNTzJFSXFrVXFuaURLZkZxWndxMHRSNA",
+    "payload": {
+      "completeness_score": 0.1667,
+      "threshold": 0.8,
+      "reason_code": "MISSING_SURVEY_PERIOD",
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ],
+      "invalid_fields": []
+    },
+    "status": "pending",
+    "created_at": "2026-02-23T10:16:15.436909+00:00"
+  },
+  {
+    "id": "rvq_36441ef9531f5000",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_28b652315fffc54c",
+    "issue_type": "extract_error",
+    "stage": "legal_completeness_v1",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "required legal fields completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMic0FVX3lxTFB6SWZjTVVtenBZRko1RTBSUVZfQndNcmQ4cnc0UlZhVDNSY3IxaHBENmFZSTlyMS14cGtFN1dqYXEzc1g1QzR1T2NVY0RHNTNhTjRNWGFZSWZ3UHRsREdhckhpLWRXTDRtZ19fMUcyMXdFdmfSAXdBVV95cUxQTUxjaThUSlAyWHdHTE11aTRTVTdVUmFvNlZLMlo0M25tWXRTNzRYUDRQV05BSVhqR20xY1lJSHVVZVlVZVhXZnBkSThmbWZuZmNDX2R3NGdzZjBPWXN2OThJZ2dreHFWQ3l0TFZDUl9iN1pYbWE0bw",
+    "payload": {
+      "completeness_score": 0.1667,
+      "threshold": 0.8,
+      "reason_code": "MISSING_SURVEY_PERIOD",
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ],
+      "invalid_fields": []
+    },
+    "status": "pending",
+    "created_at": "2026-02-23T10:16:15.436918+00:00"
+  },
+  {
+    "id": "rvq_e7db6457e0ce0676",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_f02b9da293d85f45",
+    "issue_type": "extract_error",
+    "stage": "legal_completeness_v1",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "required legal fields completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMicEFVX3lxTE5SVTdnNi1DU3hFdmF1S3ZjbHdidU9tOVktNE1TZ095c2hMdmMxODNHckNxd0ZSQjVtYUZHeVg0TExGUU1jUUotdTFRUUJRZldLb1BSeTFueGhSM1p2WURuZnBUa3JHLVh3Q3FCcXJhdnM",
+    "payload": {
+      "completeness_score": 0.1667,
+      "threshold": 0.8,
+      "reason_code": "MISSING_SURVEY_PERIOD",
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ],
+      "invalid_fields": []
+    },
+    "status": "pending",
+    "created_at": "2026-02-23T10:16:15.436927+00:00"
+  },
+  {
+    "id": "rvq_323f63e0c10801b8",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_0f7b70cba187620c",
+    "issue_type": "extract_error",
+    "stage": "legal_completeness_v1",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "required legal fields completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMiTkFVX3lxTE9xeU1ObnV5dzM5NTF2eURUelNNWFlTcVNlR3RpSU4xNFVUWXdBQi1ZbzRIcl83ZUNnOTVxS1o5a1MzSlNzRGQzMS16R2kwQQ",
+    "payload": {
+      "completeness_score": 0.1667,
+      "threshold": 0.8,
+      "reason_code": "MISSING_SURVEY_PERIOD",
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ],
+      "invalid_fields": []
+    },
+    "status": "pending",
+    "created_at": "2026-02-23T10:16:15.436936+00:00"
+  },
+  {
+    "id": "rvq_fc454acbd0c59466",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_ca72aacb9b35270c",
+    "issue_type": "extract_error",
+    "stage": "legal_completeness_v1",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "required legal fields completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMiVEFVX3lxTFBZZ1NjWTBJb2VFbmV1alZ0WXY5bnBzVEFrWEItMG92enpSQkpTNGtMVy12X21uUS1mUnJTeWdTM29sSHE0VGpiWjVFMXBQb3ZoR1BhbNIBWEFVX3lxTE9NRzItMGNnM3VFdmFFWHFsc2VOUU5nVXZld3BYOV9JNFZZeEZDUFlkeE9ueFZzRkN5d3NsMjBnYkg4NmVCQXIwYUZYZGp2TUxOaVdmc3VaLUs",
+    "payload": {
+      "completeness_score": 0.1667,
+      "threshold": 0.8,
+      "reason_code": "MISSING_SURVEY_PERIOD",
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ],
+      "invalid_fields": []
+    },
+    "status": "pending",
+    "created_at": "2026-02-23T10:16:15.436945+00:00"
+  },
+  {
+    "id": "rvq_d1cea183316b85f3",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_452db4024c0a564f",
+    "issue_type": "extract_error",
+    "stage": "legal_completeness_v1",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "required legal fields completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMiWkFVX3lxTFBtSUU5RVB3VnZEMDRzWUpNamxPNXk4WHpVR29KVVE2MDYtSFMxTTh5UWIxZ0dfcUlUVVZhVVhyYjlPeHNoYTdzam0tY2d0YUZibGRESW9MSXNoQQ",
+    "payload": {
+      "completeness_score": 0.1667,
+      "threshold": 0.8,
+      "reason_code": "MISSING_SURVEY_PERIOD",
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ],
+      "invalid_fields": []
+    },
+    "status": "pending",
+    "created_at": "2026-02-23T10:16:15.436955+00:00"
+  },
+  {
+    "id": "rvq_1a6fc23ef0f7c081",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_abb740f7fe640154",
+    "issue_type": "extract_error",
+    "stage": "legal_completeness_v1",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "required legal fields completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMimwFBVV95cUxPMjFRclBzZnhwdWlFY1l1QU1aRHNzem5UM0kzSW9LQjVldFNHeGg5ajlkZ1MycDYzek5RbWFTLVl5RjFlTlBLSzV4LXR1M1VmdTR3akpvTEp0SkFaR3h3Q0lIdEhDR0VkOFNJRWZEYXYtNEJGcHhuTEJOTG5zSEItZG04UWNUM2JsZUJsLUJnNXZYZExjSjRfQk0wQQ",
+    "payload": {
+      "completeness_score": 0.1667,
+      "threshold": 0.8,
+      "reason_code": "MISSING_SURVEY_PERIOD",
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ],
+      "invalid_fields": []
+    },
+    "status": "pending",
+    "created_at": "2026-02-23T10:16:15.436966+00:00"
+  },
+  {
+    "id": "rvq_93aeb36910033672",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_4466ab3585586751",
+    "issue_type": "extract_error",
+    "stage": "legal_completeness_v1",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "required legal fields completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMiYEFVX3lxTE1uRzhOaDNwa3IwZzl2RUdGNFZpdFVuU09Nd1VQS1F0UVZtLUdqOG5XcXNsNGxfb0gwRmllS2FxbVU5THN1ai1WLXRHVUxOY0ZzT2syakVYb3E3ME1Md05Dbw",
+    "payload": {
+      "completeness_score": 0.1667,
+      "threshold": 0.8,
+      "reason_code": "MISSING_SURVEY_PERIOD",
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ],
+      "invalid_fields": []
+    },
+    "status": "pending",
+    "created_at": "2026-02-23T10:16:15.436975+00:00"
+  },
+  {
+    "id": "rvq_46f1ca5611145674",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_99f136b9a635fd9c",
+    "issue_type": "extract_error",
+    "stage": "legal_completeness_v1",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "required legal fields completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMiYEFVX3lxTE4xWmdDbjdTOGNqY2Nrb3YxZXBuWGI3Wk5JVHpPVkVXMGpTbFhJcFdwNE9YdW91SG5OcmREWmVsU2hHYXJraEFsZmRfbUU1X2plYktaZWsta096RmNLSXlwbA",
+    "payload": {
+      "completeness_score": 0.1667,
+      "threshold": 0.8,
+      "reason_code": "MISSING_SURVEY_PERIOD",
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ],
+      "invalid_fields": []
+    },
+    "status": "pending",
+    "created_at": "2026-02-23T10:16:15.436984+00:00"
+  },
+  {
+    "id": "rvq_02bb980a8ad92829",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_95b0381df82f842f",
+    "issue_type": "extract_error",
+    "stage": "legal_completeness_v1",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "required legal fields completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMiakFVX3lxTE4wZGZXMFVLN3J2UHp3azQ4QXo3djlLTlpYQW5IQTdBMjRzSVJvWTlXRGVWNDZITi14WEp1ZDR2N2w5M0NVeEt5d0UzTjAtcmM2c0g2NVk2QWNMNGRzUjBVa2hISHY4UUJhZWfSAW5BVV95cUxOT3ZlMFB2VWxXNDBzVEdEazZHdWdfZkN5MkJ6a1N3TTVCM3ZZb0hnRXZDenhhMi1uZnVBYkp2UnVVN0Nld1BFTWIzMUpjekNvcFRnZGQyVTNBanowNFFiN3FVYWRxZ09OTnB1MHRhZw",
+    "payload": {
+      "completeness_score": 0.1667,
+      "threshold": 0.8,
+      "reason_code": "MISSING_SURVEY_PERIOD",
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ],
+      "invalid_fields": []
+    },
+    "status": "pending",
+    "created_at": "2026-02-23T10:16:15.436993+00:00"
+  },
+  {
+    "id": "rvq_c5bd3e5b6cce6170",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_ab61646857088d53",
+    "issue_type": "extract_error",
+    "stage": "legal_completeness_v1",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "required legal fields completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMiZkFVX3lxTE9KVFFNaktfaGhib2ktZi1kU1BDdFRFNkpkMjU3V0ZvbS1ZcUlCTGtPeV9xZWdvVlNzLUFpUi11aEpDSThtRFJ6eU15ZTFDdENobTNHeGJkdHhBWmtTWEpvS2R4dzlkUQ",
+    "payload": {
+      "completeness_score": 0.1667,
+      "threshold": 0.8,
+      "reason_code": "MISSING_SURVEY_PERIOD",
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ],
+      "invalid_fields": []
+    },
+    "status": "pending",
+    "created_at": "2026-02-23T10:16:15.437003+00:00"
+  },
+  {
+    "id": "rvq_f655b985f50181c6",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_d665019db527a0c8",
+    "issue_type": "extract_error",
+    "stage": "legal_completeness_v1",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "required legal fields completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMic0FVX3lxTE9vcmhfUVFoYXhYSWFsbW5HLXRFRnhxZDNyWXJKMWJFR05sVUIzVTFtN21TTTBldU5GWVFXa1BjVDk3YTRJNDlaQTJnOXhxQmpwT1dIaW9GSEF3NzBLZnIwZG44TGZvbzVwbEo3RFhjek81M3M",
+    "payload": {
+      "completeness_score": 0.1667,
+      "threshold": 0.8,
+      "reason_code": "MISSING_SURVEY_PERIOD",
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ],
+      "invalid_fields": []
+    },
+    "status": "pending",
+    "created_at": "2026-02-23T10:16:15.437013+00:00"
+  },
+  {
+    "id": "rvq_6914b5cfa65d0615",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_8dc5d149038ab97c",
+    "issue_type": "extract_error",
+    "stage": "legal_completeness_v1",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "required legal fields completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMicEFVX3lxTE9TYVNqLXN0aW1lemlIME05b25KX09HNFYydlg1Zk9iaUgyZ2kwcG12b0tTVHRtSEZNVTBoRm1xYS1zMlVCQzZaSnVYZjJlWjNZSkI2cUZlUVZ4TlY1M1BJUUFLd09UV2hiV0taaERtbi0",
+    "payload": {
+      "completeness_score": 0.1667,
+      "threshold": 0.8,
+      "reason_code": "MISSING_SURVEY_PERIOD",
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ],
+      "invalid_fields": []
+    },
+    "status": "pending",
+    "created_at": "2026-02-23T10:16:15.437022+00:00"
+  },
+  {
+    "id": "rvq_b683e5fe6d70a4cb",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_abd5a820705a0c85",
+    "issue_type": "extract_error",
+    "stage": "legal_completeness_v1",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "required legal fields completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMia0FVX3lxTE5rV1JFMFR0SkxfYlpaYkdnX1NtV1prMG9wSnV5aXRzZjJyMUVVWTg4cGx6NE45QlQ4RXE0anZDcWFwdGc1VldURDk5RENTcnRkQ2g4RjdfTDFYQkJhWkYtOFROWUZVZldWOFlF",
+    "payload": {
+      "completeness_score": 0.1667,
+      "threshold": 0.8,
+      "reason_code": "MISSING_SURVEY_PERIOD",
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ],
+      "invalid_fields": []
+    },
+    "status": "pending",
+    "created_at": "2026-02-23T10:16:15.437031+00:00"
+  },
+  {
+    "id": "rvq_7d1d3cd5a84d23a0",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_267a35b25c0310e6",
+    "issue_type": "extract_error",
+    "stage": "legal_completeness_v1",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "required legal fields completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMia0FVX3lxTE9RaTBaY1Qtc1A4RUlBQjJsSTZ4RnFfejV3MWlyZ1hhdFFBNjBQZGxCRzFTQVdMZlBhM0FjYnJCVDFQYVdiQzg3cHprdlRqT2RkbEpQTlk5S2VnaGZKS0pneTJZbDhZVF9mYlJr",
+    "payload": {
+      "completeness_score": 0.1667,
+      "threshold": 0.8,
+      "reason_code": "MISSING_SURVEY_PERIOD",
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ],
+      "invalid_fields": []
+    },
+    "status": "pending",
+    "created_at": "2026-02-23T10:16:15.437042+00:00"
+  },
+  {
+    "id": "rvq_239c2cd09ba3301b",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_ca5a62c853918c7d",
+    "issue_type": "extract_error",
+    "stage": "legal_completeness_v1",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "required legal fields completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMiakFVX3lxTE96dFJCbG1saGdROTh2XzBiTC1JWmVadFNRNkxGc3hsUk1ObDBHR3ZUUTJIclZGWVRxejZpNVlmeXU3WEJfZDduTU1DaWNyLVBXVFNBb2JNcDhQbmFENEtaVXFJZUdiLUx3OFE",
+    "payload": {
+      "completeness_score": 0.1667,
+      "threshold": 0.8,
+      "reason_code": "MISSING_SURVEY_PERIOD",
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ],
+      "invalid_fields": []
+    },
+    "status": "pending",
+    "created_at": "2026-02-23T10:16:15.437051+00:00"
+  },
+  {
+    "id": "rvq_7debc3a645ccf71a",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_10bff193dbeab2c2",
+    "issue_type": "extract_error",
+    "stage": "legal_completeness_v1",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "required legal fields completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMib0FVX3lxTE9hSmNUcHRHczB6dUJMb1dQdVFGWURiZkwtT185Z3NPREM2SEhhUVR3em40MC1Bb1RrWVQ0QW5EcFRrWDNMMDlUamF6WG5jMEpPYTdyQWE0alFkVlBrUDNEN1BlRHNfaEx2UG5sZ3lIc9IBc0FVX3lxTFBpckNUaTJsNWJoWTF2VWswYXp2cEVCSDBkLXRhekxwR3NldGhTZ1dNLUYtRDRQVDZ4NnhhUmRESkc1ek1EbEVKNmlDVEZjZGg3V1Y0OWtvNm8xZ1BUYnNzajIwVTVwME9Db0NNUzJEQVMyekE",
+    "payload": {
+      "completeness_score": 0.1667,
+      "threshold": 0.8,
+      "reason_code": "MISSING_SURVEY_PERIOD",
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ],
+      "invalid_fields": []
+    },
+    "status": "pending",
+    "created_at": "2026-02-23T10:16:15.437061+00:00"
+  },
+  {
+    "id": "rvq_cfd0f29214bf9879",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_9d3ae556e5c1176c",
+    "issue_type": "extract_error",
+    "stage": "legal_completeness_v1",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "required legal fields completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMibEFVX3lxTFB4a1kyeXpHZGEwQUQ2TlBXMkVhdFlmVVMzNzE4Y280SUVtQThUb2t0ZkVCVnAtTW81emxZLUpLb3BfdVV4MFgyX3ZPZ29xSndCdlBMSUJ6OGNnMlNzTFk3U3NmMWFiZDNNd1FoXw",
+    "payload": {
+      "completeness_score": 0.1667,
+      "threshold": 0.8,
+      "reason_code": "MISSING_SURVEY_PERIOD",
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ],
+      "invalid_fields": []
+    },
+    "status": "pending",
+    "created_at": "2026-02-23T10:16:15.437070+00:00"
+  },
+  {
+    "id": "rvq_b1fd7c77f7f9da4c",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_dce561b2d5190dbd",
+    "issue_type": "extract_error",
+    "stage": "legal_completeness_v1",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "required legal fields completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMibkFVX3lxTE13dHFYekJqODh4ZWhRMXJsM3JGNmRfUWlfM1ZBSVAteTZMVUZDZkJkUGRMbXhUbmRJaFBuUzZZVkVUVTd4ODlPeUpESDU5dVNTVjJnbjZBRERlZEVqMVhDSDgzWDFyU21RclBhdFV30gFyQVVfeXFMT0ZhbmdvTTVUd1ZYWEhLVFJ4RUVsZnkxWFNKUnFHLXAtbEFRbHRlLVZET0lHRTY0V0dQSWVuYl9vSjlBRnZ5UEw1LXVxdW9FNXgtUnlsV2xYWGgzSHZfS291RnNaUXJNMkg0cUM2UnhUUzRR",
+    "payload": {
+      "completeness_score": 0.1667,
+      "threshold": 0.8,
+      "reason_code": "MISSING_SURVEY_PERIOD",
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ],
+      "invalid_fields": []
+    },
+    "status": "pending",
+    "created_at": "2026-02-23T10:16:15.437080+00:00"
+  },
+  {
+    "id": "rvq_980c9ab48c3e327e",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_e1bbab6ef90f2035",
+    "issue_type": "extract_error",
+    "stage": "legal_completeness_v1",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "required legal fields completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMid0FVX3lxTE1LVDNVWnh6TjVlamhFRnMyT0ZWUzFMYnFSaXdlTTRQeHlQMk5pVTVpaGlCT2l3WDhvanhKRDYtTnJ1NE5CaVZWUW1oSTNCZXFlbEpyY3JRd0U1WDhxUi16cTc5bWdUaDdwWVpReTg3bG5hbGFiMG9r",
+    "payload": {
+      "completeness_score": 0.1667,
+      "threshold": 0.8,
+      "reason_code": "MISSING_SURVEY_PERIOD",
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ],
+      "invalid_fields": []
+    },
+    "status": "pending",
+    "created_at": "2026-02-23T10:16:15.437089+00:00"
+  },
+  {
+    "id": "rvq_d196f74ff3d8b835",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_d341b16da9bbd2f8",
+    "issue_type": "extract_error",
+    "stage": "legal_completeness_v1",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "required legal fields completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMic0FVX3lxTFBVYXlraGpwNnV1cG03cUptT1RVMzh5djQtUlhTaUU4TGl2RDROODE3d0ZNNWFOV2hIQ0Zib2NhS0tfT3J4QlZ6N0d4V1hDbENQbUhRM29zQklsRTZJMnN1Wksxem5QRnRUSXlRdFh4VDBRU2vSAXdBVV95cUxQdTgzNm1GNUxYZUkxMHBaX1VQWnp5ZXJGZExxMm8xVVlyeGlWcWxlYV9RVGJTWi1VOGljVzdFeUxVM3FqcGs1OWM5d043MWxibldsQm5aaWF1MDlYdDlkaUdQT0JVSXpGSnRMTXRrUjZNeEFtdUh2UQ",
+    "payload": {
+      "completeness_score": 0.1667,
+      "threshold": 0.8,
+      "reason_code": "MISSING_SURVEY_PERIOD",
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ],
+      "invalid_fields": []
+    },
+    "status": "pending",
+    "created_at": "2026-02-23T10:16:15.437098+00:00"
+  },
+  {
+    "id": "rvq_83968a3e77f0a921",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_7ccfac81c4403bf6",
+    "issue_type": "extract_error",
+    "stage": "legal_completeness_v1",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "required legal fields completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMiX0FVX3lxTE9JS21CZlgydEwySXlWd2dLR01aYkt0TEk1d1lwMldvbmREQXgxM0lrU3pIRlE4Q2J1dUxGSGlVSnZMeTNnYzZYRXlrYmRiQk1HUExPR3l2NnRzbktSU21n",
+    "payload": {
+      "completeness_score": 0.1667,
+      "threshold": 0.8,
+      "reason_code": "MISSING_SURVEY_PERIOD",
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ],
+      "invalid_fields": []
+    },
+    "status": "pending",
+    "created_at": "2026-02-23T10:16:15.437108+00:00"
+  },
+  {
+    "id": "rvq_4faf2d1dc3d4fc45",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_a02b7812d9a92751",
+    "issue_type": "extract_error",
+    "stage": "legal_completeness_v1",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "required legal fields completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMiZ0FVX3lxTE5jQVU3NlFQUjVHVWJZOHpLUzNzOVlhNlBHVWpidkpNc3ZHcmN3VzgxZjZHLUhMbFFwNHRFR2FTSFltVUZYZ3NRTlBaTlNHT2d0eGtXNE9uYm5PX3pyTU5tVzh0Um04ME0",
+    "payload": {
+      "completeness_score": 0.1667,
+      "threshold": 0.8,
+      "reason_code": "MISSING_SURVEY_PERIOD",
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ],
+      "invalid_fields": []
+    },
+    "status": "pending",
+    "created_at": "2026-02-23T10:16:15.437117+00:00"
+  },
+  {
+    "id": "rvq_9f36849dc8ed0812",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_160d17843ca5cf29",
+    "issue_type": "extract_error",
+    "stage": "legal_completeness_v1",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "required legal fields completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMie0FVX3lxTE5oMVdrbXRkWnZ3el9Rdm9lUDFMXzFyLV84MGlNWHdKWkNDcUc5MjVrQWNyQ3h0Rml5TjFoVjU4YTR1ejRMbzltMXNoX0x6ektuVF90dHJkbnVwV1J5d2RvZ0FOcWc2cFI4MEZ3dnFQcGU0OXlIbmxSU0s1OA",
+    "payload": {
+      "completeness_score": 0.1667,
+      "threshold": 0.8,
+      "reason_code": "MISSING_SURVEY_PERIOD",
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ],
+      "invalid_fields": []
+    },
+    "status": "pending",
+    "created_at": "2026-02-23T10:16:15.437127+00:00"
+  },
+  {
+    "id": "rvq_c1b38016a0466e5a",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_3b751ae1d39aae53",
+    "issue_type": "extract_error",
+    "stage": "legal_completeness_v1",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "required legal fields completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMiwwJBVV95cUxQX2VpWjVZelZWb1FuMWhYSV91QmZPa2ZtZ0NsbU0xN3FyVW9MbjVxOHRqRjYzMm1jNjFCNUduVXJ4TWF2UDFZVUdjLXk4YXl1YmpXaUJ1Y2l5WTBmUGpESWlfV1Zoai16Rncyc2JLenVFM0ZYNU1fbXdvcS0yTV9VT3JjelAxZi1KYTFZNjU5U2NkeUlTNlVmVXVDbk4zR3FZa2FPT2ZZcjdZQ0VlNWYwZHF4WldiYnBIdk1FSWFDYkQ1RW1mOWtLRHRKNUxxR05wS3JkQ0ctYkJCZnRfS2hpMEl3N3pPSVN5YzRXb0M4bkk5VXFxZEx4X0Z6bXE1dlRQMERjblQzNEswSkU3YS1vc201OExYS19DUFEzZE45UWFpeDlRaDdRY3FnWktaRnZXbmNtRWphY1QtTGNGcUU3WWRVVQ",
+    "payload": {
+      "completeness_score": 0.1667,
+      "threshold": 0.8,
+      "reason_code": "MISSING_SURVEY_PERIOD",
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ],
+      "invalid_fields": []
+    },
+    "status": "pending",
+    "created_at": "2026-02-23T10:16:15.437137+00:00"
+  },
+  {
+    "id": "rvq_f194cf4eb16dcdf9",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_92b3ae667ed44a57",
+    "issue_type": "extract_error",
+    "stage": "legal_completeness_v1",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "required legal fields completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMiRkFVX3lxTE1fR1ZSZ0UtYi1yXzhrY2E2RG0zSVY1emdGY2d1X0E2MFhoMFJzWmdxdHVGc01SVVAtWXBRTFB1TF9HOWtKcHc",
+    "payload": {
+      "completeness_score": 0.1667,
+      "threshold": 0.8,
+      "reason_code": "MISSING_SURVEY_PERIOD",
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ],
+      "invalid_fields": []
+    },
+    "status": "pending",
+    "created_at": "2026-02-23T10:16:15.437146+00:00"
+  },
+  {
+    "id": "rvq_e9c8facc659a7598",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_83b190c9d54487cf",
+    "issue_type": "extract_error",
+    "stage": "legal_completeness_v1",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "required legal fields completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMiVEFVX3lxTE9Md3dtcUxnNEdfenIxX3BmVFpvcTFXWDZSOF92eHY2cXMyWnRyZlJnUF92c29fNVRHNEhHSUV0QzNDbVJmVFVlSmFPQktaVHF1ckkxWA",
+    "payload": {
+      "completeness_score": 0.1667,
+      "threshold": 0.8,
+      "reason_code": "MISSING_SURVEY_PERIOD",
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ],
+      "invalid_fields": []
+    },
+    "status": "pending",
+    "created_at": "2026-02-23T10:16:15.437155+00:00"
+  },
+  {
+    "id": "rvq_439c07c5a5112bcf",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_13d822a5fd33a42a",
+    "issue_type": "extract_error",
+    "stage": "legal_completeness_v1",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "required legal fields completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMimwFBVV95cUxOQ2VPMzZEc2hfMTg4U1JTREtmUFZ2N1dLR25UYzVyelk2RkJNMUxFSFpqSzBBYnZkcjROR19VX2N5MVE4QWh4ZWFtUWU2QTFiN293clhINkplVlFrbndmanNRb2ljVUlaWGJlTFhsLXZlWUM0RjZTTkM1OGhmbGJsVnBiRllQM2dESGN2OGVucG8tSmkxeXZkNWtYaw",
+    "payload": {
+      "completeness_score": 0.1667,
+      "threshold": 0.8,
+      "reason_code": "MISSING_SURVEY_PERIOD",
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ],
+      "invalid_fields": []
+    },
+    "status": "pending",
+    "created_at": "2026-02-23T10:16:15.437164+00:00"
+  },
+  {
+    "id": "rvq_fe2721e6489aa6b8",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_d0980e8b742d5af7",
+    "issue_type": "extract_error",
+    "stage": "legal_completeness_v1",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "required legal fields completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMiWkFVX3lxTE1BM2JoVG1qT3VaUG1Jd2xrb2ZWWVIyd0Q2VF80TjlORUhoODQ0RkVvOUZMTHdET3gzd29KV0ZNdXRzWnptRGlpTm80d2FSbFFGb3B2ajI1TkRzQdIBWEFVX3lxTE1vM2pwWUw4VVA5Mzd1MTk5dEQ2TlRETUhURnlFWjhQU2hXXzdlajJCXzIyUktYSW1HeDVWNXBldDd3a0ladWFCM2ZOakZ5QU9MZklhdi10cjE",
+    "payload": {
+      "completeness_score": 0.1667,
+      "threshold": 0.8,
+      "reason_code": "MISSING_SURVEY_PERIOD",
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ],
+      "invalid_fields": []
+    },
+    "status": "pending",
+    "created_at": "2026-02-23T10:16:15.437173+00:00"
+  }
+]

--- a/scripts/generate_collector_article_legal_completeness_v1_batch50.py
+++ b/scripts/generate_collector_article_legal_completeness_v1_batch50.py
@@ -1,0 +1,299 @@
+from __future__ import annotations
+
+from collections import Counter
+from datetime import date
+import json
+from pathlib import Path
+import re
+from typing import Any
+
+from src.pipeline.contracts import new_review_queue_item
+
+INPUT_SOURCE = "data/bootstrap_ingest_coverage_v2.json"
+OUT_BATCH = "data/collector_article_legal_completeness_v1_batch50.json"
+OUT_REPORT = "data/collector_article_legal_completeness_v1_report.json"
+OUT_REVIEW_QUEUE = "data/collector_article_legal_completeness_v1_review_queue_candidates.json"
+
+REQUIRED_FIELDS: tuple[str, ...] = (
+    "sponsor",
+    "pollster",
+    "survey_period",
+    "sample_size",
+    "response_rate",
+    "margin_of_error",
+)
+
+SAMPLE_SIZE = 50
+THRESHOLD = 0.8
+
+_SPONSOR_RE = re.compile(r"(?:의뢰자|의뢰기관|의뢰처|의뢰)\s*[:：]?\s*([가-힣A-Za-z0-9\(\)\-·\s]{2,40})")
+
+
+def _parse_json(path: str) -> dict[str, Any]:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def _extract_sponsor_from_text(article_text: str | None) -> str | None:
+    if not article_text:
+        return None
+    m = _SPONSOR_RE.search(article_text)
+    if not m:
+        return None
+    candidate = " ".join((m.group(1) or "").split()).strip(" .,)")
+    if len(candidate) < 2:
+        return None
+    return candidate
+
+
+def _is_valid_iso_date(value: str | None) -> bool:
+    if not value:
+        return False
+    text = str(value).strip()
+    if not text:
+        return False
+    if "T" in text:
+        text = text.split("T", 1)[0]
+    try:
+        date.fromisoformat(text)
+    except ValueError:
+        return False
+    return True
+
+
+def _is_valid_numeric(field: str, value: Any) -> bool:
+    if value is None:
+        return False
+    try:
+        n = float(value)
+    except (TypeError, ValueError):
+        return False
+
+    if field == "sample_size":
+        return n > 0 and float(n).is_integer()
+    if field == "response_rate":
+        return 0 < n <= 100
+    if field == "margin_of_error":
+        return 0 < n <= 100
+    return False
+
+
+def _reason_code(missing_fields: list[str], invalid_fields: list[str]) -> str:
+    if not missing_fields and not invalid_fields:
+        return "COMPLETE"
+    if invalid_fields:
+        return "ABNORMAL_REQUIRED_FIELD_VALUE"
+    if "survey_period" in missing_fields:
+        return "MISSING_SURVEY_PERIOD"
+    if any(k in missing_fields for k in ("sponsor", "pollster")):
+        return "MISSING_SURVEY_ACTOR"
+    if any(k in missing_fields for k in ("sample_size", "response_rate", "margin_of_error")):
+        return "MISSING_STATISTICAL_META"
+    return "MISSING_REQUIRED_FIELDS"
+
+
+def _field_value(field: str, observation: dict[str, Any], article: dict[str, Any]) -> Any:
+    if field == "sponsor":
+        obs_value = observation.get("sponsor")
+        if isinstance(obs_value, str) and obs_value.strip():
+            return obs_value.strip()
+        return _extract_sponsor_from_text(article.get("raw_text"))
+    if field == "pollster":
+        return observation.get("pollster")
+    if field == "survey_period":
+        start = observation.get("survey_start_date")
+        end = observation.get("survey_end_date")
+        return {
+            "survey_start_date": start,
+            "survey_end_date": end,
+        }
+    if field == "sample_size":
+        return observation.get("sample_size")
+    if field == "response_rate":
+        return observation.get("response_rate")
+    if field == "margin_of_error":
+        return observation.get("margin_of_error")
+    return None
+
+
+def _field_present_and_valid(field: str, value: Any) -> tuple[bool, bool]:
+    if field in {"sponsor", "pollster"}:
+        present = isinstance(value, str) and bool(value.strip())
+        return present, present
+
+    if field == "survey_period":
+        period = value if isinstance(value, dict) else {}
+        start_ok = _is_valid_iso_date(period.get("survey_start_date"))
+        end_ok = _is_valid_iso_date(period.get("survey_end_date"))
+        present = start_ok or end_ok
+        valid = present
+        return present, valid
+
+    present = value is not None
+    valid = _is_valid_numeric(field, value)
+    return present, valid
+
+
+def generate_collector_article_legal_completeness_v1_batch50(
+    *,
+    source_path: str = INPUT_SOURCE,
+    sample_size: int = SAMPLE_SIZE,
+    threshold: float = THRESHOLD,
+) -> dict[str, Any]:
+    payload = _parse_json(source_path)
+    rows = list(payload.get("records") or [])[:sample_size]
+    if len(rows) < sample_size:
+        raise RuntimeError(f"insufficient source records: got={len(rows)} required={sample_size}")
+
+    scored_records: list[dict[str, Any]] = []
+    review_queue_candidates: list[dict[str, Any]] = []
+
+    present_counts = Counter()
+    valid_counts = Counter()
+    missing_counts = Counter()
+    invalid_counts = Counter()
+    reason_counts = Counter()
+
+    threshold_miss_count = 0
+
+    for idx, row in enumerate(rows):
+        article = row.get("article") or {}
+        observation = dict(row.get("observation") or {})
+
+        required_schema: dict[str, dict[str, Any]] = {}
+        missing_fields: list[str] = []
+        invalid_fields: list[str] = []
+
+        for field in REQUIRED_FIELDS:
+            value = _field_value(field, observation, article)
+            present, valid = _field_present_and_valid(field, value)
+            required_schema[field] = {
+                "value": value,
+                "is_present": present,
+                "is_valid": valid,
+            }
+
+            if present:
+                present_counts[field] += 1
+            else:
+                missing_counts[field] += 1
+                missing_fields.append(field)
+
+            if valid:
+                valid_counts[field] += 1
+            elif present:
+                invalid_counts[field] += 1
+                invalid_fields.append(field)
+
+        filled_count = sum(1 for field in REQUIRED_FIELDS if required_schema[field]["is_present"] and required_schema[field]["is_valid"])
+        required_count = len(REQUIRED_FIELDS)
+        score = round(filled_count / required_count, 4)
+        reason_code = _reason_code(missing_fields, invalid_fields)
+        reason_counts[reason_code] += 1
+
+        observation["legal_required_schema"] = required_schema
+        observation["legal_completeness_score"] = score
+        observation["legal_filled_count"] = filled_count
+        observation["legal_required_count"] = required_count
+        observation["legal_missing_fields"] = missing_fields
+        observation["legal_invalid_fields"] = invalid_fields
+        observation["legal_reason_code"] = reason_code
+
+        new_row = dict(row)
+        new_row["observation"] = observation
+        scored_records.append(new_row)
+
+        if score < threshold:
+            threshold_miss_count += 1
+            review_queue_candidates.append(
+                new_review_queue_item(
+                    entity_type="poll_observation",
+                    entity_id=str(observation.get("observation_key") or f"obs-{idx}"),
+                    issue_type="extract_error",
+                    stage="legal_completeness_v1",
+                    error_code="LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+                    error_message="required legal fields completeness below threshold",
+                    source_url=article.get("url"),
+                    payload={
+                        "completeness_score": score,
+                        "threshold": threshold,
+                        "reason_code": reason_code,
+                        "missing_fields": missing_fields,
+                        "invalid_fields": invalid_fields,
+                    },
+                ).to_dict()
+            )
+
+    field_rates = {}
+    for field in REQUIRED_FIELDS:
+        field_rates[field] = {
+            "present_count": present_counts[field],
+            "present_rate": round(present_counts[field] / sample_size, 4),
+            "valid_count": valid_counts[field],
+            "valid_rate": round(valid_counts[field] / sample_size, 4),
+            "missing_count": missing_counts[field],
+            "missing_rate": round(missing_counts[field] / sample_size, 4),
+            "invalid_count": invalid_counts[field],
+            "invalid_rate": round(invalid_counts[field] / sample_size, 4),
+        }
+
+    avg_score = round(
+        sum((r.get("observation") or {}).get("legal_completeness_score") or 0.0 for r in scored_records) / sample_size,
+        4,
+    )
+
+    report = {
+        "run_type": "collector_article_legal_completeness_v1",
+        "source_path": source_path,
+        "sample_size": sample_size,
+        "required_fields": list(REQUIRED_FIELDS),
+        "threshold": threshold,
+        "completeness": {
+            "avg_score": avg_score,
+            "min_score": min((r.get("observation") or {}).get("legal_completeness_score") or 0.0 for r in scored_records),
+            "max_score": max((r.get("observation") or {}).get("legal_completeness_score") or 0.0 for r in scored_records),
+            "threshold_miss_count": threshold_miss_count,
+            "threshold_miss_rate": round(threshold_miss_count / sample_size, 4),
+        },
+        "field_rates": field_rates,
+        "reason_code_counts": dict(reason_counts),
+        "review_queue_candidate_count": len(review_queue_candidates),
+        "acceptance_checks": {
+            "sample_size_eq_50": sample_size == 50,
+            "threshold_miss_review_queue_synced": len(review_queue_candidates) == threshold_miss_count,
+            "has_missing_or_abnormal_cases": threshold_miss_count > 0,
+        },
+    }
+
+    batch = {
+        "run_type": "collector_article_legal_completeness_v1",
+        "extractor_version": "collector-legal-completeness-v1",
+        "source_payload": source_path,
+        "threshold": threshold,
+        "required_fields": list(REQUIRED_FIELDS),
+        "records": scored_records,
+    }
+
+    return {
+        "batch": batch,
+        "report": report,
+        "review_queue_candidates": review_queue_candidates,
+    }
+
+
+def main() -> None:
+    out = generate_collector_article_legal_completeness_v1_batch50()
+    Path(OUT_BATCH).write_text(json.dumps(out["batch"], ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    Path(OUT_REPORT).write_text(json.dumps(out["report"], ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    Path(OUT_REVIEW_QUEUE).write_text(
+        json.dumps(out["review_queue_candidates"], ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    print(json.dumps(out["report"], ensure_ascii=False, indent=2))
+    print("written:", OUT_BATCH)
+    print("written:", OUT_REPORT)
+    print("written:", OUT_REVIEW_QUEUE)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_collector_article_legal_completeness_v1_script.py
+++ b/tests/test_collector_article_legal_completeness_v1_script.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.generate_collector_article_legal_completeness_v1_batch50 import (
+    generate_collector_article_legal_completeness_v1_batch50,
+)
+
+
+def _record(
+    *,
+    key: str,
+    pollster: str | None,
+    survey_end_date: str | None,
+    sample_size: int | None,
+    response_rate: float | None,
+    margin_of_error: float | None,
+    raw_text: str,
+) -> dict:
+    return {
+        "article": {
+            "url": f"https://example.test/{key}",
+            "title": "기사",
+            "publisher": "테스트",
+            "published_at": "2026-02-20T09:00:00+09:00",
+            "raw_text": raw_text,
+            "raw_hash": key,
+        },
+        "region": {
+            "region_code": "11-000",
+            "sido_name": "서울특별시",
+            "sigungu_name": "전체",
+            "admin_level": "sido",
+            "parent_region_code": None,
+        },
+        "candidates": [],
+        "observation": {
+            "observation_key": key,
+            "survey_name": "조사",
+            "pollster": pollster,
+            "survey_start_date": None,
+            "survey_end_date": survey_end_date,
+            "sample_size": sample_size,
+            "response_rate": response_rate,
+            "margin_of_error": margin_of_error,
+            "region_code": "11-000",
+            "office_type": "광역자치단체장",
+            "matchup_id": "20260603|광역자치단체장|11-000",
+            "verified": False,
+            "source_grade": None,
+        },
+        "options": [],
+    }
+
+
+def test_completeness_threshold_routes_review_queue(tmp_path: Path) -> None:
+    payload = {
+        "run_type": "collector_bootstrap",
+        "extractor_version": "x",
+        "llm_model": None,
+        "records": [
+            _record(
+                key="obs-good",
+                pollster="한국갤럽",
+                survey_end_date="2026-02-20",
+                sample_size=1000,
+                response_rate=12.3,
+                margin_of_error=3.1,
+                raw_text="의뢰자: 서울신문",
+            ),
+            _record(
+                key="obs-bad",
+                pollster=None,
+                survey_end_date=None,
+                sample_size=None,
+                response_rate=None,
+                margin_of_error=None,
+                raw_text="의뢰 정보 없음",
+            ),
+        ],
+    }
+    source = tmp_path / "source.json"
+    source.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+
+    out = generate_collector_article_legal_completeness_v1_batch50(
+        source_path=str(source),
+        sample_size=2,
+        threshold=0.8,
+    )
+
+    assert out["report"]["completeness"]["threshold_miss_count"] == 1
+    assert len(out["review_queue_candidates"]) == 1
+    assert out["review_queue_candidates"][0]["error_code"] == "LEGAL_COMPLETENESS_BELOW_THRESHOLD"
+
+
+def test_completeness_schema_injection_and_reason_codes(tmp_path: Path) -> None:
+    payload = {
+        "run_type": "collector_bootstrap",
+        "extractor_version": "x",
+        "llm_model": None,
+        "records": [
+            _record(
+                key="obs-1",
+                pollster="한국갤럽",
+                survey_end_date="2026-02-20",
+                sample_size=1000,
+                response_rate=12.3,
+                margin_of_error=3.1,
+                raw_text="의뢰자: 서울신문",
+            ),
+            _record(
+                key="obs-2",
+                pollster="리얼미터",
+                survey_end_date="2026-02-20",
+                sample_size=1000,
+                response_rate=200.0,
+                margin_of_error=3.1,
+                raw_text="의뢰자: 부산일보",
+            ),
+        ],
+    }
+    source = tmp_path / "source.json"
+    source.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+
+    out = generate_collector_article_legal_completeness_v1_batch50(
+        source_path=str(source),
+        sample_size=2,
+        threshold=0.8,
+    )
+
+    rec1 = out["batch"]["records"][0]["observation"]
+    rec2 = out["batch"]["records"][1]["observation"]
+
+    assert rec1["legal_completeness_score"] == 1.0
+    assert rec1["legal_reason_code"] == "COMPLETE"
+    assert rec1["legal_required_schema"]["sponsor"]["is_present"] is True
+
+    assert rec2["legal_reason_code"] == "ABNORMAL_REQUIRED_FIELD_VALUE"
+    assert "response_rate" in rec2["legal_invalid_fields"]


### PR DESCRIPTION
## Summary\n- Add batch50 legal-required completeness scoring pipeline for article extraction records\n- Enforce required schema fields and compute completeness score (0~1)\n- Route below-threshold cases to review_queue candidates with reason_code/missing_fields/invalid_fields\n- Generate report + review_queue evidence artifacts\n\n## Verification\n- PYTHONPATH=. /Users/gimtaehun/election2026_codex/.venv/bin/pytest -q tests/test_collector_article_legal_completeness_v1_script.py tests/test_collector_extract.py\n- Result: 14 passed\n- PYTHONPATH=. /Users/gimtaehun/election2026_codex/.venv/bin/python scripts/generate_collector_article_legal_completeness_v1_batch50.py\n\n## Report\n- Collector_reports/2026-02-23_S2_기사_법정필수항목_completeness_스코어링_report.md\n\nCloses #218