### PR TITLE
[COLLECTOR] #248 live-news green 이후 실데이터 품질 Post-check

### DIFF
--- a/Collector_reports/2026-02-24_s5_live_news_post_green_quality_postcheck_report.md
+++ b/Collector_reports/2026-02-24_s5_live_news_post_green_quality_postcheck_report.md
@@ -1,0 +1,60 @@
+# [COLLECTOR][S5] live-news green 이후 실데이터 품질 Post-check 보고서 (#248)
+
+## 1) 분석 대상
+- 기준 run: `22338262595` (collector-live-news-schedule first green)
+- 아티팩트 경로:
+  - `data/verification/issue248_run_22338262595_artifacts/collector-live-news-artifacts/collector_live_news_v1_report.json`
+  - `data/verification/issue248_run_22338262595_artifacts/collector-live-news-artifacts/collector_live_news_v1_review_queue_candidates.json`
+  - `data/verification/issue248_run_22338262595_artifacts/collector-live-news-artifacts/collector_live_news_v1_ingest_runner_report.json`
+- 분석 요약 JSON:
+  - `data/verification/issue248_live_news_postcheck_summary.json`
+
+## 2) 지표표
+| Metric | Value |
+|---|---:|
+| ingest_count | 37 |
+| threshold_miss_rate | 1.0000 |
+| fallback_fetch_count | 63 |
+| review_queue_mix.fetch_error | 63 (59.43%) |
+| review_queue_mix.extract_error | 42 (39.62%) |
+| review_queue_mix.mapping_error | 1 (0.94%) |
+
+## 3) completeness / threshold miss 분포
+- threshold: `0.8`
+- avg/min/max: `0.1802 / 0.1667 / 0.3333`
+- score value 분포:
+  - `0.1667`: 34건
+  - `0.3333`: 3건
+- score bucket 분포:
+  - `<0.2`: 34건
+  - `0.2~<0.4`: 3건
+- threshold miss: `37/37 (100%)`
+- missing field 집중:
+  - `sponsor/sample_size/response_rate/margin_of_error`: 각 37건 누락
+  - `survey_period`: 34건 누락
+
+## 4) ingest runner 신호
+- 최종 상태: `success=true`, `http_status=200`, `job_status=success`
+- 시도: 3회
+  - 1~2회 timeout
+  - 3회 성공
+
+## 5) 해석
+- 런 자체는 green이며 ingest 수량 기준(`>=30`)은 충족했지만, 추출 품질은 threshold 기준에서 전량 미달입니다.
+- review_queue의 과반이 `fetch_error(ROBOTS_BLOCKLIST_BYPASS)`로, fetch 단계 병목이 가장 큽니다.
+- completeness 저하는 법정필수 필드 파싱 부재가 직접 원인입니다.
+
+## 6) 다음 튜닝 우선순위(2개)
+1. 법정필수 필드 추출 강화(최우선)
+- 대상: `sponsor/sample_size/response_rate/margin_of_error/survey_period`
+- 방법: 본문/표 캡션 패턴팩 + 수치 정규화 파서 확장 + 필드별 fallback 규칙
+- 기대효과: `threshold_miss_rate` 직접 하락
+
+2. fetch 차단 대응 경로 개선
+- 대상: `ROBOTS_BLOCKLIST_BYPASS` 대량 발생 소스
+- 방법: 도메인별 fetch 정책 분기(허용 소스 직수집 + 차단 소스 대체 경로/메타수집) 및 discovery 품질 게이트 재조정
+- 기대효과: `fallback_fetch_count`/`fetch_error` 비중 축소, 추출 가능 문서 비율 상승
+
+## 7) 완료 기준 충족 여부
+- `Collector_reports/` post-green 분석 보고서 제출: 충족
+- 지표표(ingest_count, threshold_miss_rate, fallback_fetch_count, review_queue_mix) 포함: 충족

--- a/data/verification/issue248_live_news_postcheck_summary.json
+++ b/data/verification/issue248_live_news_postcheck_summary.json
@@ -1,0 +1,68 @@
+{
+  "run_id": 22338262595,
+  "artifact_dir": "/Users/gimtaehun/election2026_codex__issue248/data/verification/issue248_run_22338262595_artifacts/collector-live-news-artifacts",
+  "metric_table": {
+    "ingest_count": 37,
+    "threshold_miss_rate": 1.0,
+    "fallback_fetch_count": 63,
+    "review_queue_mix": {
+      "extract_error": {
+        "count": 42,
+        "ratio": 0.3962
+      },
+      "fetch_error": {
+        "count": 63,
+        "ratio": 0.5943
+      },
+      "mapping_error": {
+        "count": 1,
+        "ratio": 0.0094
+      }
+    }
+  },
+  "legal_completeness": {
+    "threshold": 0.8,
+    "avg_score": 0.1802,
+    "min_score": 0.1667,
+    "max_score": 0.3333,
+    "score_value_distribution": {
+      "0.1667": 34,
+      "0.3333": 3
+    },
+    "score_bucket_distribution": {
+      "0_2_to_lt_0_4": 3,
+      "lt_0_2": 34
+    },
+    "threshold_miss_count": 37,
+    "threshold_miss_rate": 1.0,
+    "missing_field_counts": {
+      "sponsor": 37,
+      "sample_size": 37,
+      "response_rate": 37,
+      "margin_of_error": 37,
+      "survey_period": 34
+    }
+  },
+  "review_queue": {
+    "total_count": 106,
+    "issue_type_counts": {
+      "extract_error": 42,
+      "fetch_error": 63,
+      "mapping_error": 1
+    },
+    "error_code_top10": {
+      "ROBOTS_BLOCKLIST_BYPASS": 63,
+      "LEGAL_COMPLETENESS_BELOW_THRESHOLD": 37,
+      "NO_TITLE_CANDIDATE_SIGNAL": 4,
+      "POLICY_ONLY_SIGNAL": 1,
+      "REGION_OFFICE_NOT_MAPPED": 1
+    }
+  },
+  "ingest_runner": {
+    "success": true,
+    "attempt_count": 3,
+    "timeout_attempt_count": 2,
+    "final_http_status": 200,
+    "final_job_status": "success"
+  }
+}

--- a/data/verification/issue248_run_22338262595_artifacts/collector-live-news-artifacts/collector_live_news_v1_ingest_runner_report.json
+++ b/data/verification/issue248_run_22338262595_artifacts/collector-live-news-artifacts/collector_live_news_v1_ingest_runner_report.json
@@ -1,0 +1,45 @@
+{
+  "success": true,
+  "attempts": [
+    {
+      "attempt": 1,
+      "http_status": null,
+      "job_status": null,
+      "failure_class": "timeout",
+      "failure_type": "timeout",
+      "retryable": true,
+      "request_timeout_seconds": 180.0,
+      "error": "ReadTimeout: timed out",
+      "detail": null
+    },
+    {
+      "attempt": 2,
+      "http_status": null,
+      "job_status": null,
+      "failure_class": "timeout",
+      "failure_type": "timeout",
+      "retryable": true,
+      "request_timeout_seconds": 270.0,
+      "error": "ReadTimeout: timed out",
+      "detail": null
+    },
+    {
+      "attempt": 3,
+      "http_status": 200,
+      "job_status": "success",
+      "failure_class": null,
+      "failure_type": null,
+      "retryable": false,
+      "request_timeout_seconds": 360.0,
+      "error": null,
+      "detail": null
+    }
+  ],
+  "run_ids": [
+    362
+  ],
+  "finished_at": "2026-02-24T05:54:20.298261+00:00",
+  "failure_class": null,
+  "failure_type": null,
+  "failure_reason": null
+}

--- a/data/verification/issue248_run_22338262595_artifacts/collector-live-news-artifacts/collector_live_news_v1_payload.json
+++ b/data/verification/issue248_run_22338262595_artifacts/collector-live-news-artifacts/collector_live_news_v1_payload.json
@@ -1,0 +1,3391 @@
+{
+  "run_type": "collector_live_news_v1",
+  "extractor_version": "collector-live-news-v1",
+  "llm_model": null,
+  "records": [
+    {
+      "article": {
+        "url": "https://www.khan.co.kr/article/202602231023001/",
+        "title": "경기지사 후보 조사서 추미애 20%·김동연 15%···오차범위 내 접전 - 경향신문",
+        "publisher": "경향신문",
+        "published_at": "2026-02-23T10:23:00+09:00",
+        "raw_text": "경기지사 후보 조사서 추미애 20%·김동연 15%···오차범위 내 접전 - 경향신문 창간 80주년 경향신문 오피니언 정치 경제 사회 국제 문화 라이프 경기지사 후보 조사서 추미애 20%·김동연 15%···오차범위 내 접전 myNews --> 로그인 검색 메뉴 댓글 0 공유하기 뉴스플리 글자크기 기사듣기 완독 닫기 검색 경향신문 메뉴 펼치기 메뉴 접기 오피니언 전체 사설 여적 기자메모 칼럼 만평 독자마당 정치 전체 청와대 국회·정당 국방·외교 북한·한반도 선거 정치 일반 경제 전체 금융·재테크 산업 IT·가전 부동산 자동차 생활경제 취업·창업 경제 일반 사회 전체 사건·사고 법원·검찰 교육·입시 노동 보건·복지 미디어 젠더 사회 일반 국제 전체 미국·중남미 일본 중국·대만 유럽 아시아·호주 중동·아프리카 국제 일반 문화 전체 책 연극·클래식 학술·문화재 종교 미술·건축 대중음악 영화 방송 문화 일반 스포츠 지역 과학·환경 라이프 사람 ENGLISH 뉴스레터 영상 플랫 사진+ 인터랙티브 이슈 기획·연재 경향티비 스튜디오 경향 암호명 3701 최신 기사 실시간 랭킹 기사 구독신청 기사제보 지면보기 RSS 보도자료 알림 경향신문 앱 스포츠경향 주간경향 레이디경향 facebook youtube x instagram google RSS 공유하기 닫기 카카오톡 카카오톡 페이스북 페이스북 X X 밴드 밴드 --> 블로그 블로그 --> URL 복사 URL 복사 이메일 이메일 보기 설정 닫기 글자 크기 보통 보통 크게 크게 아주 크게 아주 크게 컬러 모드 라이트 라이트 다크 다크 베이지 베이지 그린 그린 컬러 모드 닫기 라이트 라이트 다크 다크 베이지 베이지 그린 그린 본문 요약 닫기 다가오는 6·3 지방선거를 앞두고 실시된 경기지사 후보 적합도 여론조사에서 추미애 더불어민주당 의원과 현역인 김동연 경기지사가 오차범위 내 접전을 벌이고 있다는 결과가 나왔다. 민주당 후보 적합도 조사 결과를 보면 김 지사가 27%, 추 의원이 21%를 각각 얻으며 오차범위 내에서 경쟁을 벌이고 있는 것으로 나타났다. 민주당을 지지한다고 밝힌 응답자들 중에선 추 의원이 35%, 김 지사가 28%였다. 인공지능 기술로 자동 요약된 내용입니다. 전체 내용을 이해하기 위해 본문과 함께 읽는 것을 추천합니다. (제공 = 경향신문&NAVER MEDIA API) 내 뉴스플리에 저장 닫기 정치 경기지사 후보 조사서 추미애 20%·김동연 15%···오차범위 내 접전 입력 2026.02.23 10:23 수정 2026.02.23 18:01 펼치기/접기 김태희 기자 기사 읽기 요약 기사를 재생 중이에요 기사 읽기 민주당 후보 조사선 김 지사 27%, 추 의원 21% 범보수 야권, “적합한 후보 없다” 54% 6·3 지방선거를 100일 앞둔 23일 서울 종로구 서울특별시선거관리위원회에서 선관위 직원들이 안내판 스티커를 붙이고 있다. 연합뉴스 다가오는 6·3 지방선거를 앞두고 실시된 경기지사 후보 적합도 여론조사에서 추미애 더불어민주당 의원과 현역인 김동연 경기지사가 오차범위 내 접전을 벌이고 있다는 결과가 나왔다. 23일 경인일보가 지난 19~20일 한국리서치에 의뢰해 경기도민 1000명을 대상으로 조사한 결과를 보면 ‘경기도지사 선거 후보로 거론되는 인물 중 누구를 지지하느냐’는 질문에 응답자의 20%는 추 의원을, 15%는 김 지사를 선택했다. 이어 김은혜 국민의힘 의원은 11%, 한준호 민주당 의원 8%, 안철수 국민의힘 의원 7%, 이준석 개혁신당 대표 5% 등 순이었다. 지지하는 후보가 없다는 응답은 23%, 모름/무응답은 5%였다. 민주당 후보 적합도 조사 결과를 보면 김 지사가 27%, 추 의원이 21%를 각각 얻으며 오차범위 내에서 경쟁을 벌이고 있는 것으로 나타났다. 민주당을 지지한다고 밝힌 응답자들 중에선 추 의원이 35%, 김 지사가 28%였다. 민주당 외 다른 정당 지지층 응답을 분석했을 때 김 지사는 국민의힘(23%), 개혁신당(45%), 진보당(47%) 등에서 강세를 보였고, 추 의원은 조국혁신당 지지층(47%)에서 우위를 보였다. 범보수 야권 후보 적합도 조사에서는 김은혜 의원이 14%, 안철수 의원이 12%, 이준석 대표가 9%를 각각 기록했다. 다만 범보수 야권에서 적합한 후보가 없다는 응답률이 54%로 가장 높았다. 이번 조사는 경인일보 의뢰로 여론조사 전문기관 한국리서치가 19~20일 이틀간 경기도에 거주하는 만 18세 이상 남녀 1000명을 대상으로 진행했다. 성·연령·지역으로 층화된 휴대전화 가상(안심)번호를 무작위로 추출해 100% 면접원에 의한 전화면접 조사를 실시했다. 표본오차는 95% 신뢰수준에서 ±3.1%p, 응답률은 11.1%다. 2026년 1월 말 행정안전부 주민등록 인구를 기준으로 성별, 연령별, 지역별 가중치(셀가중)를 적용했다. 자세한 사항은 중앙선거여론조사심의위원회 홈페이지를 참조하면 된다. 김태희 기자 전국사회부 구독 80억 부동산 공매에 뒤늦게···김건희 모친 최은순, 체납액 절반 납부 ‘쌍방울 대북송금’ 김성태 제3자 뇌물혐의 1심서 공소기각···“이중 기소” 왼쪽으로 오른쪽으로 좋아요 댓글 쓰기 AD AD AD 댓글 0 글자 크기 글자 크기 글자 크기 설정 닫기 보통 보통 크게 크게 아주 크게 아주 크게 컬러 모드 컬러 모드 컬러 모드 설정 닫기 라이트 라이트 다크 다크 베이지 베이지 그린 그린 뉴스플리 뉴스플리 내 뉴스플리에 저장 닫기 공유하기 공유하기 공유하기 닫기 카카오톡 카카오톡 페이스북 페이스북 X X 밴드 밴드 --> 블로그 블로그 --> URL 복사 URL 복사 이메일 이메일 인쇄하기 인쇄하기 주요 기사 더 깊이, 더 넓게 보는 기사 점선면 🔢숫자 뒤에 진짜 사람이 있다 매일 아침 '점선면'이 뉴스의 맥락과 관점을 정리해드려요! 레터 받기 뉴스레터를 구독해주셔서 감사합니다. 플랫 취약계층 여성청소년 이용하는 ‘바우처몰’에선 2배나 더 비싼 생리대 사진 정동길 옆 사진관 “척척학사 됐어요!” 이화여대 졸업식 풍경 인터랙티브 불법계엄의 재구성 지금 많이 보는 기사 읽어볼 만한 기사 점선면 뉴스레터 구독하기 더 적게 읽고, 더 많이 아는 점선면 뉴스룸 PICK 에디터 PICK --> 오마주 응답하라 ‘아키라키드’…전설이 된 한 소년의 이야기 --> 위근우의 리플레이 '유퀴즈'도 인정한 영화 상단 자막 센스, 오늘은 또 어떤 ‘드립’이 기다리고 있을까 뉴스레터 구독 닫기 이메일 뉴스레터를 구독해주셔서 감사합니다. 이름 점선면을 알게 된 경로 전체 동의 전체 동의는 선택 항목에 대한 동의를 포함하고 있으며, 선택 항목에 대해 동의를 거부해도 서비스 이용이 가능합니다. (필수) 개인정보 수집 및 이용에 동의합니다. 보기 개인정보 이용 목적 - 뉴스레터 발송 및 CS처리, 공지 안내 등 개인정보 수집 항목 - 이메일 주소, 닉네임 개인정보 보유 및 이용기간 - 원칙적으로 개인정보 수집 및 이용목적이 달성된 후에 해당정보를 지체없이 파기합니다. 단, 관계법령의 규정에 의하여 보존할 필요가 있는 경우 일정기간 동안 개인정보를 보관할 수 있습니다. 그 밖의 사항은 경향신문 개인정보취급방침을 준수합니다. (선택) 광고성 정보 수신에 동의합니다. 보기 경향신문의 새 서비스 소개, 프로모션 이벤트 등을 놓치지 않으시려면 '광고 동의'를 눌러 주세요. 여러분의 관심으로 뉴스레터가 성장하면 뉴욕타임스, 월스트리트저널 등의 매체처럼 좋은 광고가 삽입될 수 있는데요. 이를 위한 '사전 동의'를 받는 것입니다. 많은 응원 부탁드립니다. (광고만 메일로 나가는 일은 '결코' 없습니다.) 레터 받기 취소하기 뉴스레터 구독 닫기 닫기 닫기 뉴스레터 구독이 완료되었습니다. 개인정보 수집 및 이용 닫기 개인정보 이용 목적 - 뉴스레터 발송 및 CS처리, 공지 안내 등 개인정보 수집 항목 - 이메일 주소, 닉네임 개인정보 보유 및 이용기간 - 원칙적으로 개인정보 수집 및 이용목적이 달성된 후에 해당정보를 지체없이 파기합니다. 단, 관계법령의 규정에 의하여 보존할 필요가 있는 경우 일정기간 동안 개인정보를 보관할 수 있습니다. 그 밖의 사항은 경향신문 개인정보취급방침을 준수합니다. 닫기 --> 광고성 정보 수신 동의 닫기 경향신문의 새 서비스 소개, 프로모션 이벤트 등을 놓치지 않으시려면 '광고 동의'를 눌러 주세요. 여러분의 관심으로 뉴스레터가 성장하면 뉴욕타임스, 월스트리트저널 등의 매체처럼 좋은 광고가 삽입될 수 있는데요. 이를 위한 '사전 동의'를 받는 것입니다. 많은 응원 부탁드립니다. (광고만 메일로 나가는 일은 '결코' 없습니다.) 닫기 --> 댓글 새로고침 닫기 하루 10분, 뉴스 유산소 뉴스레터 점선면 구독하기 주요 기사 지금 많이 보는 기사 오피니언 정치 경제 사회 국제 문화 스포츠 지역 과학·환경 라이프 사람 뉴스레터 영상 플랫 사진+ 인터랙티브 이슈 기획·연재 알림 기사제보 디지털 지면보기 디지털 초판보기 옛날 신문 보기 보도자료 회사소개 구독신청 온라인광고 사업제휴 채용 저작권∙콘텐츠 사용 고충처리 HELP Family site 스포츠경향 주간경향 레이디경향 경향신문 앱 스포츠경향 주간경향 레이디경향 경향신문 이용약관 개인정보처리방침 사이트맵 서울시 중구 정동길3 경향신문사 고객센터 : 02-3701-1114 등록번호 : 서울 아02041 등록일자 : 2012.03.22 발행인 : 김석종 편집인 : 이기수 청소년보호책임자 : 남지원 ⓒ경향신문, All rights reserved. facebook youtube X instagram google rss 상단으로 페이지 이동 닫기 닫기",
+        "raw_hash": "84b8bf443acc64672c16b1f0c5a1bde46ca1598f15da2daabc3743589667f7ae"
+      },
+      "region": {
+        "region_code": "41-000",
+        "sido_name": "경기도",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:지사가",
+          "name_ko": "지사가",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:의원이",
+          "name_ko": "의원이",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:추미애",
+          "name_ko": "추미애",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:김동연",
+          "name_ko": "김동연",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:지사",
+          "name_ko": "지사",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:의원",
+          "name_ko": "의원",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:응답자의",
+          "name_ko": "응답자의",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:응답률이",
+          "name_ko": "응답률이",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:표본오차는",
+          "name_ko": "표본오차는",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:응답률은",
+          "name_ko": "응답률은",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_3923340f5af55d45",
+        "survey_name": "경기지사 후보 조사서 추미애 20%·김동연 15%···오차범위 내 접전 - 경향신문",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": "2026-02-23",
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "41-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|41-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.3333,
+        "legal_filled_count": 2,
+        "legal_required_count": 6,
+        "date_resolution": "relative_day",
+        "date_inference_mode": "relative_published_at",
+        "date_inference_confidence": 0.9,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "지사가",
+          "value_raw": "27%",
+          "value_min": 27.0,
+          "value_max": 27.0,
+          "value_mid": 27.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "의원이",
+          "value_raw": "21%",
+          "value_min": 21.0,
+          "value_max": 21.0,
+          "value_mid": 21.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "의원이",
+          "value_raw": "35%",
+          "value_min": 35.0,
+          "value_max": 35.0,
+          "value_mid": 35.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "지사가",
+          "value_raw": "28%",
+          "value_min": 28.0,
+          "value_max": 28.0,
+          "value_mid": 28.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "추미애",
+          "value_raw": "20%",
+          "value_min": 20.0,
+          "value_max": 20.0,
+          "value_mid": 20.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "김동연",
+          "value_raw": "15%",
+          "value_min": 15.0,
+          "value_max": 15.0,
+          "value_mid": 15.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "지사",
+          "value_raw": "27%",
+          "value_min": 27.0,
+          "value_max": 27.0,
+          "value_mid": 27.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "의원",
+          "value_raw": "21%",
+          "value_min": 21.0,
+          "value_max": 21.0,
+          "value_mid": 21.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "응답자의",
+          "value_raw": "20%",
+          "value_min": 20.0,
+          "value_max": 20.0,
+          "value_mid": 20.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "응답률이",
+          "value_raw": "54%",
+          "value_min": 54.0,
+          "value_max": 54.0,
+          "value_mid": 54.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "표본오차는",
+          "value_raw": "95%",
+          "value_min": 95.0,
+          "value_max": 95.0,
+          "value_mid": 95.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "응답률은",
+          "value_raw": "11.1%",
+          "value_min": 11.1,
+          "value_max": 11.1,
+          "value_mid": 11.1,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiWkFVX3lxTE9HamZYd25pRGI3UmxSZGpRRHFHaDF0dDJ2RHJyNG5qaE9ybWFDb0F5OUQ2Mk5EVDU1bk9mZWpEUk84MXk1LU9DT3Rhdm92MTBJbjBOME4zYlVDd9IBX0FVX3lxTE5fd1ZmcUxyQ21BWWRBTnhjUWRfMVkzVnNjamFvbXY3bktLekpjNDNFam5rckZlVHQwQ2xKMlRFSTFvRDZIV2JYY3plTkhVeEd3eEE0MGdISmFuZ0JDNE84",
+        "title": "경기지사 후보 조사서 추미애 20%·김동연 15%···오차범위 내 접전",
+        "publisher": "경향신문",
+        "published_at": null,
+        "raw_text": "경기지사 후보 조사서 추미애 20%·김동연 15%···오차범위 내 접전 - 경향신문 경기지사 후보 조사서 추미애 20%·김동연 15%···오차범위 내 접전 &nbsp;&nbsp; 경향신문 지방선거 경기지사 여론조사",
+        "raw_hash": "raw_481d7e296c2722f9"
+      },
+      "region": {
+        "region_code": "41-000",
+        "sido_name": "경기도",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:추미애",
+          "name_ko": "추미애",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:김동연",
+          "name_ko": "김동연",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_1a9d3bc2062fbfd4",
+        "survey_name": "경기지사 후보 조사서 추미애 20%·김동연 15%···오차범위 내 접전",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "41-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|41-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "추미애",
+          "value_raw": "20%",
+          "value_min": 20.0,
+          "value_max": 20.0,
+          "value_mid": 20.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "김동연",
+          "value_raw": "15%",
+          "value_min": 15.0,
+          "value_max": 15.0,
+          "value_mid": 15.0,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMib0FVX3lxTFBJc3BDSGVxWFV6cXZaUXBjdy1ZX3JSODJpbXVlNnhTcFpNZEFITmV6MkFEUHlDZEw4cUtYVGZhVVpUWEN6amVNQ29YMFdjclh0Xy1seV9pbmlIV01mWlduZTE1T08yZ1V1dkExSHRUMA",
+        "title": "[경기도지사 여론조사] 민주 후보적합도… 김동연 35%vs추미애 22%",
+        "publisher": "중부일보",
+        "published_at": null,
+        "raw_text": "[경기도지사 여론조사] 민주 후보적합도… 김동연 35%vs추미애 22% - 중부일보 [경기도지사 여론조사] 민주 후보적합도… 김동연 35%vs추미애 22% &nbsp;&nbsp; 중부일보 지방선거 경기지사 오차범위",
+        "raw_hash": "raw_00f9484f8734db67"
+      },
+      "region": {
+        "region_code": "41-000",
+        "sido_name": "경기도",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:김동연",
+          "name_ko": "김동연",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:추미애",
+          "name_ko": "추미애",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_1b476b3c9acf3ed0",
+        "survey_name": "[경기도지사 여론조사] 민주 후보적합도… 김동연 35%vs추미애 22%",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "41-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|41-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "김동연",
+          "value_raw": "35%",
+          "value_min": 35.0,
+          "value_max": 35.0,
+          "value_mid": 35.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "추미애",
+          "value_raw": "22%",
+          "value_min": 22.0,
+          "value_max": 22.0,
+          "value_mid": 22.0,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMicEFVX3lxTE5QYU9aVVd5UEt6SHFZcm9TVERHOTBqRE5YbHlpOXR1VTUzcWtNcGR2V1Jhai1fLXk3bUJyWC1lbEw0VUNxcFR0eklxclVHWENudzlZZWtkZEpUTkxvaDE0d0lScV9DYXZ2dFhzbEJlQ3Y",
+        "title": "[6·3 지방선거 여론조사-성남시] 성남시장 신상진 35% 김병욱 32%…오차 내 접전",
+        "publisher": "인천일보",
+        "published_at": null,
+        "raw_text": "[6·3 지방선거 여론조사-성남시] 성남시장 신상진 35% 김병욱 32%…오차 내 접전 - 인천일보 [6·3 지방선거 여론조사-성남시] 성남시장 신상진 35% 김병욱 32%…오차 내 접전 &nbsp;&nbsp; 인천일보 지방선거 경기지사 가상대결",
+        "raw_hash": "raw_896bf07c5bf3bf82"
+      },
+      "region": {
+        "region_code": "41-000",
+        "sido_name": "경기도",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:신상진",
+          "name_ko": "신상진",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:김병욱",
+          "name_ko": "김병욱",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_259e580fdbc42986",
+        "survey_name": "[6·3 지방선거 여론조사-성남시] 성남시장 신상진 35% 김병욱 32%…오차 내 접전",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "41-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|41-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "신상진",
+          "value_raw": "35%",
+          "value_min": 35.0,
+          "value_max": 35.0,
+          "value_mid": 35.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "김병욱",
+          "value_raw": "32%",
+          "value_min": 32.0,
+          "value_max": 32.0,
+          "value_mid": 32.0,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMieEFVX3lxTE5tTW9iQy1QNXd2ZUU2OE5kZmZWMWlkem9tRDRMZXpVcVRVNXgxSGVicUxKdVBXX2QxeW5NYVBCQUp3NmdVRXF0c3VYZ19DT0F2UGtWVTZSYjdHa0J0SFFCOGM3N3lEM0JQMDJpZU5ybnBnY0ZRV2YwWdIBeEFVX3lxTFBXWWNrY1FkOUNlcWd3Z3hNZ1dkQ3JnbmNKcDFKVUpUN1k3SWt5UThzUVYxaDNMVkRzeDhTZV8yU2VTVHhlNVdFbllQVEl0QXZVYVVTOG85aDNMc0EzVVV4Nk1qZ1lUNVE0eTRIcS1FbTVrbk43RDc1Nw",
+        "title": "[MBC여론조사] 서울시장 가상 대결서‥정원오 40% VS 오세훈 36%",
+        "publisher": "MBC 뉴스",
+        "published_at": null,
+        "raw_text": "[MBC여론조사] 서울시장 가상 대결서‥정원오 40% VS 오세훈 36% - MBC 뉴스 [MBC여론조사] 서울시장 가상 대결서‥정원오 40% VS 오세훈 36% &nbsp;&nbsp; MBC 뉴스 지방선거 서울시장 가상대결",
+        "raw_hash": "raw_a5fb06f2255166eb"
+      },
+      "region": {
+        "region_code": "11-000",
+        "sido_name": "서울특별시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:정원오",
+          "name_ko": "정원오",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:오세훈",
+          "name_ko": "오세훈",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_c98ca4f5973f8d49",
+        "survey_name": "[MBC여론조사] 서울시장 가상 대결서‥정원오 40% VS 오세훈 36%",
+        "pollster": "MBC",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "11-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|11-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "정원오",
+          "value_raw": "40%",
+          "value_min": 40.0,
+          "value_max": 40.0,
+          "value_mid": 40.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "오세훈",
+          "value_raw": "36%",
+          "value_min": 36.0,
+          "value_max": 36.0,
+          "value_mid": 36.0,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiVkFVX3lxTE5mZnp1cU5sXzNkMk52b1Y4bWpsaXhoZUswNEVsaDN4RERfV2RyTFdOY1hackVlbWFwWlBRaFFITkZOeDRiWFo2Sll4UWNaTEt1aFJoYzh30gGGAkFVX3lxTE16ZVBkOUM3T2hYWm5LOEhjNDlFRXNfbWpqbUhqQjBBdlJocTg3dnJXb3VvZ0FTR2lkbjFGMHRPZlBuTVo0Q2w0M3NZVmhZTjdzLWlzdkFKb1RJVmNkMUpFX1lsMDZOa2Z4MmQwTUlxVm1EdGJxUTUxR2hmeUNnU0JBN1h0OXllZXFpZlo4Ry03U3hMN3ZDbExRUklHcUE4cHV6R2hBODdkYnJWd1VYMWEwaGRUcFNnLXNLa3BRd1p5TERzTHVfNkNhQjV1bzFWLTBpcmYzM0RZMnZrQ1M3dzVTNEVicFFxbHB0UFJYQTFTUzNicXNfNEFoaGk2SHFtdXU0b3RTVXc",
+        "title": "[설 연휴 여론조사] 정원오 38% 오세훈 36%…서울시장 오차내 '팽팽'",
+        "publisher": "데일리안",
+        "published_at": null,
+        "raw_text": "[설 연휴 여론조사] 정원오 38% 오세훈 36%…서울시장 오차내 '팽팽' - 데일리안 [설 연휴 여론조사] 정원오 38% 오세훈 36%…서울시장 오차내 '팽팽' &nbsp;&nbsp; 데일리안 지방선거 서울시장 오차범위",
+        "raw_hash": "raw_5dd517bdc3c5c82d"
+      },
+      "region": {
+        "region_code": "11-000",
+        "sido_name": "서울특별시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:정원오",
+          "name_ko": "정원오",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:오세훈",
+          "name_ko": "오세훈",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_f5aefbfbb344c0d1",
+        "survey_name": "[설 연휴 여론조사] 정원오 38% 오세훈 36%…서울시장 오차내 '팽팽'",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "11-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|11-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "정원오",
+          "value_raw": "38%",
+          "value_min": 38.0,
+          "value_max": 38.0,
+          "value_mid": 38.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "오세훈",
+          "value_raw": "36%",
+          "value_min": 36.0,
+          "value_max": 36.0,
+          "value_mid": 36.0,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMidEFVX3lxTE0tR240RHM3eWhpWHhBUmFDZzl1eUFIRjJZN0JGU185MXBaanpESmxwTUREYThKU3h6anpJRklRelduaHR1UjBLSFhlbDhoNkhJN284eS1RS2lmTm5wUTZXWXZLNFBNWm1vOW03YS1wTmdaRjB5",
+        "title": "부산시장여론조사 전재수 43.3% 또 앞서, 박형준은 34.6%",
+        "publisher": "오마이뉴스",
+        "published_at": null,
+        "raw_text": "부산시장여론조사 전재수 43.3% 또 앞서, 박형준은 34.6% - 오마이뉴스 부산시장여론조사 전재수 43.3% 또 앞서, 박형준은 34.6% &nbsp;&nbsp; 오마이뉴스 지방선거 부산시장 오차범위",
+        "raw_hash": "raw_321af2cbddc97dc8"
+      },
+      "region": {
+        "region_code": "26-000",
+        "sido_name": "부산광역시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:전재수",
+          "name_ko": "전재수",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:박형준은",
+          "name_ko": "박형준은",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_136dffa93edf3413",
+        "survey_name": "부산시장여론조사 전재수 43.3% 또 앞서, 박형준은 34.6%",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "26-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|26-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "전재수",
+          "value_raw": "43.3%",
+          "value_min": 43.3,
+          "value_max": 43.3,
+          "value_mid": 43.3,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "박형준은",
+          "value_raw": "34.6%",
+          "value_min": 34.6,
+          "value_max": 34.6,
+          "value_mid": 34.6,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiT0FVX3lxTE1TR0RwR3pLa1lTTXY0XzFmaF81SFA3NXhhcHNLWWhTczVrQUtJcDJtOUxaNGxYdnNueXRBU19VSTAzVGpselZMTXVHWUJfYTg",
+        "title": "부산시장 여론조사, 전재수 46.7% vs 박형준 38.4%…오차범위 밖 격차",
+        "publisher": "v.daum.net",
+        "published_at": null,
+        "raw_text": "부산시장 여론조사, 전재수 46.7% vs 박형준 38.4%…오차범위 밖 격차 - v.daum.net 부산시장 여론조사, 전재수 46.7% vs 박형준 38.4%…오차범위 밖 격차 &nbsp;&nbsp; v.daum.net 지방선거 부산시장 오차범위",
+        "raw_hash": "raw_ebc4aa67475cc50f"
+      },
+      "region": {
+        "region_code": "26-000",
+        "sido_name": "부산광역시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:전재수",
+          "name_ko": "전재수",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:박형준",
+          "name_ko": "박형준",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_444bed2fb448053a",
+        "survey_name": "부산시장 여론조사, 전재수 46.7% vs 박형준 38.4%…오차범위 밖 격차",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "26-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|26-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "전재수",
+          "value_raw": "46.7%",
+          "value_min": 46.7,
+          "value_max": 46.7,
+          "value_mid": 46.7,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "박형준",
+          "value_raw": "38.4%",
+          "value_min": 38.4,
+          "value_max": 38.4,
+          "value_mid": 38.4,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMieEFVX3lxTE5YR2RWdVVLempqS2xCZU9WR083VHZWcEFjRnpqUUJpbWd3YjVINFBsNlU2UVRyNHU0UEg0YnBIRl9MLTkwaldWaDVPeE1XVnVKVWdGNlFXNTR5UFlfakR6bXZ4V0hTcVBrNU9oaEpPdWJjY2tpa1I4UQ",
+        "title": "전재수 43.4% vs 박형준 32.3%… 오차범위 밖 격차 [6·3 지방선거 여론조사]",
+        "publisher": "부산일보사",
+        "published_at": null,
+        "raw_text": "전재수 43.4% vs 박형준 32.3%… 오차범위 밖 격차 [6·3 지방선거 여론조사] - 부산일보사 전재수 43.4% vs 박형준 32.3%… 오차범위 밖 격차 [6·3 지방선거 여론조사] &nbsp;&nbsp; 부산일보사 지방선거 부산시장 오차범위",
+        "raw_hash": "raw_720c32cdb6eda98c"
+      },
+      "region": {
+        "region_code": "26-000",
+        "sido_name": "부산광역시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:전재수",
+          "name_ko": "전재수",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:박형준",
+          "name_ko": "박형준",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_82f9da3ac3360057",
+        "survey_name": "전재수 43.4% vs 박형준 32.3%… 오차범위 밖 격차 [6·3 지방선거 여론조사]",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "26-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|26-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "전재수",
+          "value_raw": "43.4%",
+          "value_min": 43.4,
+          "value_max": 43.4,
+          "value_mid": 43.4,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "박형준",
+          "value_raw": "32.3%",
+          "value_min": 32.3,
+          "value_max": 32.3,
+          "value_mid": 32.3,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiUkFVX3lxTE1lS3hWUFprb0RROTRHT1FzUHo5QmpBOGdLU3RvNnQxQlJjYVBMakk3NmdXaUZpY19aWXY4U1dxMHhjQVlJanB1UHY1QURTVHRWNHc",
+        "title": "[경인일보 여론조사] “야권에 적합한 경기도지사 후보 없다” 54%",
+        "publisher": "경인일보",
+        "published_at": null,
+        "raw_text": "[경인일보 여론조사] “야권에 적합한 경기도지사 후보 없다” 54% - 경인일보 [경인일보 여론조사] “야권에 적합한 경기도지사 후보 없다” 54% &nbsp;&nbsp; 경인일보 지방선거 경기지사 여론조사",
+        "raw_hash": "raw_420eeb5b61ef0d3c"
+      },
+      "region": {
+        "region_code": "41-000",
+        "sido_name": "경기도",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [],
+      "observation": {
+        "observation_key": "obs_6348089eeaf5b9f8",
+        "survey_name": "[경인일보 여론조사] “야권에 적합한 경기도지사 후보 없다” 54%",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "41-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|41-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": []
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiUkFVX3lxTFBxZHRodk44MXJxVnVlSFRnUkxoQi0yR0tUSmRFdE80LVFmazhtdmdHcjhQQmlXNG92bEZySVpGVG5LaGZNQ2JxUEdTN20zbVhpb3c",
+        "title": "[경인일보 여론조사] 김동연 27% vs 추미애 21% 오차범위 내 양강구도",
+        "publisher": "경인일보",
+        "published_at": null,
+        "raw_text": "[경인일보 여론조사] 김동연 27% vs 추미애 21% 오차범위 내 양강구도 - 경인일보 [경인일보 여론조사] 김동연 27% vs 추미애 21% 오차범위 내 양강구도 &nbsp;&nbsp; 경인일보 지방선거 경기지사 오차범위",
+        "raw_hash": "raw_0fec332ae9d099e7"
+      },
+      "region": {
+        "region_code": "41-000",
+        "sido_name": "경기도",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:김동연",
+          "name_ko": "김동연",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:추미애",
+          "name_ko": "추미애",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_85c4e876cf8b2a2a",
+        "survey_name": "[경인일보 여론조사] 김동연 27% vs 추미애 21% 오차범위 내 양강구도",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "41-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|41-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "김동연",
+          "value_raw": "27%",
+          "value_min": 27.0,
+          "value_max": 27.0,
+          "value_mid": 27.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "추미애",
+          "value_raw": "21%",
+          "value_min": 21.0,
+          "value_max": 21.0,
+          "value_mid": 21.0,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiUkFVX3lxTE8zQ29Gc1hUUnRvSXNrdjBsbW1VSERKTVJLa3NPZHFETnkyLUVnMHYwVm9OMFMzVUJBeTBtN192eTZXUThkM1U0RkE5Yk1PUk0yNmc",
+        "title": "[경인일보 여론조사] 민주당내 인천시장 후보 적합도, 박찬대 43% 당내 압도적",
+        "publisher": "경인일보",
+        "published_at": null,
+        "raw_text": "[경인일보 여론조사] 민주당내 인천시장 후보 적합도, 박찬대 43% 당내 압도적 - 경인일보 [경인일보 여론조사] 민주당내 인천시장 후보 적합도, 박찬대 43% 당내 압도적 &nbsp;&nbsp; 경인일보 지방선거 인천시장 여론조사",
+        "raw_hash": "raw_7b179e23d089dd5a"
+      },
+      "region": {
+        "region_code": "28-000",
+        "sido_name": "인천광역시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:박찬대",
+          "name_ko": "박찬대",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_297e45acd1bc8bec",
+        "survey_name": "[경인일보 여론조사] 민주당내 인천시장 후보 적합도, 박찬대 43% 당내 압도적",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "28-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|28-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "박찬대",
+          "value_raw": "43%",
+          "value_min": 43.0,
+          "value_max": 43.0,
+          "value_mid": 43.0,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiVEFVX3lxTE5rS0JxZXRJT3piMlN2VW5tWnpDVmtZNmFGRDJUZ0dnb0k2NjFsWTRVZkY4NDNHb0pSendnS0FqVUhpMG9JRkhwYUo5Nk92SnZSQWNacw",
+        "title": "[6·3 지방선거 여론조사-수원특례시] 수원시장 이재준 31.5%…국힘 안교재·이봉준 추격",
+        "publisher": "v.daum.net",
+        "published_at": null,
+        "raw_text": "[6·3 지방선거 여론조사-수원특례시] 수원시장 이재준 31.5%…국힘 안교재·이봉준 추격 - v.daum.net [6·3 지방선거 여론조사-수원특례시] 수원시장 이재준 31.5%…국힘 안교재·이봉준 추격 &nbsp;&nbsp; v.daum.net 지방선거 인천시장 가상대결",
+        "raw_hash": "raw_9789c415120c0b69"
+      },
+      "region": {
+        "region_code": "28-000",
+        "sido_name": "인천광역시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:이재준",
+          "name_ko": "이재준",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_0f585774f2b41565",
+        "survey_name": "[6·3 지방선거 여론조사-수원특례시] 수원시장 이재준 31.5%…국힘 안교재·이봉준 추격",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "28-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|28-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "이재준",
+          "value_raw": "31.5%",
+          "value_min": 31.5,
+          "value_max": 31.5,
+          "value_mid": 31.5,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMib0FVX3lxTFBVb1NSZjJ1enV6eDFDLWppUzM4eGlsc2RKRDVxY0pfSmxOUTBLcE1MbGZ0VGdqcVhUMVhHZTBzWk5xanF6Znl4Ym9icFMtX0xweWhsdTlVSzNURjVGUXdsQ1AzTC0xdXJDZDBjaG5TMA",
+        "title": "인천시장 여론조사서 유정복 36.8% vs 박찬대 52.1%",
+        "publisher": "중부일보",
+        "published_at": null,
+        "raw_text": "인천시장 여론조사서 유정복 36.8% vs 박찬대 52.1% - 중부일보 인천시장 여론조사서 유정복 36.8% vs 박찬대 52.1% &nbsp;&nbsp; 중부일보 지방선거 인천시장 가상대결",
+        "raw_hash": "raw_465fb12f6e7974a4"
+      },
+      "region": {
+        "region_code": "28-000",
+        "sido_name": "인천광역시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:유정복",
+          "name_ko": "유정복",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:박찬대",
+          "name_ko": "박찬대",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_0cc203a71a596743",
+        "survey_name": "인천시장 여론조사서 유정복 36.8% vs 박찬대 52.1%",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "28-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|28-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "유정복",
+          "value_raw": "36.8%",
+          "value_min": 36.8,
+          "value_max": 36.8,
+          "value_mid": 36.8,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "박찬대",
+          "value_raw": "52.1%",
+          "value_min": 52.1,
+          "value_max": 52.1,
+          "value_mid": 52.1,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiZ0FVX3lxTE9VTlluWEJ1dFcydUhIa2M4YlhNSVloa1JmNkdtRHVEbGgxQzl5THhmaEY5Vlk3WTFIQTRUYmdVZjQ1SjRHRGF3YnA0MlFQQVB1UE1MY3lBdlVZM3IyS3FyMGhaelNaWFk",
+        "title": "[6·3 지방선거] 인천시장 여론조사...민주 박찬대 40.5% ‘압도’, 국힘 유정복 29.2% 1위",
+        "publisher": "M이코노미뉴스",
+        "published_at": null,
+        "raw_text": "[6·3 지방선거] 인천시장 여론조사...민주 박찬대 40.5% ‘압도’, 국힘 유정복 29.2% 1위 - M이코노미뉴스 [6·3 지방선거] 인천시장 여론조사...민주 박찬대 40.5% ‘압도’, 국힘 유정복 29.2% 1위 &nbsp;&nbsp; M이코노미뉴스 지방선거 인천시장 가상대결",
+        "raw_hash": "raw_47a5c84614475252"
+      },
+      "region": {
+        "region_code": "28-000",
+        "sido_name": "인천광역시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:박찬대",
+          "name_ko": "박찬대",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:유정복",
+          "name_ko": "유정복",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_57d26088f1d9972c",
+        "survey_name": "[6·3 지방선거] 인천시장 여론조사...민주 박찬대 40.5% ‘압도’, 국힘 유정복 29.2% 1위",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "28-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|28-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "박찬대",
+          "value_raw": "40.5%",
+          "value_min": 40.5,
+          "value_max": 40.5,
+          "value_mid": 40.5,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "유정복",
+          "value_raw": "29.2%",
+          "value_min": 29.2,
+          "value_max": 29.2,
+          "value_mid": 29.2,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMimwFBVV95cUxPMjFRclBzZnhwdWlFY1l1QU1aRHNzem5UM0kzSW9LQjVldFNHeGg5ajlkZ1MycDYzek5RbWFTLVl5RjFlTlBLSzV4LXR1M1VmdTR3akpvTEp0SkFaR3h3Q0lIdEhDR0VkOFNJRWZEYXYtNEJGcHhuTEJOTG5zSEItZG04UWNUM2JsZUJsLUJnNXZYZExjSjRfQk0wQQ",
+        "title": "[서울시장 후보 지지도] 정원오 30.8%-박주민 13.1%...정 49.0%-오 37.2%, 박 48.2%-오 35.2%",
+        "publisher": "오마이뉴스",
+        "published_at": null,
+        "raw_text": "[서울시장 후보 지지도] 정원오 30.8%-박주민 13.1%...정 49.0%-오 37.2%, 박 48.2%-오 35.2% - 오마이뉴스 [서울시장 후보 지지도] 정원오 30.8%-박주민 13.1%...정 49.0%-오 37.2%, 박 48.2%-오 35.2% &nbsp;&nbsp; 오마이뉴스 지방선거 서울시장 지지율",
+        "raw_hash": "raw_d22fbb359e6cc147"
+      },
+      "region": {
+        "region_code": "11-000",
+        "sido_name": "서울특별시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:정원오",
+          "name_ko": "정원오",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:박주민",
+          "name_ko": "박주민",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_7f29a3027242a383",
+        "survey_name": "[서울시장 후보 지지도] 정원오 30.8%-박주민 13.1%...정 49.0%-오 37.2%, 박 48.2%-오 35.2%",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "11-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|11-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "정원오",
+          "value_raw": "30.8%",
+          "value_min": 30.8,
+          "value_max": 30.8,
+          "value_mid": 30.8,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "박주민",
+          "value_raw": "13.1%",
+          "value_min": 13.1,
+          "value_max": 13.1,
+          "value_mid": 13.1,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiWkFVX3lxTFB2YUZpOFMxY2JtNEIwQi1GSTMwd0hkT1pzcDM3WWlKWnB6dE1vRDhDZzB2RVZfQjRQemJ6WkdrSDlIdXNmNm5hSnB0cjdKTEEtOE9JNjdtc3lJdw",
+        "title": "서울시장 가상대결 정원오 40% vs 오세훈 36%…오차범위 내 접전",
+        "publisher": "뉴스1",
+        "published_at": null,
+        "raw_text": "서울시장 가상대결 정원오 40% vs 오세훈 36%…오차범위 내 접전 - 뉴스1 서울시장 가상대결 정원오 40% vs 오세훈 36%…오차범위 내 접전 &nbsp;&nbsp; 뉴스1 지방선거 서울시장 가상대결",
+        "raw_hash": "raw_a7e6b633020e0e2f"
+      },
+      "region": {
+        "region_code": "11-000",
+        "sido_name": "서울특별시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:정원오",
+          "name_ko": "정원오",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:오세훈",
+          "name_ko": "오세훈",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_debd6bb9da6779e7",
+        "survey_name": "서울시장 가상대결 정원오 40% vs 오세훈 36%…오차범위 내 접전",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "11-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|11-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "정원오",
+          "value_raw": "40%",
+          "value_min": 40.0,
+          "value_max": 40.0,
+          "value_mid": 40.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "오세훈",
+          "value_raw": "36%",
+          "value_min": 36.0,
+          "value_max": 36.0,
+          "value_mid": 36.0,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMibkFVX3lxTE5VZ1UzR1k0dzJRRGgxdDl4QkR3bzBEUjFpc0hSc1Z5ZFFQWnU0VGg0NHJBeFFJLUE3RHhycFVjaUc2Q0RmQ3lNUkU2cU1lT3d0RlQxNGZuWjhFUVZvYUtWa0JSWE8xbkoxczc3VHFB0gFyQVVfeXFMTVYtemZ5RlluSnhqRklvaEZBdm0zMFh3MlBhN2NYYVFWM1F1MUpBajhsMFZZdHdfZGE1WVJMUHZRdUQ3SEVfWW1JYTJqbXBKN1Vnd1VET016bV9EX0lwZEpmeXFLTUp2b3BZaU9qOUxyTkFR",
+        "title": "[6·3 지방선거] '설민심'은 여권 우세, 李 지지율 60% 상회·국정안정론 과반…정치권, 6월 지선 모드 전환",
+        "publisher": "폴리뉴스 Polinews",
+        "published_at": null,
+        "raw_text": "[6·3 지방선거] '설민심'은 여권 우세, 李 지지율 60% 상회·국정안정론 과반…정치권, 6월 지선 모드 전환 - 폴리뉴스 Polinews [6·3 지방선거] '설민심'은 여권 우세, 李 지지율 60% 상회·국정안정론 과반…정치권, 6월 지선 모드 전환 &nbsp;&nbsp; 폴리뉴스 Polinews 지방선거 서울시장 가상대결",
+        "raw_hash": "raw_5e087796393a073e"
+      },
+      "region": {
+        "region_code": "11-000",
+        "sido_name": "서울특별시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [],
+      "observation": {
+        "observation_key": "obs_5ab631e8fc7413b4",
+        "survey_name": "[6·3 지방선거] '설민심'은 여권 우세, 李 지지율 60% 상회·국정안정론 과반…정치권, 6월 지선 모드 전환",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "11-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|11-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": []
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiT0FVX3lxTE9nVmxoSnkzMUNfX1V5YTZyYktkSm5WUEk0ZGVyOEZxc3Y2cVF4cko5NjdsUklaLUpROGVRUGh4NFVzY2s0T3JWcjI1ZXgzNVE",
+        "title": "부산시장 후보 가상 대결…전재수 40%·박형준 30%",
+        "publisher": "v.daum.net",
+        "published_at": null,
+        "raw_text": "부산시장 후보 가상 대결…전재수 40%·박형준 30% - v.daum.net 부산시장 후보 가상 대결…전재수 40%·박형준 30% &nbsp;&nbsp; v.daum.net 지방선거 부산시장 가상대결",
+        "raw_hash": "raw_0432a859f4f454d7"
+      },
+      "region": {
+        "region_code": "26-000",
+        "sido_name": "부산광역시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:전재수",
+          "name_ko": "전재수",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:박형준",
+          "name_ko": "박형준",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_bf18847149fb4b56",
+        "survey_name": "부산시장 후보 가상 대결…전재수 40%·박형준 30%",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "26-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|26-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "전재수",
+          "value_raw": "40%",
+          "value_min": 40.0,
+          "value_max": 40.0,
+          "value_mid": 40.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "박형준",
+          "value_raw": "30%",
+          "value_min": 30.0,
+          "value_max": 30.0,
+          "value_mid": 30.0,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiT0FVX3lxTE54TGg4cF9nTG9rU3M2X0FGWGVKMllQRGMtUmNUNzJTREJCYUxRdFo0ZVBtTEgxc2ZiYnJiWG1yLWM5UXBDZHJFZld2OTl6a1E",
+        "title": "[경기도지사 후보 지지도] 추미애 20.3%, 김동연 17.6%, 한준호 13.8%...김은혜와 가상대결 모두 오차밖 승리",
+        "publisher": "v.daum.net",
+        "published_at": null,
+        "raw_text": "[경기도지사 후보 지지도] 추미애 20.3%, 김동연 17.6%, 한준호 13.8%...김은혜와 가상대결 모두 오차밖 승리 - v.daum.net [경기도지사 후보 지지도] 추미애 20.3%, 김동연 17.6%, 한준호 13.8%...김은혜와 가상대결 모두 오차밖 승리 &nbsp;&nbsp; v.daum.net 지방선거 경기지사 가상대결",
+        "raw_hash": "raw_1f96daf64e47c377"
+      },
+      "region": {
+        "region_code": "41-000",
+        "sido_name": "경기도",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:추미애",
+          "name_ko": "추미애",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:김동연",
+          "name_ko": "김동연",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:한준호",
+          "name_ko": "한준호",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_09aef8cf8f7252e5",
+        "survey_name": "[경기도지사 후보 지지도] 추미애 20.3%, 김동연 17.6%, 한준호 13.8%...김은혜와 가상대결 모두 오차밖 승리",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "41-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|41-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "추미애",
+          "value_raw": "20.3%",
+          "value_min": 20.3,
+          "value_max": 20.3,
+          "value_mid": 20.3,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "김동연",
+          "value_raw": "17.6%",
+          "value_min": 17.6,
+          "value_max": 17.6,
+          "value_mid": 17.6,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "한준호",
+          "value_raw": "13.8%",
+          "value_min": 13.8,
+          "value_max": 13.8,
+          "value_mid": 13.8,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiT0FVX3lxTE9Nc1VkNEhQaDhxVkpJZ1ZfWHl0SXhJeG1DSHZHRnM0bmlZbV9na3hrS2t1V3BBeElBcFYzOEhHTWFLUklNcVU1V3RIdVVVZmM",
+        "title": "[경기도지사 후보 지지도] 추미애 27.0% - 김동연 21.2% - 한준호 17.2%... 오차범위 내 각축",
+        "publisher": "v.daum.net",
+        "published_at": null,
+        "raw_text": "[경기도지사 후보 지지도] 추미애 27.0% - 김동연 21.2% - 한준호 17.2%... 오차범위 내 각축 - v.daum.net [경기도지사 후보 지지도] 추미애 27.0% - 김동연 21.2% - 한준호 17.2%... 오차범위 내 각축 &nbsp;&nbsp; v.daum.net 지방선거 경기지사 오차범위",
+        "raw_hash": "raw_b2b0a6f611e53fb8"
+      },
+      "region": {
+        "region_code": "41-000",
+        "sido_name": "경기도",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:추미애",
+          "name_ko": "추미애",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:김동연",
+          "name_ko": "김동연",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:한준호",
+          "name_ko": "한준호",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_3ac1b89163285638",
+        "survey_name": "[경기도지사 후보 지지도] 추미애 27.0% - 김동연 21.2% - 한준호 17.2%... 오차범위 내 각축",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "41-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|41-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "추미애",
+          "value_raw": "27.0%",
+          "value_min": 27.0,
+          "value_max": 27.0,
+          "value_mid": 27.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "김동연",
+          "value_raw": "21.2%",
+          "value_min": 21.2,
+          "value_max": 21.2,
+          "value_mid": 21.2,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "한준호",
+          "value_raw": "17.2%",
+          "value_min": 17.2,
+          "value_max": 17.2,
+          "value_mid": 17.2,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMid0FVX3lxTE90WTBqQ1BTb1dLYm90TUhacW82V2NxZGNMY1VNRGJmdHZ1MWFfOU0xX2I1LXFUUlZuWlNQWXFWRWl4UXBiVTBJYkNJZjRRUXF5TVpvZkJBaVhmU0lDVWtGalp5aDAxUGhKUGZJaTRRVGxzbXNtWkdR0gFmQVVfeXFMT01DbmstNW4zeEU5Tm9CMnpjeElNdUFRa1JYQmdpaGJGQWJLT2NMMndBYTdxV0VNYmhNa2Fyb0t2a0ZtelV0THlidk9GaEpNNV9lZ1JPLTNTaF9iVmxRQnhGTkItbFln",
+        "title": "정원오-오세훈 서울시장 대결… 44%:31%, 40%:36%, 38%:36%",
+        "publisher": "동아일보",
+        "published_at": null,
+        "raw_text": "정원오-오세훈 서울시장 대결… 44%:31%, 40%:36%, 38%:36% - 동아일보 정원오-오세훈 서울시장 대결… 44%:31%, 40%:36%, 38%:36% &nbsp;&nbsp; 동아일보 지방선거 서울시장 여론조사",
+        "raw_hash": "raw_3bc0623f651ff25a"
+      },
+      "region": {
+        "region_code": "11-000",
+        "sido_name": "서울특별시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [],
+      "observation": {
+        "observation_key": "obs_c5fd83f12d656982",
+        "survey_name": "정원오-오세훈 서울시장 대결… 44%:31%, 40%:36%, 38%:36%",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "11-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|11-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": []
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiUEFVX3lxTE9XUDhsQXlSS2d5SDZXTUJITU9nRnRpa1l3NXNVUENyMkdQZG04T0s5UG9SXzlySXJ2YlZ4ejN4Nmg3TzhJSDFXMWd5U0loM0Mw",
+        "title": "[속보]서울시장 양자대결, 정원오 47.5%·오세훈 33.3% ‘격차확대’-조원씨앤아이",
+        "publisher": "문화일보",
+        "published_at": null,
+        "raw_text": "[속보]서울시장 양자대결, 정원오 47.5%·오세훈 33.3% ‘격차확대’-조원씨앤아이 - 문화일보 [속보]서울시장 양자대결, 정원오 47.5%·오세훈 33.3% ‘격차확대’-조원씨앤아이 &nbsp;&nbsp; 문화일보 지방선거 서울시장 여론조사",
+        "raw_hash": "raw_f87c80d8c9db2320"
+      },
+      "region": {
+        "region_code": "11-000",
+        "sido_name": "서울특별시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:정원오",
+          "name_ko": "정원오",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:오세훈",
+          "name_ko": "오세훈",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_04f52b0dbb2a3f38",
+        "survey_name": "[속보]서울시장 양자대결, 정원오 47.5%·오세훈 33.3% ‘격차확대’-조원씨앤아이",
+        "pollster": "조원씨앤아이",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "11-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|11-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "정원오",
+          "value_raw": "47.5%",
+          "value_min": 47.5,
+          "value_max": 47.5,
+          "value_mid": 47.5,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "오세훈",
+          "value_raw": "33.3%",
+          "value_min": 33.3,
+          "value_max": 33.3,
+          "value_mid": 33.3,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiZkFVX3lxTE9oNUFjcktRS0p1ZENLRHVJdTdiQlZCVkY1T0dOWU55MjBBOUlKU3ZXWGZrVDBqeTlLMDFUUVJmNzc1anJ5VVJDNHdyUjR3TWhmZi1GRkR6WkczRHVpU01jWldPM3pldw",
+        "title": "[6·3 지방선거 여론조사]서울·부산·강원서 여당 '우세'…국정안정론 50%대 중반",
+        "publisher": "이로운넷",
+        "published_at": null,
+        "raw_text": "[6·3 지방선거 여론조사]서울·부산·강원서 여당 '우세'…국정안정론 50%대 중반 - 이로운넷 [6·3 지방선거 여론조사]서울·부산·강원서 여당 '우세'…국정안정론 50%대 중반 &nbsp;&nbsp; 이로운넷 지방선거 서울시장 여론조사",
+        "raw_hash": "raw_72adbb846abfc849"
+      },
+      "region": {
+        "region_code": "11-000",
+        "sido_name": "서울특별시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:국정안정론",
+          "name_ko": "국정안정론",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_d8cd4d8f6a0f22b8",
+        "survey_name": "[6·3 지방선거 여론조사]서울·부산·강원서 여당 '우세'…국정안정론 50%대 중반",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "11-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|11-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "국정안정론",
+          "value_raw": "50%대",
+          "value_min": 50.0,
+          "value_max": 59.0,
+          "value_mid": 54.5,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMid0FVX3lxTE00bnR0cThIMG9qNFFQRERXbnE3LTNmd2JKcTh0c196VjJSUGEyVXd0WkE1TS1zeHc0bzk4aEtzUFVEWEc5VlBGSFBja1R6Y1JobW5mby1SWWFSUjEtM0p1b204OG9GNWRsMGgxXzBZOWFERnNrajRz",
+        "title": "[부산시장여론조사] 전재수 43.3% 또 앞서, 박형준은 34.6%",
+        "publisher": "오마이뉴스",
+        "published_at": null,
+        "raw_text": "[부산시장여론조사] 전재수 43.3% 또 앞서, 박형준은 34.6% - 오마이뉴스 [부산시장여론조사] 전재수 43.3% 또 앞서, 박형준은 34.6% &nbsp;&nbsp; 오마이뉴스 지방선거 부산시장 여론조사",
+        "raw_hash": "raw_245f01a0538b56f8"
+      },
+      "region": {
+        "region_code": "26-000",
+        "sido_name": "부산광역시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:전재수",
+          "name_ko": "전재수",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:박형준은",
+          "name_ko": "박형준은",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_62b73089a352ef4b",
+        "survey_name": "[부산시장여론조사] 전재수 43.3% 또 앞서, 박형준은 34.6%",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "26-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|26-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "전재수",
+          "value_raw": "43.3%",
+          "value_min": 43.3,
+          "value_max": 43.3,
+          "value_mid": 43.3,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "박형준은",
+          "value_raw": "34.6%",
+          "value_min": 34.6,
+          "value_max": 34.6,
+          "value_mid": 34.6,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMieEFVX3lxTE1Tdmg3TFdqS3NUN21RSTVtdXU2RG90czEtQmN0MWs1RFpabTYzOFctYXdGYU1DZExRMUZ2S2xfY3gydkJ3VjdyTTAwZ2F1ak5RWHN1d3A2ZXJiYnlnaW1nNm40Z2NJZHhSZUsyaEp5TUhVUGR6bXA4X9IBeEFVX3lxTE5INHczQnc2WlFxcF9iel9LN1doU01jOXJjbm9FS1kwTU9kZ0FTcHkzTzV2OWlLYmJiX1otNnNqTk5xMGMtdm5TNnRnYnlYR3VMaEp5UVZ2aUV3bnUwTVkxLXVhT01oRjJDRmVuNGlDOG80NlZscllVYg",
+        "title": "부산시장 가상 양자대결서 전재수 43.3% vs 박형준 34.6%",
+        "publisher": "MBC 뉴스",
+        "published_at": null,
+        "raw_text": "부산시장 가상 양자대결서 전재수 43.3% vs 박형준 34.6% - MBC 뉴스 부산시장 가상 양자대결서 전재수 43.3% vs 박형준 34.6% &nbsp;&nbsp; MBC 뉴스 지방선거 부산시장 여론조사",
+        "raw_hash": "raw_e9ef17270691910a"
+      },
+      "region": {
+        "region_code": "26-000",
+        "sido_name": "부산광역시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:전재수",
+          "name_ko": "전재수",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:박형준",
+          "name_ko": "박형준",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_3b0cf776632dd287",
+        "survey_name": "부산시장 가상 양자대결서 전재수 43.3% vs 박형준 34.6%",
+        "pollster": "MBC",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "26-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|26-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "전재수",
+          "value_raw": "43.3%",
+          "value_min": 43.3,
+          "value_max": 43.3,
+          "value_mid": 43.3,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "박형준",
+          "value_raw": "34.6%",
+          "value_min": 34.6,
+          "value_max": 34.6,
+          "value_mid": 34.6,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMib0FVX3lxTE5sRDhVVG5DV0xxZTFDbExIM3I0MXdGTnUtY3BCWmdCRndlcmdid1NVX0oxQjNYdGtTeXk4aFlDLVZMbHIwNWZwdnBtdXQxMGFJMnpHaVdjenZNTXp5eWJRMWNQd1d3c1FfVTh4ekhxbw",
+        "title": "[중부일보 여론조사] 경기도지사, 김동연·추미애 20% 동률 초박빙… 김은혜 11%-안철수·한준호 8%",
+        "publisher": "중부일보",
+        "published_at": null,
+        "raw_text": "[중부일보 여론조사] 경기도지사, 김동연·추미애 20% 동률 초박빙… 김은혜 11%-안철수·한준호 8% - 중부일보 [중부일보 여론조사] 경기도지사, 김동연·추미애 20% 동률 초박빙… 김은혜 11%-안철수·한준호 8% &nbsp;&nbsp; 중부일보 지방선거 경기지사 여론조사",
+        "raw_hash": "raw_2ee3c31fb6ace23d"
+      },
+      "region": {
+        "region_code": "41-000",
+        "sido_name": "경기도",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:추미애",
+          "name_ko": "추미애",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:김은혜",
+          "name_ko": "김은혜",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:한준호",
+          "name_ko": "한준호",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_d513d499f4698d34",
+        "survey_name": "[중부일보 여론조사] 경기도지사, 김동연·추미애 20% 동률 초박빙… 김은혜 11%-안철수·한준호 8%",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "41-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|41-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "추미애",
+          "value_raw": "20%",
+          "value_min": 20.0,
+          "value_max": 20.0,
+          "value_mid": 20.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "김은혜",
+          "value_raw": "11%",
+          "value_min": 11.0,
+          "value_max": 11.0,
+          "value_mid": 11.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "한준호",
+          "value_raw": "8%",
+          "value_min": 8.0,
+          "value_max": 8.0,
+          "value_mid": 8.0,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiZ0FVX3lxTE5QSHRHTU84ejRWemFhbTJMTVFYeXhtcnljV3otMWltOXk1Vk9rX2Jmd29meVo4LXpaa2NCeC02WUg3TTRiUlZwZjVBVjRYemxBNi1IbVFBNmJpaGVHZllRMVNRbTIwTlk",
+        "title": "[지선특집조사/경기도] 국정지지도 70.9% 민주당 54.3% 국민의힘 25.2%",
+        "publisher": "서귀포방송",
+        "published_at": null,
+        "raw_text": "[지선특집조사/경기도] 국정지지도 70.9% 민주당 54.3% 국민의힘 25.2% - 서귀포방송 [지선특집조사/경기도] 국정지지도 70.9% 민주당 54.3% 국민의힘 25.2% &nbsp;&nbsp; 서귀포방송 지방선거 경기지사 가상대결",
+        "raw_hash": "raw_5ef88dd0faf3f961"
+      },
+      "region": {
+        "region_code": "41-000",
+        "sido_name": "경기도",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:국정지지도",
+          "name_ko": "국정지지도",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_7a093d267de2d6f7",
+        "survey_name": "[지선특집조사/경기도] 국정지지도 70.9% 민주당 54.3% 국민의힘 25.2%",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "41-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|41-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "국정지지도",
+          "value_raw": "70.9%",
+          "value_min": 70.9,
+          "value_max": 70.9,
+          "value_mid": 70.9,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMicEFVX3lxTE1UTGpubjRpUklYVl8yS01Vai03NVB0ekRfU1k2LTlESXNsdFR1REJ4SUtDTC1lNEtsR3hBNHpacEFpRUR4RVRQUUNlbXloUWtfV3k4TzRYTnVlaHNvbVJwa2JDazJ2a1lRTTR6bl84M0k",
+        "title": "[여론조사] 인천시장, 박찬대 34% 유정복 22%···민주 48% 국힘 20%",
+        "publisher": "인천투데이",
+        "published_at": null,
+        "raw_text": "[여론조사] 인천시장, 박찬대 34% 유정복 22%···민주 48% 국힘 20% - 인천투데이 [여론조사] 인천시장, 박찬대 34% 유정복 22%···민주 48% 국힘 20% &nbsp;&nbsp; 인천투데이 지방선거 인천시장 여론조사",
+        "raw_hash": "raw_75346770ad6801e8"
+      },
+      "region": {
+        "region_code": "28-000",
+        "sido_name": "인천광역시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:박찬대",
+          "name_ko": "박찬대",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:유정복",
+          "name_ko": "유정복",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:민주",
+          "name_ko": "민주",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:국힘",
+          "name_ko": "국힘",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_0715ab45c5380b9c",
+        "survey_name": "[여론조사] 인천시장, 박찬대 34% 유정복 22%···민주 48% 국힘 20%",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "28-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|28-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "박찬대",
+          "value_raw": "34%",
+          "value_min": 34.0,
+          "value_max": 34.0,
+          "value_mid": 34.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "유정복",
+          "value_raw": "22%",
+          "value_min": 22.0,
+          "value_max": 22.0,
+          "value_mid": 22.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "민주",
+          "value_raw": "48%",
+          "value_min": 48.0,
+          "value_max": 48.0,
+          "value_mid": 48.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "국힘",
+          "value_raw": "20%",
+          "value_min": 20.0,
+          "value_max": 20.0,
+          "value_mid": 20.0,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiUkFVX3lxTE1BaU42T0NXektTMGdZOTlQRVVxTXRRRWZpLWh1alN1dkpOaEdHbk5keG56U3dwd2tVTlFrVHJKNDNrMGpoZGowa2UxNTdvWHBJcFE",
+        "title": "[경인일보 여론조사] 인천시장, 박찬대 45% vs 유정복 27%… 김교흥 27% vs 유정복 30%",
+        "publisher": "경인일보",
+        "published_at": null,
+        "raw_text": "[경인일보 여론조사] 인천시장, 박찬대 45% vs 유정복 27%… 김교흥 27% vs 유정복 30% - 경인일보 [경인일보 여론조사] 인천시장, 박찬대 45% vs 유정복 27%… 김교흥 27% vs 유정복 30% &nbsp;&nbsp; 경인일보 지방선거 인천시장 여론조사",
+        "raw_hash": "raw_d8e5f157ce006a8f"
+      },
+      "region": {
+        "region_code": "28-000",
+        "sido_name": "인천광역시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:박찬대",
+          "name_ko": "박찬대",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:유정복",
+          "name_ko": "유정복",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:김교흥",
+          "name_ko": "김교흥",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_73e9db6baf85b5d3",
+        "survey_name": "[경인일보 여론조사] 인천시장, 박찬대 45% vs 유정복 27%… 김교흥 27% vs 유정복 30%",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "28-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|28-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "박찬대",
+          "value_raw": "45%",
+          "value_min": 45.0,
+          "value_max": 45.0,
+          "value_mid": 45.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "유정복",
+          "value_raw": "27%",
+          "value_min": 27.0,
+          "value_max": 27.0,
+          "value_mid": 27.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "김교흥",
+          "value_raw": "27%",
+          "value_min": 27.0,
+          "value_max": 27.0,
+          "value_mid": 27.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "유정복",
+          "value_raw": "30%",
+          "value_min": 30.0,
+          "value_max": 30.0,
+          "value_mid": 30.0,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiUEFVX3lxTE5ZVmw4S0lqNUl2blhORDJNaDhNYXRuOU5YVjEtbDB2X2JnUFRHaUlLamktTVIwRERxRFRvUU8tZUNJN3BSMHVFWHp3Skl4UTVW",
+        "title": "[속보]서울시장 양자대결 정원오 50.5%·오세훈 40.3% ‘격차 확대’-조원씨앤아이",
+        "publisher": "문화일보",
+        "published_at": null,
+        "raw_text": "[속보]서울시장 양자대결 정원오 50.5%·오세훈 40.3% ‘격차 확대’-조원씨앤아이 - 문화일보 [속보]서울시장 양자대결 정원오 50.5%·오세훈 40.3% ‘격차 확대’-조원씨앤아이 &nbsp;&nbsp; 문화일보 지방선거 서울시장 지지율",
+        "raw_hash": "raw_b732981064ae9a87"
+      },
+      "region": {
+        "region_code": "11-000",
+        "sido_name": "서울특별시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:정원오",
+          "name_ko": "정원오",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:오세훈",
+          "name_ko": "오세훈",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_9720c0cca1ab37ca",
+        "survey_name": "[속보]서울시장 양자대결 정원오 50.5%·오세훈 40.3% ‘격차 확대’-조원씨앤아이",
+        "pollster": "조원씨앤아이",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "11-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|11-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "정원오",
+          "value_raw": "50.5%",
+          "value_min": 50.5,
+          "value_max": 50.5,
+          "value_mid": 50.5,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "오세훈",
+          "value_raw": "40.3%",
+          "value_min": 40.3,
+          "value_max": 40.3,
+          "value_mid": 40.3,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiVEFVX3lxTE1IVU9vU0VXNTM3RndSNUpkTzFmVWJCYWNXRzdkNjJoQ19SeEZ6ZzBVenIzUXpBTlFRckVNZVVIQXAzR1dXVmIyY1lJa3JjVHRJYnBUQw",
+        "title": "정원오 vs 오세훈…KBS 44%:31%·MBC 40%:36%·SBS 38%:36%",
+        "publisher": "v.daum.net",
+        "published_at": null,
+        "raw_text": "정원오 vs 오세훈…KBS 44%:31%·MBC 40%:36%·SBS 38%:36% - v.daum.net 정원오 vs 오세훈…KBS 44%:31%·MBC 40%:36%·SBS 38%:36% &nbsp;&nbsp; v.daum.net 지방선거 서울시장 오차범위",
+        "raw_hash": "raw_2a048880e2d04040"
+      },
+      "region": {
+        "region_code": "11-000",
+        "sido_name": "서울특별시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:kbs",
+          "name_ko": "KBS",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:mbc",
+          "name_ko": "MBC",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:sbs",
+          "name_ko": "SBS",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_7e3a173859cf577d",
+        "survey_name": "정원오 vs 오세훈…KBS 44%:31%·MBC 40%:36%·SBS 38%:36%",
+        "pollster": "KBS",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "11-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|11-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "KBS",
+          "value_raw": "44%",
+          "value_min": 44.0,
+          "value_max": 44.0,
+          "value_mid": 44.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "MBC",
+          "value_raw": "40%",
+          "value_min": 40.0,
+          "value_max": 40.0,
+          "value_mid": 40.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "SBS",
+          "value_raw": "38%",
+          "value_min": 38.0,
+          "value_max": 38.0,
+          "value_mid": 38.0,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiW0FVX3lxTE43YUpldmVfcHp3QlZFeWNTTFQ2UllWLXFscm91WGdRRVJYNTVxYXdSVlVlLWJjczc5VTZvQ0wzb2VTZlBWTzktc0kyOVkwUi1Wa3dzTlltOFlUakk",
+        "title": "부산·경남 행정통합…“6월 지방선거 이후” 73%",
+        "publisher": "KBS 뉴스",
+        "published_at": null,
+        "raw_text": "부산·경남 행정통합…“6월 지방선거 이후” 73% - KBS 뉴스 부산·경남 행정통합…“6월 지방선거 이후” 73% &nbsp;&nbsp; KBS 뉴스 지방선거 부산시장 가상대결",
+        "raw_hash": "raw_9bb6338622f7c2d9"
+      },
+      "region": {
+        "region_code": "26-000",
+        "sido_name": "부산광역시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [],
+      "observation": {
+        "observation_key": "obs_3f6ca2ed23cdeb99",
+        "survey_name": "부산·경남 행정통합…“6월 지방선거 이후” 73%",
+        "pollster": "KBS",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "26-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|26-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": []
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiX0FVX3lxTE9GWVBudXBmWV8wR3pnY1RmTGRtcVZLVDFRQ0VZVmdWdmZSdnpvSFZ3S1RwdzBGS2NVMjFJM3hqczEyNlZzMzVsUTVzdkhsWUc2QnQ0UmNkQUtqd2ZMQURF",
+        "title": "국정안정론 우세…부산시장 전재수 40% vs 박형준 30%",
+        "publisher": "뉴스1",
+        "published_at": null,
+        "raw_text": "국정안정론 우세…부산시장 전재수 40% vs 박형준 30% - 뉴스1 국정안정론 우세…부산시장 전재수 40% vs 박형준 30% &nbsp;&nbsp; 뉴스1 지방선거 부산시장 오차범위",
+        "raw_hash": "raw_08c7cd1e40dd4f06"
+      },
+      "region": {
+        "region_code": "26-000",
+        "sido_name": "부산광역시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:전재수",
+          "name_ko": "전재수",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:박형준",
+          "name_ko": "박형준",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_9d438b8ddd2dce8e",
+        "survey_name": "국정안정론 우세…부산시장 전재수 40% vs 박형준 30%",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "26-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|26-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "전재수",
+          "value_raw": "40%",
+          "value_min": 40.0,
+          "value_max": 40.0,
+          "value_mid": 40.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "박형준",
+          "value_raw": "30%",
+          "value_min": 30.0,
+          "value_max": 30.0,
+          "value_mid": 30.0,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiYEFVX3lxTE5iM0Z6YzdVTU1hNHZHb0dXRWJxb0dPU2RoQlV1bHQ5Vk93OXlGQW1najU3TEE0UVVSd2RYT0s5Q0VYVnBnR2hscV9ac1pFUng5RjZSUUlpNjdtRHFRV25pMw",
+        "title": "6.3지방선거 인천시장 누구 선호? ‘박찬대’ 52.1% vs ‘유정복’ 36.8%",
+        "publisher": "CNB뉴스",
+        "published_at": null,
+        "raw_text": "6.3지방선거 인천시장 누구 선호? ‘박찬대’ 52.1% vs ‘유정복’ 36.8% - CNB뉴스 6.3지방선거 인천시장 누구 선호? ‘박찬대’ 52.1% vs ‘유정복’ 36.8% &nbsp;&nbsp; CNB뉴스 지방선거 인천시장 가상대결",
+        "raw_hash": "raw_d5f9b103d3eaf4f4"
+      },
+      "region": {
+        "region_code": "28-000",
+        "sido_name": "인천광역시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [],
+      "observation": {
+        "observation_key": "obs_2a69111033285a20",
+        "survey_name": "6.3지방선거 인천시장 누구 선호? ‘박찬대’ 52.1% vs ‘유정복’ 36.8%",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "28-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|28-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": []
+    },
+    {
+      "article": {
+        "url": "https://www.newsis.com/view/NISX20260224_0003524306",
+        "title": "국힘 소장파 \"'윤어게인'으로 지선 치를 수 있나, 의총서 투표\"…지도부 \"필버 정국 이후에\"(종합) :: 공감언론 뉴시스 ::",
+        "publisher": "뉴시스",
+        "published_at": "2026-02-24T13:50:31+09:00",
+        "raw_text": "국힘 소장파 \"'윤어게인'으로 지선 치를 수 있나, 의총서 투표\"…지도부 \"필버 정국 이후에\"(종합) :: 공감언론 뉴시스 :: --> 2026.02.24 (화) 서울 5.3℃ K-Artprice 프라임뉴시스 위클리뉴시스 실시간 정치 국제 경제 금융 산업 IT·바이오 사회 수도권 지방 문화 스포츠 연예 광장 포토 TV뉴시스 제휴 콘텐츠 [속보] \"트럼프 122조 관세, 10%로 개시…15% 인상은 추후에\" NBC 은마아파트 화재 사망…\"스프링클러 없고 화재경보기도 인지 못해\" 비트코인 6만3000달러선 붕괴…관세·중동 긴장에 5% 급락 [속보] 트럼프, 무역법 122조 전격 가동…오늘부터 '글로벌 15% 관세' 발효 '전한길 콘서트' 대관 취소…김동연 \"윤어게인 활개 안 돼\" 밀양 산불, 20시간 만에 주불 진화…산불영향구역 143㏊ [속보]삼성전자, 20만원 돌파…사상최고가 [속보]국회 법사위, 與 주도로 전남광주 통합특별법 통과 [속보]SK하이닉스, 장중 100만원 돌파…5%↑ [속보] 중국, 20개 日 기업 수출제한 목록 추가…미쓰비시 등 포함 [속보]코스피, 5900선 재돌파 [속보]이 대통령 \"공론화 거쳐 두달 안에 촉법소년 하향 문제 결정\" [속보]'무기징역' 윤석열, 1심 판결 불복해 항소 [속보]김건희특검, '도이치 주가조작 주포' 이준수 징역 1년6개월 구형 '1억 공천헌금' 강선우, 체포안 통과시 3월 초 영장심사 [속보] 경찰, '김병기 차남 취업 청탁 의혹' 빗썸 본사 등 2곳 압수수색 [속보]대법원, 내일 '사법개혁 3법' 관련 전국 법원장회의 소집 [속보]코스피 0.13% 오른 5853.48 출발 밀양 산불 이틀째, 진화율 70%…\"확산 저지 총력\" [속보]서울 강남 은마아파트 화재 1시간 20분만 완진…1명 사망·3명 부상 --> 정치 정치최신 청와대 국회/정당 국방/외교 북한 행정 지방정가 지방선거 --> 국힘 소장파 \"'윤어게인'으로 지선 치를 수 있나, 의총서 투표\"…지도부 \"필버 정국 이후에\"(종합) 등록 2026.02.24 13:50:31 작게 크게 \"결론 확실하게 나오면 대안과 미래도 따를 것\" 장 대표가 제시한 여론조사에는 \"왜곡된 부분 있어\" [서울=뉴시스] 김금보 기자 = 국민의힘 장동혁 대표와 송언석 원내대표가 24일 오전 서울 여의도 국회에서 열린 의원총회에 참석하고 있다. 2026.02.24. [email protected] [서울=뉴시스]김지훈 이승재 전상우 기자 = 국민의힘 내 소장파 모임인 '대안과 미래'는 24일 당 지도부를 향해 '윤어게인' 노선으로 6·3 지방선거를 치를 수 있는지를 논의하기 위한 의원총회 소집을 요구했다. 해당 안건을 표결에 부쳐 결론을 내야 한다는 주장도 나온다. 지도부는 민주당 쟁점 입법 강행 대응 필리버스터(무제한 토론) 정국 이후 논의하자는 입장이다. 대안과 미래 간사인 이성권 의원은 이날 오전 국회에서 대안과 미래 조찬 모임을 마친 뒤 기자들과 만나 \"지난 20일 장동혁 대표가 윤석열 전 대통령 1심 선고에 대한 기자회견에서 언론과 국민들이 받아들이기에 윤어게인 노선으로 보이는 입장을 발표했다\"며 이같이 말했다. 이 의원은 \"과연 윤어게인 노선으로 지선을 치를 수 있는지에 대해서 의원들의 허심탄회하고 격렬한 토론이 필요했음에도 어제 의총은 그러한 장이 되지 못했다\"고 했다. 이어 \"의원들의 총의가 모아질 수 있는 의총을 개최할 것을 지도부에게 요청한다\"며 \"의총을 통해서 지선까지 윤어게인 노선으로 치를 수 있는지에 대한 결론을 확실하게 내려줄 수 있기를 바라고, 대안과 미래도 결론에는 전적으로 따르겠다\"고 덧붙였다. 앞서 23일 열린 의원총회에서는 장 대표의 '절윤(윤 전 대통령과의 절연) 거부'에 관한 충분한 논의가 이뤄지지 못했다는 게 대안과 미래의 입장이다. 당시 의총에서 장 대표는 '절윤 거부'에 대한 당내 비판을 반박하고자, 일부 언론과 여의도연구원 등에서 진행한 비공개 여론조사를 제시한 것으로 전해졌다. 당 지지층을 대상으로 한 조사였고, '윤 전 대통령과 함께 가야 한다'는 취지의 답변이 더 많다는 내용이 담겼다고 한다. [서울=뉴시스] 조성봉 기자 = 국민의힘 소장파모임인 '대안과미래' 이성권 간사 등 소속 의원들이 24일 오전 서울 여의도 국회 의원회관 간담회의실에서 당내현안 관련 비공개 회동을 하고 있다. 2026.02.24. [email protected] 이 의원은 이와 관련한 질문에 \"오늘 몇몇 의원이 여론조사 로데이터(raw data·가공되지 않은 자료)를 가져와 분석했는데, 상당히 왜곡되고 종합적으로 보지 못하고 필요한 부분만 뽑아서 해석한 부분들이 있다는 게 명확했다\"며 \"그래서 이런 부분들을 의총에서 치열하게 토론할 필요가 있다는 것\"이라고 설명했다. 또한 \"격렬한 토론 이후에 의원들의 표결도 필요하다\"며 \"비밀투표 형태로 표결을 통해서 최종적으로 노선을 정할 것을 제안한다\"고 했다. 이날 오전 국회에서 열린 의원총회에서도 이같은 요구가 나왔다고 한다. 곽규택 원내수석대변인은 의원총회 후 기자들과 만나 \"의총에서는 본회의에 쟁점 법안들이 올라오는 상황에 대한 대응, 행정통합법에 대한 논의가 길어지다 보니 당내 문제를 집중적으로 논의할 시간은 없었다\"라면서도 \"일부 의원이 이 (절윤) 문제를 집중 논의할 의총을 별도로 했으면 좋겠다고 했고, 당 지도부는 필리버스터 정국이 끝나는 3월3일 이후 당내 문제를 집중적으로 논의할 수 있는 의총을 다시 잡아보겠다는 정도로 말했다\"고 전했다. ◎공감언론 뉴시스 [email protected] , [email protected] , [email protected] Copyright © NEWSIS.COM, 무단 전재 및 재배포 금지 많이 본 사진 은마아파트 화재현장 조사 '밀가루 전쟁' 즐기는 축제 참가자들 화재 발생한 은마아파트 밀양 산불진화하는 군 시누크 헬기 시범 경기, 번트 시도하는 이정후 사랑스러운 안유진 러블리 장원영 컴백한 아이브 BAFTA 참석한 이재 카리나 앙 러블리 혜리 뉴시스Pic 은마아파트 화재로 1명 숨지고 3명 다쳐 '李 최측근' 김남준, 정청래와 면담… \"계양을 출마 의지 밝혀\" '음주운전→헝가리 행' 스피드 김민석, 노메달로 밀라노 올림픽 마무리 이재명 대통령 국무회의 주재, '공직자 국민 위한 헌신 재차 주문' 그래픽뉴스 2026 밀라노·코르티나담페초 동계올림픽 최종 순위 이시간 핫뉴스 하정우, 차정원과 열애 인정 후 삭발 임성근 \"앞으론 음주운전 없을 것\" 활동 재개 '1100억 자산가' 손흥민, 이 차를 탄다고? '유퀴즈 MC 후보' 허경환, \"왜 발표 안 해\" 분노 전한길 초청 받은 최시원, 의미심장 게시글 오늘의 헤드라인 \"\"관세 15%라더니 10%\" 트럼프, 시행 직전 번복 도널드 트럼프 미국 대통령이 무역법 122조를 근거로 부과하기로 한 글로벌 관세가 당초 밝힌 15%가 아닌 10%로 우선 적용된다. 24일(현지 시간) NBC뉴스에 따르면 관세 발효를 몇 시간 앞두고 미 관세국경보호청(CBP)은 수입업자들에게 공문을 보내 \"특정 면제 대상이 아닌 한 모든 국가에 대해 150일간 10% 세율이 적용된다\"며 이날 오 정치 李 \"농지 투기 전수조사해 강제 매각 검토\" 국제 쿠팡 대표, 美하원 증언…'301조' 불씨될까 경제 전기료, 낮 1~3시 낮추고 저녁 6~8시 높일듯 금융 20만전자·100만닉스…육천피까지 단 40포인트 산업 재계 총수 총출동…한·브라질, 전방위 경제 협력 IT·바이오 \"증원 못 막았다\"…'의협회장 불신임' 움직임 사회 '무기징역' 윤석열, 1심 판결 불복해 항소 문화 28만명 본 '신라 금관'…경주 달군 황금 열기 스포츠 '사실상 종신' 한화-노시환 '뉴노멀' 된 비FA 시장 연예 조세호, '조폭 연루설' 이후 \"복귀라고 생각하지 않아\" 많이 본 기사 종합 정치 국제 경제 금융 산업 IT·바이오 사회 수도권 지방 문화 스포츠 연예 '1100억 자산가' 손흥민, LA서 포착된 의외의 차량…\"슈퍼카 아니었어?\" 전한길 공개 초청…최시원, 성경 구절 게시 의미심장 \"반도체 훈풍에…\" 기업심리, 팬데믹 후 4년 만에 첫 '낙관' 전환 북 김여정, 9차 당대회서 당 부장으로 승진 정원오, 오는 3월4일 구청장 사퇴…다음날 與서울시장 예비후보 등록 우크라 \"종전회담 27일께 예상…러우 정상회담, 러측 답변 없어\" 인식 차이 큰 미국과 이란…전쟁 피하기 힘들다-NYT \"4중 작용, 경구약\"…셀트리온, 비만 신약 개발 들어간다 북 김여정, 9차 당대회서 당 부장으로 승진 정원오, 오는 3월4일 구청장 사퇴…다음날 與서울시장 예비후보 등록 이 대통령 \"촉법소년 연령 1년 낮추는 게 압도적 의견…두달 후 결정\" 與, '사법개혁 3법'·상법개정안 등 본회의 처리 시도…'필버 정국' 재현될 듯 李대통령 \"다주택 유지는 자유…정상화 따른 위험 피할 수 없어\" 국회 법사위, 전남광주 행정통합법 통과…충남대전·대구경북 보류 이 대통령 \"공론화 거쳐 두달 안에 촉법소년 하향 문제 결정\" 나보다 월급 121만원 많은 친구, 부장 되니 456만원 더 받네…더 심해진 '이중구조' 우크라 \"종전회담 27일께 예상…러우 정상회담, 러측 답변 없어\" 인식 차이 큰 미국과 이란…전쟁 피하기 힘들다-NYT \"美합참, 이란 공격 위험성 경고\" 보도…트럼프 \"거짓\" 美하원, 로저스 쿠팡 대표 불러 韓차별 7시간여 조사(종합) 뉴욕 증시, 트럼프發 관세·AI 우려 하락 마감…다우지수 1.66% ↓ 중국, 20개 日 기업 수출제한 목록 추가…미쓰비시 등 포함 뉴욕 증시, 트럼프發 관세·AI 우려 하락 마감…다우지수 1.66% ↓ 멕시코 방위군, 마약 카르텔 두목 사살 후 반격 당해 25명 사망 뉴욕 증시, 트럼프發 관세·AI 우려 하락 마감…다우지수 1.66% ↓ \"3억은 빠져야\"…급매 쌓인 헬리오시티, 매수자는 '버티기' 나보다 월급 121만원 많은 친구, 부장 되니 456만원 더 받네…더 심해진 '이중구조' 뉴욕 증시, 트럼프發 관세·AI 우려 하락 마감…다우지수 1.66% ↓ '다주택자 대출'도 꽁꽁…은행권 대출 문 더 좁아진다 뉴욕 증시, 트럼프發 관세·AI 우려 하락 마감…다우지수 1.66% ↓(종합) 돌아온 '황사의 계절'…가정·학교·사업장 대응 요령은 층간소음, '이것' 설치했더니 스스로 생활습관 고쳤다 비트코인, 9500만원 거래…지속되는 '극단적 공포' 삼성전자, 20만원 돌파…사상최고가 한화비전, HBM 수혜 기대감에 24% 급등…사상최고가 SK하이닉스, 장중 100만원 돌파…5%↑ 육천피 가시권…증권가 \"27만전자·150만닉스 간다\" \"집값 오른다\" 전망 꺾였다…3년 7개월만에 낙폭 최대 코스피, 5900선 재돌파 '다주택자 대출'도 꽁꽁…은행권 대출 문 더 좁아진다 \"반도체 훈풍에…\" 기업심리, 팬데믹 후 4년 만에 첫 '낙관' 전환 한화오션, 사우디 해군 지원 협력 협약…현지 방산 시장 공략 강화 美하원, 로저스 쿠팡 대표 불러 韓차별 7시간여 조사(종합) 나보다 월급 121만원 많은 친구, 부장 되니 456만원 더 받네…더 심해진 '이중구조' 총수 총출동한 한·브라질 경제포럼…우주·방산·인프라 전방위 협력 이재용, 작년 개인 배당 3993억 1위…정의선 13% 뛴 1976억 첫 2위 삼성전자, 갤럭시 북6 글로벌 호평…프리미엄 PC 경쟁력 입증 돌아온 '황사의 계절'…가정·학교·사업장 대응 요령은 \"4중 작용, 경구약\"…셀트리온, 비만 신약 개발 들어간다 카카오엔터 '베리즈', 삼성 라이온즈 온라인 팀스토어 오픈 트럼프 '핀셋 관세', 갤럭시S26 출시 악재될까 '의대증원 반발' 전열 가다듬는 전공의·의대생…강경투쟁? 노년기 뼈 건강 지키려면…\"운동 후 '이것' 한 잔이 제일 좋아\" \"건강식인 줄 알았는데 응급실행?\"…바나나, 우리가 몰랐던 '두 얼굴' \"역시 린저씨 화력\"…리니지 클래식, 정식 서비스 일주일 만에 PC방 톱5 안착 \"모래바람 뚫고 돈맥 캔다\"…K-스킨부스터 중동 확장중 강남구 은마아파트 8층서 화재…1시간 20분만 완진 서울 강남 은마아파트 화재 1명 사망·3명 부상…1시간 20분만 완진 강남구 은마아파트 8층 화재 완진…1명 사망·3명 부상(종합) BTS 공연 앞두고 경찰, 티켓 사기·26만 인파 관리 총력 나보다 월급 121만원 많은 친구, 부장 되니 456만원 더 받네…더 심해진 '이중구조' '무기징역' 윤석열, 1심 판결 불복해 항소 '1억 공천헌금' 강선우, 체포안 통과시 3월 초 영장심사 '의대증원 반발' 전열 가다듬는 전공의·의대생…강경투쟁? \"3억은 빠져야\"…급매 쌓인 헬리오시티, 매수자는 '버티기' 컴퓨터 매장 1700만원 GPU 털이범, 하루 만에 검거…업주 \"선처 없다\" '전한길 콘서트' 대관 취소…김동연 \"윤어게인 활개 안 돼\" 부부싸움에 던져…'사패산 터널 1억 금팔찌' 주인 찾았다 이학재 인천공항 사장 오늘 사의 \"정부 인사 개입에 경종 필요\" 인천, 아침 영하권 추위…낮까지 비 또는 눈 예보 서울 시내 무량판 건축물, 설계부터 준공 후까지 안전 관리 서울시의회 국힘 \"오세훈에 구청장 출마 권한 정원오, 유치해\" 밀양 산불 이틀째, 진화율 70%…\"확산 저지 총력\" 국회 법사위, 전남광주 행정통합법 통과…충남대전·대구경북 보류 밀양 삼랑진 산불 진화율 51%…'대응 2단계'로 상향 밀양 삼랑진 산불 이틀째…주민 184명 대피 대전·충청·경상 지역에 대설특보 발효…중대본 1단계 가동 밀양 산불, 20시간 만에 주불 진화…산불영향구역 143㏊ 지하철 몰카범, 발각되자 휴대전화 던져 파손…집행유예 흐린 대구·경북, 일부 눈·비 예보…아침 -4도·한낮 8도 '비틀쥬스' 김준수 \"첫공연 때 욕하자 객석 빵 터져…'됐다' 싶었다\" 벨기에 국민 고양이 ‘르깟’ 서울 온다…필립 그뤽 개인전 은반지 하나로 되돌아간 1999년 빈…문지혁 '나이트 트레인' 문화체육관광부(2월24일 화요일) “미술관은 왜 실험하는가?”…김현석·안광휘·차지량 프로젝트 '신라 금관' 28만명 봤다…110일간 경주 달군 황금 열기 5·18 최후 항전지, 다시 시민 곁으로…옛전남도청 28일부터 시범운영 국가유산수리협회장에 박창열 현창문화재기술단 대표 '1100억 자산가' 손흥민, LA서 포착된 의외의 차량…\"슈퍼카 아니었어?\" 카카오엔터 '베리즈', 삼성 라이온즈 온라인 팀스토어 오픈 메시도 꺾은 손흥민, '3경기 연속 공격P'·새해 3연승 정조준 밀라노 동계올림픽 달군 '태극전사', 오늘 메달 걸고 금의환향 '사실상 종신 선언' 한화와 노시환…'뉴노멀' 된 비FA 시장 데뷔 3경기 연속골…오현규, 홍명보호 최전방 1순위 부상하나 한화 노시환, 구단과 '11년 307억원 계약'… KBO리그 역대 최장·최대 규모 이정후, MLB 시범경기 2경기 연속 안타…'리드오프' 김혜성도 안타 생산 전한길 공개 초청…최시원, 성경 구절 게시 의미심장 '유퀴즈 MC 후보' 허경환, 제작진에 \"왜 발표 안 해\" 분노 '불륜 중독' 男, 아내 친구·전처와 무차별 외도…\"와이프의 '설계'였다\" 김승수, 박세리와 '결혼설' 해명 \"아니라 해도 안 믿더라\" '4번 결혼' 박영규 \"25세 연하 아내, 세대 차이 나서 좋다\" '왕사남', 개봉 20일 만에 600만명…'왕의 남자'보다 빠르다 '심현섭♥' 정영림, 시험관 임신 실패 \"나이 많아 시간 없다고…\" \"앞으론 음주운전 없을 것\"…임성근, SNS·유튜브 활동 재개 뉴시스 기획특집 HBM4 시대 지선 D-100 러우戰 4년 설 이후 부동산 어디로 우울한 식품업계 많이 본 기사 1 [속보]북 김여정, 9차 당대회서 당 부장으로 승진 2 [단독]정원오, 오는 3월4일 구청장 사퇴…다음날 與서울시장 예비후보 등록 3 이 대통령 \"촉법소년 연령 1년 낮추는 게 압도적 의견…두달 후 결정\" 4 與, '사법개혁 3법'·상법개정안 등 본회의 처리 시도…'필버 정국' 재현될 듯 5 李대통령 \"다주택 유지는 자유…정상화 따른 위험 피할 수 없어\" 6 국회 법사위, 전남광주 행정통합법 통과…충남대전·대구경북 보류 7 [속보]이 대통령 \"공론화 거쳐 두달 안에 촉법소년 하향 문제 결정\" 1 '1100억 자산가' 손흥민, LA서 포착된 의외의 차량…\"슈퍼카 아니었어?\" 2 전한길 공개 초청…최시원, 성경 구절 게시 의미심장 3 \"반도체 훈풍에…\" 기업심리, 팬데믹 후 4년 만에 첫 '낙관' 전환 4 [속보]북 김여정, 9차 당대회서 당 부장으로 승진 5 [단독]정원오, 오는 3월4일 구청장 사퇴…다음날 與서울시장 예비후보 등록 6 우크라 \"종전회담 27일께 예상…러우 정상회담, 러측 답변 없어\" 7 인식 차이 큰 미국과 이란…전쟁 피하기 힘들다-NYT 기자수첩 고령사회 '요양업' 수요 느는데…규제 걸림돌 여전 민생은 뒷전, 정쟁만 보이는 본회의 풍경 피플 SM '정반합', 영리한 변형…'1주년' 하츠투하츠가 찍은 K-팝 새 좌표 \"김정문 없이는 제 인생도 없었어요\"…김정문알로에의 '남다른 선순환' 부부싸움에 던져…'사패산 터널 1억 금팔찌' 주인 찾았다 · 태국 군인 유골에서 '숟가락' 나와…가혹 행위 의혹 파문 · \"변기에 쑥\"…1200만원 금팔찌, 中 고속열차 오물탱크서 40분 만에 기적 회수 · \"크리스마스 선물 사올게\" 집 나간 엄마, 24년 뒤 옆 동네서 이중생활 '발칵' · 가짜 화폐 내밀어도 \"괜찮다\"…7년째 음식 내준 中 노점상 뉴스 실시간 정치 국제 경제 금융 산업 사회 수도권 지방 문화 IT·바이오 스포츠 연예 포토 TV뉴시스 광장 기자수첩 스토리칼럼 아트클럽 기고 인터뷰 기획특집 섹션코너 데일리뉴시스 인사 부고 동정 포토 국내사진 해외사진 그래픽 패밀리사이트 K-Artprice 프라임뉴시스 위클리뉴시스 제휴사 AP통신 新華通訊 모바일앱서비스 Android IOS 뉴시스 구독 네이버 채널 다음 언론사픽 유튜브 페이스북 X (트위터) 인스타그램 스레드 회사소개 광고 · 제휴 문의 제휴사 안내 콘텐츠 판매 저작권 규약 고충처리 기사제보 이용약관 개인정보 · 청소년보호정책 개인정보처리방침 알립니다 대표이사 : 염영남 주소 : 서울 중구 퇴계로 173 남산스퀘어빌딩 (구 극동빌딩) 12층 사업자등록번호 : 102-81-36588 발행인 : 염영남 편집인 : 염영남 고충처리인 : 김경원 통신판매업신고 : 서울중구 0398호 문의 02-721-7400 [email protected] 뉴시스의 모든 콘텐츠는 저작권법의 보호를 받는 바, 무단 전재ㆍ복사ㆍ배포를 금합니다. Copyright © NEWSIS.COM All rights reserved. 99+ -->",
+        "raw_hash": "7995ceec69939cca254b286cf94961cf50a7be88d9553433896060523a126fb9"
+      },
+      "region": {
+        "region_code": "11-000",
+        "sido_name": "서울특별시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:일간",
+          "name_ko": "일간",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:진화율",
+          "name_ko": "진화율",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_53efed5986b625b8",
+        "survey_name": "국힘 소장파 \"'윤어게인'으로 지선 치를 수 있나, 의총서 투표\"…지도부 \"필버 정국 이후에\"(종합) :: 공감언론 뉴시스 ::",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": "2026-02-23",
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "11-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|11-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.3333,
+        "legal_filled_count": 2,
+        "legal_required_count": 6,
+        "date_resolution": "relative_day",
+        "date_inference_mode": "relative_published_at",
+        "date_inference_confidence": 0.95,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "일간",
+          "value_raw": "10%",
+          "value_min": 10.0,
+          "value_max": 10.0,
+          "value_mid": 10.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "진화율",
+          "value_raw": "70%",
+          "value_min": 70.0,
+          "value_max": 70.0,
+          "value_mid": 70.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "진화율",
+          "value_raw": "51%",
+          "value_min": 51.0,
+          "value_max": 51.0,
+          "value_mid": 51.0,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://www.newsis.com/view/NISX20260224_0003524095",
+        "title": "국힘 소장파 \"'윤어게인'으로 지선 치를 수 있나…의총서 투표로 정해야\" :: 공감언론 뉴시스 ::",
+        "publisher": "뉴시스",
+        "published_at": "2026-02-24T11:28:22+09:00",
+        "raw_text": "국힘 소장파 \"'윤어게인'으로 지선 치를 수 있나…의총서 투표로 정해야\" :: 공감언론 뉴시스 :: --> 2026.02.24 (화) 서울 5.3℃ K-Artprice 프라임뉴시스 위클리뉴시스 실시간 정치 국제 경제 금융 산업 IT·바이오 사회 수도권 지방 문화 스포츠 연예 광장 포토 TV뉴시스 제휴 콘텐츠 [속보] \"트럼프 122조 관세, 10%로 개시…15% 인상은 추후에\" NBC 은마아파트 화재 사망…\"스프링클러 없고 화재경보기도 인지 못해\" 비트코인 6만3000달러선 붕괴…관세·중동 긴장에 5% 급락 [속보] 트럼프, 무역법 122조 전격 가동…오늘부터 '글로벌 15% 관세' 발효 '전한길 콘서트' 대관 취소…김동연 \"윤어게인 활개 안 돼\" 밀양 산불, 20시간 만에 주불 진화…산불영향구역 143㏊ [속보]삼성전자, 20만원 돌파…사상최고가 [속보]국회 법사위, 與 주도로 전남광주 통합특별법 통과 [속보]SK하이닉스, 장중 100만원 돌파…5%↑ [속보] 중국, 20개 日 기업 수출제한 목록 추가…미쓰비시 등 포함 [속보]코스피, 5900선 재돌파 [속보]이 대통령 \"공론화 거쳐 두달 안에 촉법소년 하향 문제 결정\" [속보]'무기징역' 윤석열, 1심 판결 불복해 항소 [속보]김건희특검, '도이치 주가조작 주포' 이준수 징역 1년6개월 구형 '1억 공천헌금' 강선우, 체포안 통과시 3월 초 영장심사 [속보] 경찰, '김병기 차남 취업 청탁 의혹' 빗썸 본사 등 2곳 압수수색 [속보]대법원, 내일 '사법개혁 3법' 관련 전국 법원장회의 소집 [속보]코스피 0.13% 오른 5853.48 출발 밀양 산불 이틀째, 진화율 70%…\"확산 저지 총력\" [속보]서울 강남 은마아파트 화재 1시간 20분만 완진…1명 사망·3명 부상 --> 정치 정치최신 청와대 국회/정당 국방/외교 북한 행정 지방정가 지방선거 --> 국힘 소장파 \"'윤어게인'으로 지선 치를 수 있나…의총서 투표로 정해야\" 등록 2026.02.24 11:24:13 수정 2026.02.24 11:28:22 작게 크게 \"결론 확실하게 나오면 대안과 미래도 따를 것\" 장 대표가 제시한 여론조사에는 \"왜곡된 부분 있어\" [서울=뉴시스] 조성봉 기자 = 국민의힘 소장파모임인 '대안과미래' 이성권 간사 등 소속 의원들이 24일 오전 서울 여의도 국회 의원회관 간담회의실에서 당내현안 관련 비공개 회동을 하고 있다. 2026.02.24. [email protected] [서울=뉴시스] 이승재 전상우 기자 = 국민의힘 내 개혁파 의원 모임인 '대안과 미래'는 24일 당 지도부를 향해 '윤어게인' 노선으로 6·3 지방선거를 치를 수 있는지를 논의하기 위한 의원총회 소집을 요구했다. 해당 안건을 표결에 부쳐 결론을 내야 한다는 주장도 나온다. 모임 간사인 이성권 의원은 이날 오전 국회에서 대안과 미래 조찬 모임을 마친 뒤 기자들과 만나 \"지난 20일 장동혁 대표가 윤석열 전 대통령 1심 선고에 대한 기자회견에서 언론과 국민들이 받아들이기에 윤어게인 노선으로 보이는 입장을 발표했다\"며 이같이 말했다. 이 의원은 \"과연 윤어게인 노선으로 지선을 치를 수 있는지에 대해서 의원들의 허심탄회하고 격렬한 토론이 필요했음에도 어제 의총은 그러한 장이 되지 못했다\"고 했다. 이어 \"의원들의 총의가 모아질 수 있는 의총을 개최할 것을 지도부에게 요청한다\"며 \"의총을 통해서 지선까지 윤어게인 노선으로 치를 수 있는지에 대한 결론을 확실하게 내려줄 수 있기를 바라고, 대안과 미래도 결론에는 전적으로 따르겠다\"고 덧붙였다. 앞서 23일 열린 의원총회에서는 장 대표의 '절윤(윤 전 대통령과의 절연) 거부'에 관한 충분한 논의가 이뤄지지 못했다는 게 대안과 미래의 입장이다. 당시 의총에서 장 대표는 '절윤 거부'에 대한 당내 비판을 반박하고자, 일부 언론과 여의도연구원 등에서 진행한 비공개 여론조사를 제시한 것으로 전해졌다. 당 지지층을 대상으로 한 조사였고, '윤 전 대통령과 함께 가야 한다'는 취지의 답변이 더 많다는 내용이 담겼다고 한다. 이 의원은 이와 관련한 질문에 \"오늘 몇몇 의원이 여론조사 로데이터(raw data·가공되지 않은 자료)를 가져와 분석했는데, 상당히 왜곡되고 종합적으로 보지 못하고 필요한 부분만 뽑아서 해석한 부분들이 있다는 게 명확했다\"며 \"그래서 이런 부분들을 의총에서 치열하게 토론할 필요가 있다는 것\"이라고 설명했다. 또한 \"격렬한 토론 이후에 의원들의 표결도 필요하다\"며 \"비밀투표 형태로 표결을 통해서 최종적으로 노선을 정할 것을 제안한다\"고 했다. ◎공감언론 뉴시스 [email protected] , [email protected] Copyright © NEWSIS.COM, 무단 전재 및 재배포 금지 많이 본 사진 은마아파트 화재현장 조사 '밀가루 전쟁' 즐기는 축제 참가자들 화재 발생한 은마아파트 밀양 산불진화하는 군 시누크 헬기 시범 경기, 번트 시도하는 이정후 사랑스러운 안유진 러블리 장원영 컴백한 아이브 BAFTA 참석한 이재 카리나 앙 러블리 혜리 뉴시스Pic 은마아파트 화재로 1명 숨지고 3명 다쳐 '李 최측근' 김남준, 정청래와 면담… \"계양을 출마 의지 밝혀\" '음주운전→헝가리 행' 스피드 김민석, 노메달로 밀라노 올림픽 마무리 이재명 대통령 국무회의 주재, '공직자 국민 위한 헌신 재차 주문' 그래픽뉴스 2026 밀라노·코르티나담페초 동계올림픽 최종 순위 이시간 핫뉴스 하정우, 차정원과 열애 인정 후 삭발 임성근 \"앞으론 음주운전 없을 것\" 활동 재개 '1100억 자산가' 손흥민, 이 차를 탄다고? '유퀴즈 MC 후보' 허경환, \"왜 발표 안 해\" 분노 전한길 초청 받은 최시원, 의미심장 게시글 오늘의 헤드라인 \"\"관세 15%라더니 10%\" 트럼프, 시행 직전 번복 도널드 트럼프 미국 대통령이 무역법 122조를 근거로 부과하기로 한 글로벌 관세가 당초 밝힌 15%가 아닌 10%로 우선 적용된다. 24일(현지 시간) NBC뉴스에 따르면 관세 발효를 몇 시간 앞두고 미 관세국경보호청(CBP)은 수입업자들에게 공문을 보내 \"특정 면제 대상이 아닌 한 모든 국가에 대해 150일간 10% 세율이 적용된다\"며 이날 오 정치 李 \"농지 투기 전수조사해 강제 매각 검토\" 국제 쿠팡 대표, 美하원 증언…'301조' 불씨될까 경제 전기료, 낮 1~3시 낮추고 저녁 6~8시 높일듯 금융 20만전자·100만닉스…육천피까지 단 40포인트 산업 재계 총수 총출동…한·브라질, 전방위 경제 협력 IT·바이오 \"증원 못 막았다\"…'의협회장 불신임' 움직임 사회 '무기징역' 윤석열, 1심 판결 불복해 항소 문화 28만명 본 '신라 금관'…경주 달군 황금 열기 스포츠 '사실상 종신' 한화-노시환 '뉴노멀' 된 비FA 시장 연예 조세호, '조폭 연루설' 이후 \"복귀라고 생각하지 않아\" 많이 본 기사 종합 정치 국제 경제 금융 산업 IT·바이오 사회 수도권 지방 문화 스포츠 연예 '1100억 자산가' 손흥민, LA서 포착된 의외의 차량…\"슈퍼카 아니었어?\" 전한길 공개 초청…최시원, 성경 구절 게시 의미심장 \"반도체 훈풍에…\" 기업심리, 팬데믹 후 4년 만에 첫 '낙관' 전환 북 김여정, 9차 당대회서 당 부장으로 승진 정원오, 오는 3월4일 구청장 사퇴…다음날 與서울시장 예비후보 등록 우크라 \"종전회담 27일께 예상…러우 정상회담, 러측 답변 없어\" 인식 차이 큰 미국과 이란…전쟁 피하기 힘들다-NYT \"4중 작용, 경구약\"…셀트리온, 비만 신약 개발 들어간다 북 김여정, 9차 당대회서 당 부장으로 승진 정원오, 오는 3월4일 구청장 사퇴…다음날 與서울시장 예비후보 등록 이 대통령 \"촉법소년 연령 1년 낮추는 게 압도적 의견…두달 후 결정\" 與, '사법개혁 3법'·상법개정안 등 본회의 처리 시도…'필버 정국' 재현될 듯 李대통령 \"다주택 유지는 자유…정상화 따른 위험 피할 수 없어\" 국회 법사위, 전남광주 행정통합법 통과…충남대전·대구경북 보류 이 대통령 \"공론화 거쳐 두달 안에 촉법소년 하향 문제 결정\" 나보다 월급 121만원 많은 친구, 부장 되니 456만원 더 받네…더 심해진 '이중구조' 우크라 \"종전회담 27일께 예상…러우 정상회담, 러측 답변 없어\" 인식 차이 큰 미국과 이란…전쟁 피하기 힘들다-NYT \"美합참, 이란 공격 위험성 경고\" 보도…트럼프 \"거짓\" 美하원, 로저스 쿠팡 대표 불러 韓차별 7시간여 조사(종합) 뉴욕 증시, 트럼프發 관세·AI 우려 하락 마감…다우지수 1.66% ↓ 중국, 20개 日 기업 수출제한 목록 추가…미쓰비시 등 포함 뉴욕 증시, 트럼프發 관세·AI 우려 하락 마감…다우지수 1.66% ↓ 멕시코 방위군, 마약 카르텔 두목 사살 후 반격 당해 25명 사망 뉴욕 증시, 트럼프發 관세·AI 우려 하락 마감…다우지수 1.66% ↓ \"3억은 빠져야\"…급매 쌓인 헬리오시티, 매수자는 '버티기' 나보다 월급 121만원 많은 친구, 부장 되니 456만원 더 받네…더 심해진 '이중구조' 뉴욕 증시, 트럼프發 관세·AI 우려 하락 마감…다우지수 1.66% ↓ '다주택자 대출'도 꽁꽁…은행권 대출 문 더 좁아진다 뉴욕 증시, 트럼프發 관세·AI 우려 하락 마감…다우지수 1.66% ↓(종합) 돌아온 '황사의 계절'…가정·학교·사업장 대응 요령은 층간소음, '이것' 설치했더니 스스로 생활습관 고쳤다 비트코인, 9500만원 거래…지속되는 '극단적 공포' 삼성전자, 20만원 돌파…사상최고가 한화비전, HBM 수혜 기대감에 24% 급등…사상최고가 SK하이닉스, 장중 100만원 돌파…5%↑ 육천피 가시권…증권가 \"27만전자·150만닉스 간다\" \"집값 오른다\" 전망 꺾였다…3년 7개월만에 낙폭 최대 코스피, 5900선 재돌파 '다주택자 대출'도 꽁꽁…은행권 대출 문 더 좁아진다 \"반도체 훈풍에…\" 기업심리, 팬데믹 후 4년 만에 첫 '낙관' 전환 한화오션, 사우디 해군 지원 협력 협약…현지 방산 시장 공략 강화 美하원, 로저스 쿠팡 대표 불러 韓차별 7시간여 조사(종합) 나보다 월급 121만원 많은 친구, 부장 되니 456만원 더 받네…더 심해진 '이중구조' 총수 총출동한 한·브라질 경제포럼…우주·방산·인프라 전방위 협력 이재용, 작년 개인 배당 3993억 1위…정의선 13% 뛴 1976억 첫 2위 삼성전자, 갤럭시 북6 글로벌 호평…프리미엄 PC 경쟁력 입증 돌아온 '황사의 계절'…가정·학교·사업장 대응 요령은 \"4중 작용, 경구약\"…셀트리온, 비만 신약 개발 들어간다 카카오엔터 '베리즈', 삼성 라이온즈 온라인 팀스토어 오픈 트럼프 '핀셋 관세', 갤럭시S26 출시 악재될까 '의대증원 반발' 전열 가다듬는 전공의·의대생…강경투쟁? 노년기 뼈 건강 지키려면…\"운동 후 '이것' 한 잔이 제일 좋아\" \"건강식인 줄 알았는데 응급실행?\"…바나나, 우리가 몰랐던 '두 얼굴' \"역시 린저씨 화력\"…리니지 클래식, 정식 서비스 일주일 만에 PC방 톱5 안착 \"모래바람 뚫고 돈맥 캔다\"…K-스킨부스터 중동 확장중 강남구 은마아파트 8층서 화재…1시간 20분만 완진 서울 강남 은마아파트 화재 1명 사망·3명 부상…1시간 20분만 완진 강남구 은마아파트 8층 화재 완진…1명 사망·3명 부상(종합) BTS 공연 앞두고 경찰, 티켓 사기·26만 인파 관리 총력 나보다 월급 121만원 많은 친구, 부장 되니 456만원 더 받네…더 심해진 '이중구조' '무기징역' 윤석열, 1심 판결 불복해 항소 '1억 공천헌금' 강선우, 체포안 통과시 3월 초 영장심사 '의대증원 반발' 전열 가다듬는 전공의·의대생…강경투쟁? \"3억은 빠져야\"…급매 쌓인 헬리오시티, 매수자는 '버티기' 컴퓨터 매장 1700만원 GPU 털이범, 하루 만에 검거…업주 \"선처 없다\" '전한길 콘서트' 대관 취소…김동연 \"윤어게인 활개 안 돼\" 부부싸움에 던져…'사패산 터널 1억 금팔찌' 주인 찾았다 이학재 인천공항 사장 오늘 사의 \"정부 인사 개입에 경종 필요\" 인천, 아침 영하권 추위…낮까지 비 또는 눈 예보 서울 시내 무량판 건축물, 설계부터 준공 후까지 안전 관리 서울시의회 국힘 \"오세훈에 구청장 출마 권한 정원오, 유치해\" 밀양 산불 이틀째, 진화율 70%…\"확산 저지 총력\" 국회 법사위, 전남광주 행정통합법 통과…충남대전·대구경북 보류 밀양 삼랑진 산불 진화율 51%…'대응 2단계'로 상향 밀양 삼랑진 산불 이틀째…주민 184명 대피 대전·충청·경상 지역에 대설특보 발효…중대본 1단계 가동 밀양 산불, 20시간 만에 주불 진화…산불영향구역 143㏊ 지하철 몰카범, 발각되자 휴대전화 던져 파손…집행유예 흐린 대구·경북, 일부 눈·비 예보…아침 -4도·한낮 8도 '비틀쥬스' 김준수 \"첫공연 때 욕하자 객석 빵 터져…'됐다' 싶었다\" 벨기에 국민 고양이 ‘르깟’ 서울 온다…필립 그뤽 개인전 은반지 하나로 되돌아간 1999년 빈…문지혁 '나이트 트레인' 문화체육관광부(2월24일 화요일) “미술관은 왜 실험하는가?”…김현석·안광휘·차지량 프로젝트 '신라 금관' 28만명 봤다…110일간 경주 달군 황금 열기 5·18 최후 항전지, 다시 시민 곁으로…옛전남도청 28일부터 시범운영 국가유산수리협회장에 박창열 현창문화재기술단 대표 '1100억 자산가' 손흥민, LA서 포착된 의외의 차량…\"슈퍼카 아니었어?\" 카카오엔터 '베리즈', 삼성 라이온즈 온라인 팀스토어 오픈 메시도 꺾은 손흥민, '3경기 연속 공격P'·새해 3연승 정조준 밀라노 동계올림픽 달군 '태극전사', 오늘 메달 걸고 금의환향 '사실상 종신 선언' 한화와 노시환…'뉴노멀' 된 비FA 시장 데뷔 3경기 연속골…오현규, 홍명보호 최전방 1순위 부상하나 한화 노시환, 구단과 '11년 307억원 계약'… KBO리그 역대 최장·최대 규모 이정후, MLB 시범경기 2경기 연속 안타…'리드오프' 김혜성도 안타 생산 전한길 공개 초청…최시원, 성경 구절 게시 의미심장 '유퀴즈 MC 후보' 허경환, 제작진에 \"왜 발표 안 해\" 분노 '불륜 중독' 男, 아내 친구·전처와 무차별 외도…\"와이프의 '설계'였다\" 김승수, 박세리와 '결혼설' 해명 \"아니라 해도 안 믿더라\" '4번 결혼' 박영규 \"25세 연하 아내, 세대 차이 나서 좋다\" '왕사남', 개봉 20일 만에 600만명…'왕의 남자'보다 빠르다 '심현섭♥' 정영림, 시험관 임신 실패 \"나이 많아 시간 없다고…\" \"앞으론 음주운전 없을 것\"…임성근, SNS·유튜브 활동 재개 뉴시스 기획특집 HBM4 시대 지선 D-100 러우戰 4년 설 이후 부동산 어디로 우울한 식품업계 많이 본 기사 1 [속보]북 김여정, 9차 당대회서 당 부장으로 승진 2 [단독]정원오, 오는 3월4일 구청장 사퇴…다음날 與서울시장 예비후보 등록 3 이 대통령 \"촉법소년 연령 1년 낮추는 게 압도적 의견…두달 후 결정\" 4 與, '사법개혁 3법'·상법개정안 등 본회의 처리 시도…'필버 정국' 재현될 듯 5 李대통령 \"다주택 유지는 자유…정상화 따른 위험 피할 수 없어\" 6 국회 법사위, 전남광주 행정통합법 통과…충남대전·대구경북 보류 7 [속보]이 대통령 \"공론화 거쳐 두달 안에 촉법소년 하향 문제 결정\" 1 '1100억 자산가' 손흥민, LA서 포착된 의외의 차량…\"슈퍼카 아니었어?\" 2 전한길 공개 초청…최시원, 성경 구절 게시 의미심장 3 \"반도체 훈풍에…\" 기업심리, 팬데믹 후 4년 만에 첫 '낙관' 전환 4 [속보]북 김여정, 9차 당대회서 당 부장으로 승진 5 [단독]정원오, 오는 3월4일 구청장 사퇴…다음날 與서울시장 예비후보 등록 6 우크라 \"종전회담 27일께 예상…러우 정상회담, 러측 답변 없어\" 7 인식 차이 큰 미국과 이란…전쟁 피하기 힘들다-NYT 기자수첩 고령사회 '요양업' 수요 느는데…규제 걸림돌 여전 민생은 뒷전, 정쟁만 보이는 본회의 풍경 피플 SM '정반합', 영리한 변형…'1주년' 하츠투하츠가 찍은 K-팝 새 좌표 \"김정문 없이는 제 인생도 없었어요\"…김정문알로에의 '남다른 선순환' 부부싸움에 던져…'사패산 터널 1억 금팔찌' 주인 찾았다 · 태국 군인 유골에서 '숟가락' 나와…가혹 행위 의혹 파문 · \"변기에 쑥\"…1200만원 금팔찌, 中 고속열차 오물탱크서 40분 만에 기적 회수 · \"크리스마스 선물 사올게\" 집 나간 엄마, 24년 뒤 옆 동네서 이중생활 '발칵' · 가짜 화폐 내밀어도 \"괜찮다\"…7년째 음식 내준 中 노점상 뉴스 실시간 정치 국제 경제 금융 산업 사회 수도권 지방 문화 IT·바이오 스포츠 연예 포토 TV뉴시스 광장 기자수첩 스토리칼럼 아트클럽 기고 인터뷰 기획특집 섹션코너 데일리뉴시스 인사 부고 동정 포토 국내사진 해외사진 그래픽 패밀리사이트 K-Artprice 프라임뉴시스 위클리뉴시스 제휴사 AP통신 新華通訊 모바일앱서비스 Android IOS 뉴시스 구독 네이버 채널 다음 언론사픽 유튜브 페이스북 X (트위터) 인스타그램 스레드 회사소개 광고 · 제휴 문의 제휴사 안내 콘텐츠 판매 저작권 규약 고충처리 기사제보 이용약관 개인정보 · 청소년보호정책 개인정보처리방침 알립니다 대표이사 : 염영남 주소 : 서울 중구 퇴계로 173 남산스퀘어빌딩 (구 극동빌딩) 12층 사업자등록번호 : 102-81-36588 발행인 : 염영남 편집인 : 염영남 고충처리인 : 김경원 통신판매업신고 : 서울중구 0398호 문의 02-721-7400 [email protected] 뉴시스의 모든 콘텐츠는 저작권법의 보호를 받는 바, 무단 전재ㆍ복사ㆍ배포를 금합니다. Copyright © NEWSIS.COM All rights reserved. 99+ -->",
+        "raw_hash": "7cd7ee4a2f174bdd90d8e5f98b6194871b0c19b6fc849b01c57ddfc43a424218"
+      },
+      "region": {
+        "region_code": "11-000",
+        "sido_name": "서울특별시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:일간",
+          "name_ko": "일간",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:진화율",
+          "name_ko": "진화율",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_2ed7ab2c5d4f26ae",
+        "survey_name": "국힘 소장파 \"'윤어게인'으로 지선 치를 수 있나…의총서 투표로 정해야\" :: 공감언론 뉴시스 ::",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": "2026-02-23",
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "11-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|11-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.3333,
+        "legal_filled_count": 2,
+        "legal_required_count": 6,
+        "date_resolution": "relative_day",
+        "date_inference_mode": "relative_published_at",
+        "date_inference_confidence": 0.95,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "일간",
+          "value_raw": "10%",
+          "value_min": 10.0,
+          "value_max": 10.0,
+          "value_mid": 10.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "진화율",
+          "value_raw": "70%",
+          "value_min": 70.0,
+          "value_max": 70.0,
+          "value_mid": 70.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "진화율",
+          "value_raw": "51%",
+          "value_min": 51.0,
+          "value_max": 51.0,
+          "value_mid": 51.0,
+          "is_missing": false
+        }
+      ]
+    }
+  ]
+}

--- a/data/verification/issue248_run_22338262595_artifacts/collector-live-news-artifacts/collector_live_news_v1_report.json
+++ b/data/verification/issue248_run_22338262595_artifacts/collector-live-news-artifacts/collector_live_news_v1_report.json
@@ -1,0 +1,56 @@
+{
+  "run_type": "collector_live_news_v1",
+  "generated_at": "2026-02-24T05:42:14.269637+00:00",
+  "discovery_metrics": {
+    "query_count": 84,
+    "raw_count": 244,
+    "dedup_count": 80,
+    "fetched_count": 80,
+    "valid_count": 38,
+    "fallback_fetch_count": 63,
+    "duplicate_count": 164,
+    "duplicate_rate": 0.6721,
+    "fetch_fail_count": 0,
+    "fetch_fail_rate": 0.0,
+    "valid_article_rate": 0.475
+  },
+  "counts": {
+    "article_count": 38,
+    "observation_count": 37,
+    "option_count": 80,
+    "review_queue_count": 106,
+    "ingest_record_count": 37,
+    "threshold_miss_count": 37
+  },
+  "legal_required_fields": [
+    "pollster",
+    "sponsor",
+    "survey_period",
+    "sample_size",
+    "response_rate",
+    "margin_of_error"
+  ],
+  "legal_completeness": {
+    "threshold": 0.8,
+    "avg_score": 0.1802,
+    "min_score": 0.1667,
+    "max_score": 0.3333,
+    "missing_field_counts": {
+      "sponsor": 37,
+      "sample_size": 37,
+      "response_rate": 37,
+      "margin_of_error": 37,
+      "survey_period": 34
+    }
+  },
+  "acceptance_checks": {
+    "live_news_candidates_present": true,
+    "ingest_records_ge_30": true,
+    "threshold_miss_review_queue_synced": true
+  },
+  "risk_signals": {
+    "threshold_miss_present": true,
+    "threshold_miss_count": 37,
+    "threshold_miss_rate": 1.0
+  }
+}

--- a/data/verification/issue248_run_22338262595_artifacts/collector-live-news-artifacts/collector_live_news_v1_review_queue_candidates.json
+++ b/data/verification/issue248_run_22338262595_artifacts/collector-live-news-artifacts/collector_live_news_v1_review_queue_candidates.json
@@ -1,0 +1,1885 @@
+[
+  {
+    "id": "rvq_ede7ddedc02bce55",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMiWkFVX3lxTE9HamZYd25pRGI3UmxSZGpRRHFHaDF0dDJ2RHJyNG5qaE9ybWFDb0F5OUQ2Mk5EVDU1bk9mZWpEUk84MXk1LU9DT3Rhdm92MTBJbjBOME4zYlVDd9IBX0FVX3lxTE5fd1ZmcUxyQ21BWWRBTnhjUWRfMVkzVnNjamFvbXY3bktLekpjNDNFam5rckZlVHQwQ2xKMlRFSTFvRDZIV2JYY3plTkhVeEd3eEE0MGdISmFuZ0JDNE84",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMiWkFVX3lxTE9HamZYd25pRGI3UmxSZGpRRHFHaDF0dDJ2RHJyNG5qaE9ybWFDb0F5OUQ2Mk5EVDU1bk9mZWpEUk84MXk1LU9DT3Rhdm92MTBJbjBOME4zYlVDd9IBX0FVX3lxTE5fd1ZmcUxyQ21BWWRBTnhjUWRfMVkzVnNjamFvbXY3bktLekpjNDNFam5rckZlVHQwQ2xKMlRFSTFvRDZIV2JYY3plTkhVeEd3eEE0MGdISmFuZ0JDNE84",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:45.460712+00:00"
+  },
+  {
+    "id": "rvq_df7a32f9e22f0c77",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMib0FVX3lxTFBJc3BDSGVxWFV6cXZaUXBjdy1ZX3JSODJpbXVlNnhTcFpNZEFITmV6MkFEUHlDZEw4cUtYVGZhVVpUWEN6amVNQ29YMFdjclh0Xy1seV9pbmlIV01mWlduZTE1T08yZ1V1dkExSHRUMA",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMib0FVX3lxTFBJc3BDSGVxWFV6cXZaUXBjdy1ZX3JSODJpbXVlNnhTcFpNZEFITmV6MkFEUHlDZEw4cUtYVGZhVVpUWEN6amVNQ29YMFdjclh0Xy1seV9pbmlIV01mWlduZTE1T08yZ1V1dkExSHRUMA",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:45.460790+00:00"
+  },
+  {
+    "id": "rvq_924fb01e329ae35d",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMicEFVX3lxTE5QYU9aVVd5UEt6SHFZcm9TVERHOTBqRE5YbHlpOXR1VTUzcWtNcGR2V1Jhai1fLXk3bUJyWC1lbEw0VUNxcFR0eklxclVHWENudzlZZWtkZEpUTkxvaDE0d0lScV9DYXZ2dFhzbEJlQ3Y",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMicEFVX3lxTE5QYU9aVVd5UEt6SHFZcm9TVERHOTBqRE5YbHlpOXR1VTUzcWtNcGR2V1Jhai1fLXk3bUJyWC1lbEw0VUNxcFR0eklxclVHWENudzlZZWtkZEpUTkxvaDE0d0lScV9DYXZ2dFhzbEJlQ3Y",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:45.460846+00:00"
+  },
+  {
+    "id": "rvq_13ac585bb12ec347",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMieEFVX3lxTE5tTW9iQy1QNXd2ZUU2OE5kZmZWMWlkem9tRDRMZXpVcVRVNXgxSGVicUxKdVBXX2QxeW5NYVBCQUp3NmdVRXF0c3VYZ19DT0F2UGtWVTZSYjdHa0J0SFFCOGM3N3lEM0JQMDJpZU5ybnBnY0ZRV2YwWdIBeEFVX3lxTFBXWWNrY1FkOUNlcWd3Z3hNZ1dkQ3JnbmNKcDFKVUpUN1k3SWt5UThzUVYxaDNMVkRzeDhTZV8yU2VTVHhlNVdFbllQVEl0QXZVYVVTOG85aDNMc0EzVVV4Nk1qZ1lUNVE0eTRIcS1FbTVrbk43RDc1Nw",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMieEFVX3lxTE5tTW9iQy1QNXd2ZUU2OE5kZmZWMWlkem9tRDRMZXpVcVRVNXgxSGVicUxKdVBXX2QxeW5NYVBCQUp3NmdVRXF0c3VYZ19DT0F2UGtWVTZSYjdHa0J0SFFCOGM3N3lEM0JQMDJpZU5ybnBnY0ZRV2YwWdIBeEFVX3lxTFBXWWNrY1FkOUNlcWd3Z3hNZ1dkQ3JnbmNKcDFKVUpUN1k3SWt5UThzUVYxaDNMVkRzeDhTZV8yU2VTVHhlNVdFbllQVEl0QXZVYVVTOG85aDNMc0EzVVV4Nk1qZ1lUNVE0eTRIcS1FbTVrbk43RDc1Nw",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:45.460899+00:00"
+  },
+  {
+    "id": "rvq_86d2a2b57c3864e7",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMiVkFVX3lxTE5mZnp1cU5sXzNkMk52b1Y4bWpsaXhoZUswNEVsaDN4RERfV2RyTFdOY1hackVlbWFwWlBRaFFITkZOeDRiWFo2Sll4UWNaTEt1aFJoYzh30gGGAkFVX3lxTE16ZVBkOUM3T2hYWm5LOEhjNDlFRXNfbWpqbUhqQjBBdlJocTg3dnJXb3VvZ0FTR2lkbjFGMHRPZlBuTVo0Q2w0M3NZVmhZTjdzLWlzdkFKb1RJVmNkMUpFX1lsMDZOa2Z4MmQwTUlxVm1EdGJxUTUxR2hmeUNnU0JBN1h0OXllZXFpZlo4Ry03U3hMN3ZDbExRUklHcUE4cHV6R2hBODdkYnJWd1VYMWEwaGRUcFNnLXNLa3BRd1p5TERzTHVfNkNhQjV1bzFWLTBpcmYzM0RZMnZrQ1M3dzVTNEVicFFxbHB0UFJYQTFTUzNicXNfNEFoaGk2SHFtdXU0b3RTVXc",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMiVkFVX3lxTE5mZnp1cU5sXzNkMk52b1Y4bWpsaXhoZUswNEVsaDN4RERfV2RyTFdOY1hackVlbWFwWlBRaFFITkZOeDRiWFo2Sll4UWNaTEt1aFJoYzh30gGGAkFVX3lxTE16ZVBkOUM3T2hYWm5LOEhjNDlFRXNfbWpqbUhqQjBBdlJocTg3dnJXb3VvZ0FTR2lkbjFGMHRPZlBuTVo0Q2w0M3NZVmhZTjdzLWlzdkFKb1RJVmNkMUpFX1lsMDZOa2Z4MmQwTUlxVm1EdGJxUTUxR2hmeUNnU0JBN1h0OXllZXFpZlo4Ry03U3hMN3ZDbExRUklHcUE4cHV6R2hBODdkYnJWd1VYMWEwaGRUcFNnLXNLa3BRd1p5TERzTHVfNkNhQjV1bzFWLTBpcmYzM0RZMnZrQ1M3dzVTNEVicFFxbHB0UFJYQTFTUzNicXNfNEFoaGk2SHFtdXU0b3RTVXc",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:45.460949+00:00"
+  },
+  {
+    "id": "rvq_d87206db93fc5866",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMidEFVX3lxTE0tR240RHM3eWhpWHhBUmFDZzl1eUFIRjJZN0JGU185MXBaanpESmxwTUREYThKU3h6anpJRklRelduaHR1UjBLSFhlbDhoNkhJN284eS1RS2lmTm5wUTZXWXZLNFBNWm1vOW03YS1wTmdaRjB5",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMidEFVX3lxTE0tR240RHM3eWhpWHhBUmFDZzl1eUFIRjJZN0JGU185MXBaanpESmxwTUREYThKU3h6anpJRklRelduaHR1UjBLSFhlbDhoNkhJN284eS1RS2lmTm5wUTZXWXZLNFBNWm1vOW03YS1wTmdaRjB5",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:45.460998+00:00"
+  },
+  {
+    "id": "rvq_4a694cce91ac5d30",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMiT0FVX3lxTE1TR0RwR3pLa1lTTXY0XzFmaF81SFA3NXhhcHNLWWhTczVrQUtJcDJtOUxaNGxYdnNueXRBU19VSTAzVGpselZMTXVHWUJfYTg",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMiT0FVX3lxTE1TR0RwR3pLa1lTTXY0XzFmaF81SFA3NXhhcHNLWWhTczVrQUtJcDJtOUxaNGxYdnNueXRBU19VSTAzVGpselZMTXVHWUJfYTg",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:45.461045+00:00"
+  },
+  {
+    "id": "rvq_01d23c3a44d9253e",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMieEFVX3lxTE5YR2RWdVVLempqS2xCZU9WR083VHZWcEFjRnpqUUJpbWd3YjVINFBsNlU2UVRyNHU0UEg0YnBIRl9MLTkwaldWaDVPeE1XVnVKVWdGNlFXNTR5UFlfakR6bXZ4V0hTcVBrNU9oaEpPdWJjY2tpa1I4UQ",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMieEFVX3lxTE5YR2RWdVVLempqS2xCZU9WR083VHZWcEFjRnpqUUJpbWd3YjVINFBsNlU2UVRyNHU0UEg0YnBIRl9MLTkwaldWaDVPeE1XVnVKVWdGNlFXNTR5UFlfakR6bXZ4V0hTcVBrNU9oaEpPdWJjY2tpa1I4UQ",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:45.461091+00:00"
+  },
+  {
+    "id": "rvq_14ec8872fff8525c",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMiUkFVX3lxTE1lS3hWUFprb0RROTRHT1FzUHo5QmpBOGdLU3RvNnQxQlJjYVBMakk3NmdXaUZpY19aWXY4U1dxMHhjQVlJanB1UHY1QURTVHRWNHc",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMiUkFVX3lxTE1lS3hWUFprb0RROTRHT1FzUHo5QmpBOGdLU3RvNnQxQlJjYVBMakk3NmdXaUZpY19aWXY4U1dxMHhjQVlJanB1UHY1QURTVHRWNHc",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:45.461136+00:00"
+  },
+  {
+    "id": "rvq_1f01e645ca569123",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMiUkFVX3lxTFBxZHRodk44MXJxVnVlSFRnUkxoQi0yR0tUSmRFdE80LVFmazhtdmdHcjhQQmlXNG92bEZySVpGVG5LaGZNQ2JxUEdTN20zbVhpb3c",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMiUkFVX3lxTFBxZHRodk44MXJxVnVlSFRnUkxoQi0yR0tUSmRFdE80LVFmazhtdmdHcjhQQmlXNG92bEZySVpGVG5LaGZNQ2JxUEdTN20zbVhpb3c",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:45.461181+00:00"
+  },
+  {
+    "id": "rvq_b32ae824e52fdbc6",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMiUkFVX3lxTE8zQ29Gc1hUUnRvSXNrdjBsbW1VSERKTVJLa3NPZHFETnkyLUVnMHYwVm9OMFMzVUJBeTBtN192eTZXUThkM1U0RkE5Yk1PUk0yNmc",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMiUkFVX3lxTE8zQ29Gc1hUUnRvSXNrdjBsbW1VSERKTVJLa3NPZHFETnkyLUVnMHYwVm9OMFMzVUJBeTBtN192eTZXUThkM1U0RkE5Yk1PUk0yNmc",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:45.461226+00:00"
+  },
+  {
+    "id": "rvq_184356b46a39a379",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMicEFVX3lxTE1YcVB6eXZOVFo0eVFnbjk1eVQ1RC12VzlDNmZkTGhLQjVsaGhmOVBqSUFZV1dDVll1ZUZlOVg2SkdfSUlsT0syakZzYl9CdnRpY29tTWVhdXdwVnZSOHJGUFp5TEhob3l1NWRZaWpnSnM",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMicEFVX3lxTE1YcVB6eXZOVFo0eVFnbjk1eVQ1RC12VzlDNmZkTGhLQjVsaGhmOVBqSUFZV1dDVll1ZUZlOVg2SkdfSUlsT0syakZzYl9CdnRpY29tTWVhdXdwVnZSOHJGUFp5TEhob3l1NWRZaWpnSnM",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:45.461271+00:00"
+  },
+  {
+    "id": "rvq_f5a0891e7330adce",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMiakFVX3lxTE4tNDlfbjdXR3ZMcWlFMFRjUmNuWmhsWE9sYmxjaUszVE5pSnJBUUsyYW54SURTX2RXdnJidDY4OHpPMHRGUzFhM0MzR1FrUGlFekpnSHpzblp1OTM3VEtoUDlSay1uVWRXVHc",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMiakFVX3lxTE4tNDlfbjdXR3ZMcWlFMFRjUmNuWmhsWE9sYmxjaUszVE5pSnJBUUsyYW54SURTX2RXdnJidDY4OHpPMHRGUzFhM0MzR1FrUGlFekpnSHpzblp1OTM3VEtoUDlSay1uVWRXVHc",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:45.461321+00:00"
+  },
+  {
+    "id": "rvq_372460ca67f72afa",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMiVEFVX3lxTE5rS0JxZXRJT3piMlN2VW5tWnpDVmtZNmFGRDJUZ0dnb0k2NjFsWTRVZkY4NDNHb0pSendnS0FqVUhpMG9JRkhwYUo5Nk92SnZSQWNacw",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMiVEFVX3lxTE5rS0JxZXRJT3piMlN2VW5tWnpDVmtZNmFGRDJUZ0dnb0k2NjFsWTRVZkY4NDNHb0pSendnS0FqVUhpMG9JRkhwYUo5Nk92SnZSQWNacw",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:45.461369+00:00"
+  },
+  {
+    "id": "rvq_2a46d86f4b197f77",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMib0FVX3lxTFBVb1NSZjJ1enV6eDFDLWppUzM4eGlsc2RKRDVxY0pfSmxOUTBLcE1MbGZ0VGdqcVhUMVhHZTBzWk5xanF6Znl4Ym9icFMtX0xweWhsdTlVSzNURjVGUXdsQ1AzTC0xdXJDZDBjaG5TMA",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMib0FVX3lxTFBVb1NSZjJ1enV6eDFDLWppUzM4eGlsc2RKRDVxY0pfSmxOUTBLcE1MbGZ0VGdqcVhUMVhHZTBzWk5xanF6Znl4Ym9icFMtX0xweWhsdTlVSzNURjVGUXdsQ1AzTC0xdXJDZDBjaG5TMA",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:45.461415+00:00"
+  },
+  {
+    "id": "rvq_7d5604cf47551792",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMiZ0FVX3lxTE9VTlluWEJ1dFcydUhIa2M4YlhNSVloa1JmNkdtRHVEbGgxQzl5THhmaEY5Vlk3WTFIQTRUYmdVZjQ1SjRHRGF3YnA0MlFQQVB1UE1MY3lBdlVZM3IyS3FyMGhaelNaWFk",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMiZ0FVX3lxTE9VTlluWEJ1dFcydUhIa2M4YlhNSVloa1JmNkdtRHVEbGgxQzl5THhmaEY5Vlk3WTFIQTRUYmdVZjQ1SjRHRGF3YnA0MlFQQVB1UE1MY3lBdlVZM3IyS3FyMGhaelNaWFk",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:45.461460+00:00"
+  },
+  {
+    "id": "rvq_9764d84022db2a8f",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMimwFBVV95cUxPMjFRclBzZnhwdWlFY1l1QU1aRHNzem5UM0kzSW9LQjVldFNHeGg5ajlkZ1MycDYzek5RbWFTLVl5RjFlTlBLSzV4LXR1M1VmdTR3akpvTEp0SkFaR3h3Q0lIdEhDR0VkOFNJRWZEYXYtNEJGcHhuTEJOTG5zSEItZG04UWNUM2JsZUJsLUJnNXZYZExjSjRfQk0wQQ",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMimwFBVV95cUxPMjFRclBzZnhwdWlFY1l1QU1aRHNzem5UM0kzSW9LQjVldFNHeGg5ajlkZ1MycDYzek5RbWFTLVl5RjFlTlBLSzV4LXR1M1VmdTR3akpvTEp0SkFaR3h3Q0lIdEhDR0VkOFNJRWZEYXYtNEJGcHhuTEJOTG5zSEItZG04UWNUM2JsZUJsLUJnNXZYZExjSjRfQk0wQQ",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:45.461507+00:00"
+  },
+  {
+    "id": "rvq_7f9efbb0f5a87e0d",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMixAJBVV95cUxOSWl4anpQRkdSb1dRVTFfb01fSE81azZLZU0wWlc0Rzl6TnJNYkQ5THR6MmowMWZGSzFabnBMZmEybWItM05teENwYkhFcVNzSlhMeXBXb3V4dTFjYWNJQ3ZuYTI3bjhHaEdnTUFOcjV2cEx1SnZtUHRkMmx2N0RhSzk5dDI1TzgyT0pmTmdiOTlfRkZ5TDFCcHY4YnhtQnp5M1hUQ1VvM0RpdWlOODVMTHNSYkxvb1dlbU9vUGVvUE80MzYyLWRXd3pGTU12MVpSWml5NU5IQ19VUEd2SFRpODdGTG95alc0eEk4VDE4dTZQUHFlTzduMXNGLVB2QzhHaURBb2RjODFHamJ0WGhBcGs3dnAtd0J2SzVFMUtRcTkzX2JZVS1LOG9fbWpDa2o1SnhkWkhTbXNNSWxEOW5mM0xRcm8",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMixAJBVV95cUxOSWl4anpQRkdSb1dRVTFfb01fSE81azZLZU0wWlc0Rzl6TnJNYkQ5THR6MmowMWZGSzFabnBMZmEybWItM05teENwYkhFcVNzSlhMeXBXb3V4dTFjYWNJQ3ZuYTI3bjhHaEdnTUFOcjV2cEx1SnZtUHRkMmx2N0RhSzk5dDI1TzgyT0pmTmdiOTlfRkZ5TDFCcHY4YnhtQnp5M1hUQ1VvM0RpdWlOODVMTHNSYkxvb1dlbU9vUGVvUE80MzYyLWRXd3pGTU12MVpSWml5NU5IQ19VUEd2SFRpODdGTG95alc0eEk4VDE4dTZQUHFlTzduMXNGLVB2QzhHaURBb2RjODFHamJ0WGhBcGs3dnAtd0J2SzVFMUtRcTkzX2JZVS1LOG9fbWpDa2o1SnhkWkhTbXNNSWxEOW5mM0xRcm8",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:45.461581+00:00"
+  },
+  {
+    "id": "rvq_3a69e02739cffc77",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMiWkFVX3lxTFB2YUZpOFMxY2JtNEIwQi1GSTMwd0hkT1pzcDM3WWlKWnB6dE1vRDhDZzB2RVZfQjRQemJ6WkdrSDlIdXNmNm5hSnB0cjdKTEEtOE9JNjdtc3lJdw",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMiWkFVX3lxTFB2YUZpOFMxY2JtNEIwQi1GSTMwd0hkT1pzcDM3WWlKWnB6dE1vRDhDZzB2RVZfQjRQemJ6WkdrSDlIdXNmNm5hSnB0cjdKTEEtOE9JNjdtc3lJdw",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:45.461635+00:00"
+  },
+  {
+    "id": "rvq_47af057fcbb69d62",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMibkFVX3lxTE5VZ1UzR1k0dzJRRGgxdDl4QkR3bzBEUjFpc0hSc1Z5ZFFQWnU0VGg0NHJBeFFJLUE3RHhycFVjaUc2Q0RmQ3lNUkU2cU1lT3d0RlQxNGZuWjhFUVZvYUtWa0JSWE8xbkoxczc3VHFB0gFyQVVfeXFMTVYtemZ5RlluSnhqRklvaEZBdm0zMFh3MlBhN2NYYVFWM1F1MUpBajhsMFZZdHdfZGE1WVJMUHZRdUQ3SEVfWW1JYTJqbXBKN1Vnd1VET016bV9EX0lwZEpmeXFLTUp2b3BZaU9qOUxyTkFR",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMibkFVX3lxTE5VZ1UzR1k0dzJRRGgxdDl4QkR3bzBEUjFpc0hSc1Z5ZFFQWnU0VGg0NHJBeFFJLUE3RHhycFVjaUc2Q0RmQ3lNUkU2cU1lT3d0RlQxNGZuWjhFUVZvYUtWa0JSWE8xbkoxczc3VHFB0gFyQVVfeXFMTVYtemZ5RlluSnhqRklvaEZBdm0zMFh3MlBhN2NYYVFWM1F1MUpBajhsMFZZdHdfZGE1WVJMUHZRdUQ3SEVfWW1JYTJqbXBKN1Vnd1VET016bV9EX0lwZEpmeXFLTUp2b3BZaU9qOUxyTkFR",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:45.461685+00:00"
+  },
+  {
+    "id": "rvq_5b79b47bca90897d",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMiT0FVX3lxTE9nVmxoSnkzMUNfX1V5YTZyYktkSm5WUEk0ZGVyOEZxc3Y2cVF4cko5NjdsUklaLUpROGVRUGh4NFVzY2s0T3JWcjI1ZXgzNVE",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMiT0FVX3lxTE9nVmxoSnkzMUNfX1V5YTZyYktkSm5WUEk0ZGVyOEZxc3Y2cVF4cko5NjdsUklaLUpROGVRUGh4NFVzY2s0T3JWcjI1ZXgzNVE",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:45.461736+00:00"
+  },
+  {
+    "id": "rvq_f8f9f06888685811",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMiT0FVX3lxTE54TGg4cF9nTG9rU3M2X0FGWGVKMllQRGMtUmNUNzJTREJCYUxRdFo0ZVBtTEgxc2ZiYnJiWG1yLWM5UXBDZHJFZld2OTl6a1E",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMiT0FVX3lxTE54TGg4cF9nTG9rU3M2X0FGWGVKMllQRGMtUmNUNzJTREJCYUxRdFo0ZVBtTEgxc2ZiYnJiWG1yLWM5UXBDZHJFZld2OTl6a1E",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:45.461781+00:00"
+  },
+  {
+    "id": "rvq_6281b955929bd027",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMiT0FVX3lxTE9Nc1VkNEhQaDhxVkpJZ1ZfWHl0SXhJeG1DSHZHRnM0bmlZbV9na3hrS2t1V3BBeElBcFYzOEhHTWFLUklNcVU1V3RIdVVVZmM",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMiT0FVX3lxTE9Nc1VkNEhQaDhxVkpJZ1ZfWHl0SXhJeG1DSHZHRnM0bmlZbV9na3hrS2t1V3BBeElBcFYzOEhHTWFLUklNcVU1V3RIdVVVZmM",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:45.461829+00:00"
+  },
+  {
+    "id": "rvq_9f3b4681be53ce60",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMid0FVX3lxTE90WTBqQ1BTb1dLYm90TUhacW82V2NxZGNMY1VNRGJmdHZ1MWFfOU0xX2I1LXFUUlZuWlNQWXFWRWl4UXBiVTBJYkNJZjRRUXF5TVpvZkJBaVhmU0lDVWtGalp5aDAxUGhKUGZJaTRRVGxzbXNtWkdR0gFmQVVfeXFMT01DbmstNW4zeEU5Tm9CMnpjeElNdUFRa1JYQmdpaGJGQWJLT2NMMndBYTdxV0VNYmhNa2Fyb0t2a0ZtelV0THlidk9GaEpNNV9lZ1JPLTNTaF9iVmxRQnhGTkItbFln",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMid0FVX3lxTE90WTBqQ1BTb1dLYm90TUhacW82V2NxZGNMY1VNRGJmdHZ1MWFfOU0xX2I1LXFUUlZuWlNQWXFWRWl4UXBiVTBJYkNJZjRRUXF5TVpvZkJBaVhmU0lDVWtGalp5aDAxUGhKUGZJaTRRVGxzbXNtWkdR0gFmQVVfeXFMT01DbmstNW4zeEU5Tm9CMnpjeElNdUFRa1JYQmdpaGJGQWJLT2NMMndBYTdxV0VNYmhNa2Fyb0t2a0ZtelV0THlidk9GaEpNNV9lZ1JPLTNTaF9iVmxRQnhGTkItbFln",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:45.461877+00:00"
+  },
+  {
+    "id": "rvq_727715f9e17bccf4",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMiY0FVX3lxTE1GYndCMDhHRFV3ZWJvbUpfZkdfandfbTBxT05YTUVVVWdPSGxJeGJLVWUwNGFKNG01R2s5QnBuODgwQjYzX3F5MGYxOTJFblhJNUZ5TUhheHYxRnJDd1dicDR2Yw",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMiY0FVX3lxTE1GYndCMDhHRFV3ZWJvbUpfZkdfandfbTBxT05YTUVVVWdPSGxJeGJLVWUwNGFKNG01R2s5QnBuODgwQjYzX3F5MGYxOTJFblhJNUZ5TUhheHYxRnJDd1dicDR2Yw",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:45.461923+00:00"
+  },
+  {
+    "id": "rvq_0407420b5f549129",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMiUEFVX3lxTE9XUDhsQXlSS2d5SDZXTUJITU9nRnRpa1l3NXNVUENyMkdQZG04T0s5UG9SXzlySXJ2YlZ4ejN4Nmg3TzhJSDFXMWd5U0loM0Mw",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMiUEFVX3lxTE9XUDhsQXlSS2d5SDZXTUJITU9nRnRpa1l3NXNVUENyMkdQZG04T0s5UG9SXzlySXJ2YlZ4ejN4Nmg3TzhJSDFXMWd5U0loM0Mw",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:45.461969+00:00"
+  },
+  {
+    "id": "rvq_e2dc7c0095cb99e7",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMiZkFVX3lxTE9oNUFjcktRS0p1ZENLRHVJdTdiQlZCVkY1T0dOWU55MjBBOUlKU3ZXWGZrVDBqeTlLMDFUUVJmNzc1anJ5VVJDNHdyUjR3TWhmZi1GRkR6WkczRHVpU01jWldPM3pldw",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMiZkFVX3lxTE9oNUFjcktRS0p1ZENLRHVJdTdiQlZCVkY1T0dOWU55MjBBOUlKU3ZXWGZrVDBqeTlLMDFUUVJmNzc1anJ5VVJDNHdyUjR3TWhmZi1GRkR6WkczRHVpU01jWldPM3pldw",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:45.462013+00:00"
+  },
+  {
+    "id": "rvq_0ed9a82cc7394646",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMid0FVX3lxTE00bnR0cThIMG9qNFFQRERXbnE3LTNmd2JKcTh0c196VjJSUGEyVXd0WkE1TS1zeHc0bzk4aEtzUFVEWEc5VlBGSFBja1R6Y1JobW5mby1SWWFSUjEtM0p1b204OG9GNWRsMGgxXzBZOWFERnNrajRz",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMid0FVX3lxTE00bnR0cThIMG9qNFFQRERXbnE3LTNmd2JKcTh0c196VjJSUGEyVXd0WkE1TS1zeHc0bzk4aEtzUFVEWEc5VlBGSFBja1R6Y1JobW5mby1SWWFSUjEtM0p1b204OG9GNWRsMGgxXzBZOWFERnNrajRz",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:45.462060+00:00"
+  },
+  {
+    "id": "rvq_13755624a08ffdf2",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMia0FVX3lxTE54SFctQXNITHdfTDNjT2lDYmVtdkh1MHZub1JULW5RcG13Xy1JNURxQ1plcDYyUDRBa180YmNqczZnbllZME04Ym5vS21xQVEyaEdaaUpIaC1nN1FKX1JwVzU2V2FRMmhMS3Rn0gFvQVVfeXFMUDM4SFA3X3pHaWNVdTIzbUF6LVozOTlwdVZuRldLcGx1dGVSREdhbFJXck9FMHZKVGIxbVlhS3VqRmtHMkI4ZDEzZU1MOFNRYm5CREtrMzRMbTVJdjRtaFpYQlRuM2hRMGt2cHBsamtz",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMia0FVX3lxTE54SFctQXNITHdfTDNjT2lDYmVtdkh1MHZub1JULW5RcG13Xy1JNURxQ1plcDYyUDRBa180YmNqczZnbllZME04Ym5vS21xQVEyaEdaaUpIaC1nN1FKX1JwVzU2V2FRMmhMS3Rn0gFvQVVfeXFMUDM4SFA3X3pHaWNVdTIzbUF6LVozOTlwdVZuRldLcGx1dGVSREdhbFJXck9FMHZKVGIxbVlhS3VqRmtHMkI4ZDEzZU1MOFNRYm5CREtrMzRMbTVJdjRtaFpYQlRuM2hRMGt2cHBsamtz",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:45.462103+00:00"
+  },
+  {
+    "id": "rvq_b0b64a50dc78dccd",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMieEFVX3lxTE1Tdmg3TFdqS3NUN21RSTVtdXU2RG90czEtQmN0MWs1RFpabTYzOFctYXdGYU1DZExRMUZ2S2xfY3gydkJ3VjdyTTAwZ2F1ak5RWHN1d3A2ZXJiYnlnaW1nNm40Z2NJZHhSZUsyaEp5TUhVUGR6bXA4X9IBeEFVX3lxTE5INHczQnc2WlFxcF9iel9LN1doU01jOXJjbm9FS1kwTU9kZ0FTcHkzTzV2OWlLYmJiX1otNnNqTk5xMGMtdm5TNnRnYnlYR3VMaEp5UVZ2aUV3bnUwTVkxLXVhT01oRjJDRmVuNGlDOG80NlZscllVYg",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMieEFVX3lxTE1Tdmg3TFdqS3NUN21RSTVtdXU2RG90czEtQmN0MWs1RFpabTYzOFctYXdGYU1DZExRMUZ2S2xfY3gydkJ3VjdyTTAwZ2F1ak5RWHN1d3A2ZXJiYnlnaW1nNm40Z2NJZHhSZUsyaEp5TUhVUGR6bXA4X9IBeEFVX3lxTE5INHczQnc2WlFxcF9iel9LN1doU01jOXJjbm9FS1kwTU9kZ0FTcHkzTzV2OWlLYmJiX1otNnNqTk5xMGMtdm5TNnRnYnlYR3VMaEp5UVZ2aUV3bnUwTVkxLXVhT01oRjJDRmVuNGlDOG80NlZscllVYg",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:45.462150+00:00"
+  },
+  {
+    "id": "rvq_5fb6b33a45539175",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMib0FVX3lxTE5sRDhVVG5DV0xxZTFDbExIM3I0MXdGTnUtY3BCWmdCRndlcmdid1NVX0oxQjNYdGtTeXk4aFlDLVZMbHIwNWZwdnBtdXQxMGFJMnpHaVdjenZNTXp5eWJRMWNQd1d3c1FfVTh4ekhxbw",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMib0FVX3lxTE5sRDhVVG5DV0xxZTFDbExIM3I0MXdGTnUtY3BCWmdCRndlcmdid1NVX0oxQjNYdGtTeXk4aFlDLVZMbHIwNWZwdnBtdXQxMGFJMnpHaVdjenZNTXp5eWJRMWNQd1d3c1FfVTh4ekhxbw",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:45.462193+00:00"
+  },
+  {
+    "id": "rvq_6218bc64d4a18715",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMiVkFVX3lxTFB2dUV6QTdnbDdJTXp2UGRTRnhZbWlrUjR5Vk9udlZ5ZTVCU2J4SVJrdFY0QThSdUpCckp5RDNaOFBQLWVtbmRvOHFFNmV0NFY2MmJ3ZjdR",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMiVkFVX3lxTFB2dUV6QTdnbDdJTXp2UGRTRnhZbWlrUjR5Vk9udlZ5ZTVCU2J4SVJrdFY0QThSdUpCckp5RDNaOFBQLWVtbmRvOHFFNmV0NFY2MmJ3ZjdR",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:45.462237+00:00"
+  },
+  {
+    "id": "rvq_77f36fe464dae9a5",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMiZ0FVX3lxTE5QSHRHTU84ejRWemFhbTJMTVFYeXhtcnljV3otMWltOXk1Vk9rX2Jmd29meVo4LXpaa2NCeC02WUg3TTRiUlZwZjVBVjRYemxBNi1IbVFBNmJpaGVHZllRMVNRbTIwTlk",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMiZ0FVX3lxTE5QSHRHTU84ejRWemFhbTJMTVFYeXhtcnljV3otMWltOXk1Vk9rX2Jmd29meVo4LXpaa2NCeC02WUg3TTRiUlZwZjVBVjRYemxBNi1IbVFBNmJpaGVHZllRMVNRbTIwTlk",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:45.462284+00:00"
+  },
+  {
+    "id": "rvq_9dc8574311cee57f",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMicEFVX3lxTE1UTGpubjRpUklYVl8yS01Vai03NVB0ekRfU1k2LTlESXNsdFR1REJ4SUtDTC1lNEtsR3hBNHpacEFpRUR4RVRQUUNlbXloUWtfV3k4TzRYTnVlaHNvbVJwa2JDazJ2a1lRTTR6bl84M0k",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMicEFVX3lxTE1UTGpubjRpUklYVl8yS01Vai03NVB0ekRfU1k2LTlESXNsdFR1REJ4SUtDTC1lNEtsR3hBNHpacEFpRUR4RVRQUUNlbXloUWtfV3k4TzRYTnVlaHNvbVJwa2JDazJ2a1lRTTR6bl84M0k",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:45.462328+00:00"
+  },
+  {
+    "id": "rvq_1eb1f3cbb521e3af",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMiUkFVX3lxTE1BaU42T0NXektTMGdZOTlQRVVxTXRRRWZpLWh1alN1dkpOaEdHbk5keG56U3dwd2tVTlFrVHJKNDNrMGpoZGowa2UxNTdvWHBJcFE",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMiUkFVX3lxTE1BaU42T0NXektTMGdZOTlQRVVxTXRRRWZpLWh1alN1dkpOaEdHbk5keG56U3dwd2tVTlFrVHJKNDNrMGpoZGowa2UxNTdvWHBJcFE",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:45.462374+00:00"
+  },
+  {
+    "id": "rvq_70bdc9a70649b703",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMiYEFVX3lxTE9INHVMdDJ4M2FVV1R2U3BmUGNpQzdmZDRHS1Vld1RwTlF0eTNGMjRwcnRqMTY2cDFlSHBWaGxQYllGV3pyLUw2ME9JTXV5RElNOXJBZTQ3VHh2X0FYdTZoWQ",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMiYEFVX3lxTE9INHVMdDJ4M2FVV1R2U3BmUGNpQzdmZDRHS1Vld1RwTlF0eTNGMjRwcnRqMTY2cDFlSHBWaGxQYllGV3pyLUw2ME9JTXV5RElNOXJBZTQ3VHh2X0FYdTZoWQ",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:45.462418+00:00"
+  },
+  {
+    "id": "rvq_b5c3f24cc5479524",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMicEFVX3lxTFAwbk1DQXJoTnprbGJSamJFRDFIQUpPYURkODg5TzNHQVF6VTJMbVdjM1JnbnhpVjNnSkVWY1R6UE9VTXBmbzd4czI2OGJqaURTZURxakM1bElFOHEwc2hObThzUUk4cFBRVDlHSGV4TDU",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMicEFVX3lxTFAwbk1DQXJoTnprbGJSamJFRDFIQUpPYURkODg5TzNHQVF6VTJMbVdjM1JnbnhpVjNnSkVWY1R6UE9VTXBmbzd4czI2OGJqaURTZURxakM1bElFOHEwc2hObThzUUk4cFBRVDlHSGV4TDU",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:45.462464+00:00"
+  },
+  {
+    "id": "rvq_f342881843a7dd75",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMiUEFVX3lxTE5ZVmw4S0lqNUl2blhORDJNaDhNYXRuOU5YVjEtbDB2X2JnUFRHaUlLamktTVIwRERxRFRvUU8tZUNJN3BSMHVFWHp3Skl4UTVW",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMiUEFVX3lxTE5ZVmw4S0lqNUl2blhORDJNaDhNYXRuOU5YVjEtbDB2X2JnUFRHaUlLamktTVIwRERxRFRvUU8tZUNJN3BSMHVFWHp3Skl4UTVW",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:46.251993+00:00"
+  },
+  {
+    "id": "rvq_3bdd2677f1708b05",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMiVEFVX3lxTE1IVU9vU0VXNTM3RndSNUpkTzFmVWJCYWNXRzdkNjJoQ19SeEZ6ZzBVenIzUXpBTlFRckVNZVVIQXAzR1dXVmIyY1lJa3JjVHRJYnBUQw",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMiVEFVX3lxTE1IVU9vU0VXNTM3RndSNUpkTzFmVWJCYWNXRzdkNjJoQ19SeEZ6ZzBVenIzUXpBTlFRckVNZVVIQXAzR1dXVmIyY1lJa3JjVHRJYnBUQw",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:46.252055+00:00"
+  },
+  {
+    "id": "rvq_474d7f4d191eafa4",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMiW0FVX3lxTE43YUpldmVfcHp3QlZFeWNTTFQ2UllWLXFscm91WGdRRVJYNTVxYXdSVlVlLWJjczc5VTZvQ0wzb2VTZlBWTzktc0kyOVkwUi1Wa3dzTlltOFlUakk",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMiW0FVX3lxTE43YUpldmVfcHp3QlZFeWNTTFQ2UllWLXFscm91WGdRRVJYNTVxYXdSVlVlLWJjczc5VTZvQ0wzb2VTZlBWTzktc0kyOVkwUi1Wa3dzTlltOFlUakk",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:46.252106+00:00"
+  },
+  {
+    "id": "rvq_698d5436814a0979",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMibEFVX3lxTE5QM29ZdVZvWUw2R2NzeEJZaG5XRldERUJpR19nX0xTNWJLaXVMM1JLbDVnYWJseEpRVnNjemZyR2NScEc2RW0tNm1ReDZCVVNYMnpZTXRMSXVPcEJSZTJQdWRJU2Mwa3NRQ0owSA",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMibEFVX3lxTE5QM29ZdVZvWUw2R2NzeEJZaG5XRldERUJpR19nX0xTNWJLaXVMM1JLbDVnYWJseEpRVnNjemZyR2NScEc2RW0tNm1ReDZCVVNYMnpZTXRMSXVPcEJSZTJQdWRJU2Mwa3NRQ0owSA",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:46.252158+00:00"
+  },
+  {
+    "id": "rvq_670548c0bb3dbfb9",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMiX0FVX3lxTE9GWVBudXBmWV8wR3pnY1RmTGRtcVZLVDFRQ0VZVmdWdmZSdnpvSFZ3S1RwdzBGS2NVMjFJM3hqczEyNlZzMzVsUTVzdkhsWUc2QnQ0UmNkQUtqd2ZMQURF",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMiX0FVX3lxTE9GWVBudXBmWV8wR3pnY1RmTGRtcVZLVDFRQ0VZVmdWdmZSdnpvSFZ3S1RwdzBGS2NVMjFJM3hqczEyNlZzMzVsUTVzdkhsWUc2QnQ0UmNkQUtqd2ZMQURF",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:46.252211+00:00"
+  },
+  {
+    "id": "rvq_c4e6e10ba4248b05",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMibEFVX3lxTE9GM2N1UWtDSTZPUjg0MnhVdjNrZFEybGxsSUFsV0ZfMEtEZjNEQnRJRkM1eUNsVTZqM2pySkZOVXpmRGJSekFiZTlCeUNsdVAxSnJNYmd5UjU4RDVXQ3V1ejU1MHdHQUV3NkVVSg",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMibEFVX3lxTE9GM2N1UWtDSTZPUjg0MnhVdjNrZFEybGxsSUFsV0ZfMEtEZjNEQnRJRkM1eUNsVTZqM2pySkZOVXpmRGJSekFiZTlCeUNsdVAxSnJNYmd5UjU4RDVXQ3V1ejU1MHdHQUV3NkVVSg",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:46.252259+00:00"
+  },
+  {
+    "id": "rvq_515ad82777c7b2fe",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMibkFVX3lxTE5jcGVzeEhMY09IQV9vbnpITG9Tb0E3SE5DT0tJcldqNkk1bW5XX3ZRbV9TOFlsZFZjU1Ntb3gwTm1sakFCMHR5dUFPZHNkS2JNTlZWV1hiV01zUEl2cVFTR3NlaFptc3lYdjJiWXdR0gFyQVVfeXFMTWVwNmNhQzU2VlI4RlZkWHBCV2JTY2NKTlhqZkVmMzlYcUxIZko3a2dVVnRWa1kzZEE0ajdBRWZDb25YNkZRNEswYUpxcl90RmNoZzNkZWpjZXVBdEg2aFBMZExDY1R6eExyLWZQZUEzeVpn",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMibkFVX3lxTE5jcGVzeEhMY09IQV9vbnpITG9Tb0E3SE5DT0tJcldqNkk1bW5XX3ZRbV9TOFlsZFZjU1Ntb3gwTm1sakFCMHR5dUFPZHNkS2JNTlZWV1hiV01zUEl2cVFTR3NlaFptc3lYdjJiWXdR0gFyQVVfeXFMTWVwNmNhQzU2VlI4RlZkWHBCV2JTY2NKTlhqZkVmMzlYcUxIZko3a2dVVnRWa1kzZEE0ajdBRWZDb25YNkZRNEswYUpxcl90RmNoZzNkZWpjZXVBdEg2aFBMZExDY1R6eExyLWZQZUEzeVpn",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:46.252310+00:00"
+  },
+  {
+    "id": "rvq_8752c0a261072b1f",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMiwAJBVV95cUxNaWJYd19jYTlBVUNRbjRyS3ROVVlqTkp4X0NOeXU0Mm9fNWsxNHZkalpMMHB5dXhmOEc4R0tvcUs2Qi1jbjlvbHBzV3lDMy1sc0dLTWNKTGRHWThFZy1EZ0hnWlBEWUx0UEtsVkljVHZVZ1BhWlk5MEZRMU9LQXBDei1DaE5FdnZTVEc3ckpPV1YxV0RMX3dtbXFWbVU0OTMxU1hEVWlzYWhodXFKX1ZtbDVUTUUxcU0yZ2NlYTZHXy1vVGNGNHF6enlsMnVOc1BqdU1QSzBnLVI1WDk5aWhzN2pGdlZFNTdpSjNaOG1DMjlXRHc1RWhjdFk1T2hOMHpQcGc3alRmWW9rWVBWTEVhSURsMHJyODZ2YkM0Rnl3aV9PRFBRZldXUjM1YTIzWXB4bXluMGxNYWtPUDZ4YkxlTQ",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMiwAJBVV95cUxNaWJYd19jYTlBVUNRbjRyS3ROVVlqTkp4X0NOeXU0Mm9fNWsxNHZkalpMMHB5dXhmOEc4R0tvcUs2Qi1jbjlvbHBzV3lDMy1sc0dLTWNKTGRHWThFZy1EZ0hnWlBEWUx0UEtsVkljVHZVZ1BhWlk5MEZRMU9LQXBDei1DaE5FdnZTVEc3ckpPV1YxV0RMX3dtbXFWbVU0OTMxU1hEVWlzYWhodXFKX1ZtbDVUTUUxcU0yZ2NlYTZHXy1vVGNGNHF6enlsMnVOc1BqdU1QSzBnLVI1WDk5aWhzN2pGdlZFNTdpSjNaOG1DMjlXRHc1RWhjdFk1T2hOMHpQcGc3alRmWW9rWVBWTEVhSURsMHJyODZ2YkM0Rnl3aV9PRFBRZldXUjM1YTIzWXB4bXluMGxNYWtPUDZ4YkxlTQ",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:46.252365+00:00"
+  },
+  {
+    "id": "rvq_49f74ae3c96b16fd",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMibkFVX3lxTE44WWJmLS1FTTB0QnB6YlpQQWR2R2xMV2ZTeXFqT1dWVTI2SWVodU1TSnNYang1OVl2NDdZb1YzMFhFa1JqWUFwVWptWW8xdGRDOTBHSUI3djVXZlVodUkxRzNXSzVSR2V2bHB3ZUNn0gFyQVVfeXFMTnhuQUU2dUdtU0hhS1RCbHdJbGQ4elhyTjJEVTJlWVhOQVhydE1yQV9DLXc3ZnJLTXRVSHlJSHFQa0xRWnhSMHpROXZ6bW5JX0xyMGF4YTdobUkzdTNwTk10alBfRmtQeS1RTTU1TXo2X2FR",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMibkFVX3lxTE44WWJmLS1FTTB0QnB6YlpQQWR2R2xMV2ZTeXFqT1dWVTI2SWVodU1TSnNYang1OVl2NDdZb1YzMFhFa1JqWUFwVWptWW8xdGRDOTBHSUI3djVXZlVodUkxRzNXSzVSR2V2bHB3ZUNn0gFyQVVfeXFMTnhuQUU2dUdtU0hhS1RCbHdJbGQ4elhyTjJEVTJlWVhOQVhydE1yQV9DLXc3ZnJLTXRVSHlJSHFQa0xRWnhSMHpROXZ6bW5JX0xyMGF4YTdobUkzdTNwTk10alBfRmtQeS1RTTU1TXo2X2FR",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:46.252413+00:00"
+  },
+  {
+    "id": "rvq_58d1546b6bcbbe43",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMiUEFVX3lxTE9PUVNqbkNVcUdZZV8xR01KMi0zWlZTUFZUWFRwTFlLTXBqTlYzZlppRkN2RzZjMjl6MDVlUGQ2WTYzUGptWlpKZC1Vem05d00y",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMiUEFVX3lxTE9PUVNqbkNVcUdZZV8xR01KMi0zWlZTUFZUWFRwTFlLTXBqTlYzZlppRkN2RzZjMjl6MDVlUGQ2WTYzUGptWlpKZC1Vem05d00y",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:46.252463+00:00"
+  },
+  {
+    "id": "rvq_c89743a6fe2224f2",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMiYEFVX3lxTE5iM0Z6YzdVTU1hNHZHb0dXRWJxb0dPU2RoQlV1bHQ5Vk93OXlGQW1najU3TEE0UVVSd2RYT0s5Q0VYVnBnR2hscV9ac1pFUng5RjZSUUlpNjdtRHFRV25pMw",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMiYEFVX3lxTE5iM0Z6YzdVTU1hNHZHb0dXRWJxb0dPU2RoQlV1bHQ5Vk93OXlGQW1najU3TEE0UVVSd2RYT0s5Q0VYVnBnR2hscV9ac1pFUng5RjZSUUlpNjdtRHFRV25pMw",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:46.252510+00:00"
+  },
+  {
+    "id": "rvq_f6a1aa6b26efa855",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMiU0FVX3lxTE40eUZBR1M5Wk1uY1prTkZoQ1JjR24wZUFSX3cxSC1TdHZ0VzhNbVNOeVhGaGprZHdWWlVvc1V2c0hzaElWdm1VbUVHNUw5dzBnNmhN",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMiU0FVX3lxTE40eUZBR1M5Wk1uY1prTkZoQ1JjR24wZUFSX3cxSC1TdHZ0VzhNbVNOeVhGaGprZHdWWlVvc1V2c0hzaElWdm1VbUVHNUw5dzBnNmhN",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:54.357626+00:00"
+  },
+  {
+    "id": "rvq_f2094fd3dc121170",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMijwFBVV95cUxORjlEX2hPbFJQM0dsWFpvSFZnY2VEdlZnMTNLeF9hMUtHb3o0YVVtVXpTenJzbEoyRWtobWZJV1hFSnpvMTFkUTJ0RlpwaDNGeXNBalI5NTduQVZSWC1vTnhtVWRqeURmWFNRTU9MSndsMVdQYk11M3NPZExUTzJ5TzdQbW92c1JBUE1VYTN5a9IBowFBVV95cUxPczZrMFRjZlFWYnY3SXZJN3MxaVBnZ0h2c2J1T2tFUnFzOTFBMFc3QTJsMXFxLUtIZHpUNk9iYy1rbHNDMHJLV3BENHJLRFVnNm10NWxhY1Myck45YWhMbENxNllCTzBfOTBGSFhISG4yTktxTEhBa1BaUmpKY2dnZUZSNE1MMFF2aGdkbk1oNWFNalo2TkIyVmtSMG5HYi1lVFpj",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMijwFBVV95cUxORjlEX2hPbFJQM0dsWFpvSFZnY2VEdlZnMTNLeF9hMUtHb3o0YVVtVXpTenJzbEoyRWtobWZJV1hFSnpvMTFkUTJ0RlpwaDNGeXNBalI5NTduQVZSWC1vTnhtVWRqeURmWFNRTU9MSndsMVdQYk11M3NPZExUTzJ5TzdQbW92c1JBUE1VYTN5a9IBowFBVV95cUxPczZrMFRjZlFWYnY3SXZJN3MxaVBnZ0h2c2J1T2tFUnFzOTFBMFc3QTJsMXFxLUtIZHpUNk9iYy1rbHNDMHJLV3BENHJLRFVnNm10NWxhY1Myck45YWhMbENxNllCTzBfOTBGSFhISG4yTktxTEhBa1BaUmpKY2dnZUZSNE1MMFF2aGdkbk1oNWFNalo2TkIyVmtSMG5HYi1lVFpj",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:54.357700+00:00"
+  },
+  {
+    "id": "rvq_bd68404587d636c2",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMiVkFVX3lxTE0teE9sTFRDeUR2YVZTVHVOQlR1MWlrR2pQV0JUTC0zMTNaTXJUUXZYTHhYNklvSFNPaGxheUZ4ekt1T2lvRWNvOXg1Z1BUX0piODQ1aXl3",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMiVkFVX3lxTE0teE9sTFRDeUR2YVZTVHVOQlR1MWlrR2pQV0JUTC0zMTNaTXJUUXZYTHhYNklvSFNPaGxheUZ4ekt1T2lvRWNvOXg1Z1BUX0piODQ1aXl3",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:54.357758+00:00"
+  },
+  {
+    "id": "rvq_5bfbd71b17822c25",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMicEFVX3lxTE1MRzd0R1o1aEwwTjRJNU50Vk9wWnRDWjBjR2xnOXdVY1JWaWNra1ZJajRITjFaN3JtUzRCN1pQU0lhdk1NVnh1ZlJjTFN4UDI0NDdTTzFVc0t6RUNBVXBhWkp2Uk5saGdJM21ZN0JlMWk",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMicEFVX3lxTE1MRzd0R1o1aEwwTjRJNU50Vk9wWnRDWjBjR2xnOXdVY1JWaWNra1ZJajRITjFaN3JtUzRCN1pQU0lhdk1NVnh1ZlJjTFN4UDI0NDdTTzFVc0t6RUNBVXBhWkp2Uk5saGdJM21ZN0JlMWk",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:54.357811+00:00"
+  },
+  {
+    "id": "rvq_a2b70b942708881d",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMiZkFVX3lxTFBDOXN5MGRrLWo3V0ZtMUhLSzd5LUpPaDZqaFFBRTk5SWxISmZfbU9vRm55TEpfYkF6TDNabGFpazlXVVZzcUFWYXpLMUZ5dFN4LVZxMkNROG1YVkFJYVUyNVA4MXY5Zw",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMiZkFVX3lxTFBDOXN5MGRrLWo3V0ZtMUhLSzd5LUpPaDZqaFFBRTk5SWxISmZfbU9vRm55TEpfYkF6TDNabGFpazlXVVZzcUFWYXpLMUZ5dFN4LVZxMkNROG1YVkFJYVUyNVA4MXY5Zw",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:54.357858+00:00"
+  },
+  {
+    "id": "rvq_bcae6430dbdc97be",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMibEFVX3lxTE5OYXh1azE5M0NzbmluR1RyNEtia3ZPWnNhbWF2X2o2UDBoZTlYbU5Ud2t1TDdTRVgxb2JfQkFIbDV5MHpBX210bUt6cHVNbkVzOUlYa3F4ZXVpaUU2SDNqWHVUZGZFQ1IwUU1sWA",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMibEFVX3lxTE5OYXh1azE5M0NzbmluR1RyNEtia3ZPWnNhbWF2X2o2UDBoZTlYbU5Ud2t1TDdTRVgxb2JfQkFIbDV5MHpBX210bUt6cHVNbkVzOUlYa3F4ZXVpaUU2SDNqWHVUZGZFQ1IwUU1sWA",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:54.357905+00:00"
+  },
+  {
+    "id": "rvq_5c39f76c12093831",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMidEFVX3lxTE9Kb3FsWjdQZG1GY0xjTlYzY2YxR3BtVlFGWDA1alpQWjl6SlNqWmRSMFJ6QlBfczY0RTMtdE1mMl83UUpxbElRTEhSS2o2aEtfTnZnZWNGa1MydktqSWNPcHFSbmVRN1BJUWFiLVdfWkYyOTR2",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMidEFVX3lxTE9Kb3FsWjdQZG1GY0xjTlYzY2YxR3BtVlFGWDA1alpQWjl6SlNqWmRSMFJ6QlBfczY0RTMtdE1mMl83UUpxbElRTEhSS2o2aEtfTnZnZWNGa1MydktqSWNPcHFSbmVRN1BJUWFiLVdfWkYyOTR2",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:54.357955+00:00"
+  },
+  {
+    "id": "rvq_b5045c04d003ef81",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMiY0FVX3lxTE1ZdXQwZHN4U0NuWHVoeXJYMU9jQ1F5V1RfTFlydDFPQUlZUU5FUE9GcWRFMHB3OThqbExFOWdDbFZDY3BqM0oydDc5NG9xbjhCSGRXUUxnSHJJcUljalNPa2EzTQ",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMiY0FVX3lxTE1ZdXQwZHN4U0NuWHVoeXJYMU9jQ1F5V1RfTFlydDFPQUlZUU5FUE9GcWRFMHB3OThqbExFOWdDbFZDY3BqM0oydDc5NG9xbjhCSGRXUUxnSHJJcUljalNPa2EzTQ",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:54.358006+00:00"
+  },
+  {
+    "id": "rvq_b65152af43431c7d",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMiRkFVX3lxTFBJNjJYVFl4cEM1a3ZmaXNFcnlNN3pLNjZtU2ZBcXlSRXZHRUJ2S29MX0hiMjdvbHhfQWVUclZlYmY3NTNYQWc",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMiRkFVX3lxTFBJNjJYVFl4cEM1a3ZmaXNFcnlNN3pLNjZtU2ZBcXlSRXZHRUJ2S29MX0hiMjdvbHhfQWVUclZlYmY3NTNYQWc",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:54.358054+00:00"
+  },
+  {
+    "id": "rvq_e6905bd36ca0e2ff",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMicEFVX3lxTE1CYmpZT0JzZmc0MTktd1ZWQjhXaGdzb2ZHVEtWTGpwaHNnNDBwcXV0eU5Wa0tkVUJyQ3ZNalJLQVV0VHp6Y0RRRmJlYmV1UUJEZTZJMlNsVHJkV25xdUhRMW8tdnJWMkl0MFJBeGt6VlU",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMicEFVX3lxTE1CYmpZT0JzZmc0MTktd1ZWQjhXaGdzb2ZHVEtWTGpwaHNnNDBwcXV0eU5Wa0tkVUJyQ3ZNalJLQVV0VHp6Y0RRRmJlYmV1UUJEZTZJMlNsVHJkV25xdUhRMW8tdnJWMkl0MFJBeGt6VlU",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:54.358103+00:00"
+  },
+  {
+    "id": "rvq_ba2ff8c32ee95f64",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMiRkFVX3lxTE5KYjlXaExwZlA0SjF0YjJnWnNJaUMyRzJBQmVEZHJaMjF1OGs2WFhlUFlzeHViVGNyMFhvYm90aXByV1JiUWc",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMiRkFVX3lxTE5KYjlXaExwZlA0SjF0YjJnWnNJaUMyRzJBQmVEZHJaMjF1OGs2WFhlUFlzeHViVGNyMFhvYm90aXByV1JiUWc",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:54.358151+00:00"
+  },
+  {
+    "id": "rvq_1184c050536749cc",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMiW0FVX3lxTE9GZi1ZbkdOOU8xRUxaNFRXUGZxZzZyVXBiZlVybDRfdXExVmZ0TU1UeXd3Y0l3em1IUWg1WG1GZk9QeTlTMEJDeThxSHNyRlhBaUx6enhzTks4Wmc",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMiW0FVX3lxTE9GZi1ZbkdOOU8xRUxaNFRXUGZxZzZyVXBiZlVybDRfdXExVmZ0TU1UeXd3Y0l3em1IUWg1WG1GZk9QeTlTMEJDeThxSHNyRlhBaUx6enhzTks4Wmc",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:54.358200+00:00"
+  },
+  {
+    "id": "rvq_a70061d79bfa51c0",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMiT0FVX3lxTE5KNmtGWWhpSG02enFETEZmdVotTVE1NFR1V3AyY2xFWWhHSGVYUElDaVBYbDBERWtYcDNObzd1dS1LdnR6bndqXy01WFpoZjg",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMiT0FVX3lxTE5KNmtGWWhpSG02enFETEZmdVotTVE1NFR1V3AyY2xFWWhHSGVYUElDaVBYbDBERWtYcDNObzd1dS1LdnR6bndqXy01WFpoZjg",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:54.358249+00:00"
+  },
+  {
+    "id": "rvq_1e1f5497d9f53fc8",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMicEFVX3lxTE5MWHZSV0VZdUZjZ0UwUUY1dEZwR0l2cGFmTHc0SUVySmljWWs1M1o2RW9nRU1RcDItVVY2VkF3ZmNpM3hoTVVuYzlXdkdjX1ZPT1BXYm5iaF9yQjhNb3VIc0tIZzM0M2t1blFQUE5LU24",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMicEFVX3lxTE5MWHZSV0VZdUZjZ0UwUUY1dEZwR0l2cGFmTHc0SUVySmljWWs1M1o2RW9nRU1RcDItVVY2VkF3ZmNpM3hoTVVuYzlXdkdjX1ZPT1BXYm5iaF9yQjhNb3VIc0tIZzM0M2t1blFQUE5LU24",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:54.358298+00:00"
+  },
+  {
+    "id": "rvq_31bf7fcc1c6dcd0d",
+    "entity_type": "article",
+    "entity_id": "https://news.google.com/rss/articles/CBMib0FVX3lxTFBWUUdTWUFmOGJCRVNpaHk2dHJHTTd1Qy14bXZEUGtQazM2S29SR2dkaVFHMTBXWVZ1NHRtb0JHcmY4U3JuZWFRV0JzWEhlODlRQWpBUkdSSTE1bzljMTZuM09US19reGpaUlNRMEJKVQ",
+    "issue_type": "fetch_error",
+    "stage": "fetch",
+    "error_code": "ROBOTS_BLOCKLIST_BYPASS",
+    "error_message": "blocked domain routed to fallback source",
+    "source_url": "https://news.google.com/rss/articles/CBMib0FVX3lxTFBWUUdTWUFmOGJCRVNpaHk2dHJHTTd1Qy14bXZEUGtQazM2S29SR2dkaVFHMTBXWVZ1NHRtb0JHcmY4U3JuZWFRV0JzWEhlODlRQWpBUkdSSTE1bzljMTZuM09US19reGpaUlNRMEJKVQ",
+    "payload": {
+      "source_type": "google_rss"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:41:54.358345+00:00"
+  },
+  {
+    "id": "rvq_a9c8a3d707ce8ad5",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_3923340f5af55d45",
+    "issue_type": "extract_error",
+    "stage": "live_news_v1_legal",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "live news legal completeness below threshold",
+    "source_url": "https://www.khan.co.kr/article/202602231023001/",
+    "payload": {
+      "threshold": 0.8,
+      "completeness_score": 0.3333,
+      "missing_fields": [
+        "sponsor",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ]
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:42:14.256829+00:00"
+  },
+  {
+    "id": "rvq_e31211ae4066b435",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_1a9d3bc2062fbfd4",
+    "issue_type": "extract_error",
+    "stage": "live_news_v1_legal",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "live news legal completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMiWkFVX3lxTE9HamZYd25pRGI3UmxSZGpRRHFHaDF0dDJ2RHJyNG5qaE9ybWFDb0F5OUQ2Mk5EVDU1bk9mZWpEUk84MXk1LU9DT3Rhdm92MTBJbjBOME4zYlVDd9IBX0FVX3lxTE5fd1ZmcUxyQ21BWWRBTnhjUWRfMVkzVnNjamFvbXY3bktLekpjNDNFam5rckZlVHQwQ2xKMlRFSTFvRDZIV2JYY3plTkhVeEd3eEE0MGdISmFuZ0JDNE84",
+    "payload": {
+      "threshold": 0.8,
+      "completeness_score": 0.1667,
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ]
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:42:14.257029+00:00"
+  },
+  {
+    "id": "rvq_f057b68be322b2ba",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_1b476b3c9acf3ed0",
+    "issue_type": "extract_error",
+    "stage": "live_news_v1_legal",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "live news legal completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMib0FVX3lxTFBJc3BDSGVxWFV6cXZaUXBjdy1ZX3JSODJpbXVlNnhTcFpNZEFITmV6MkFEUHlDZEw4cUtYVGZhVVpUWEN6amVNQ29YMFdjclh0Xy1seV9pbmlIV01mWlduZTE1T08yZ1V1dkExSHRUMA",
+    "payload": {
+      "threshold": 0.8,
+      "completeness_score": 0.1667,
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ]
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:42:14.257188+00:00"
+  },
+  {
+    "id": "rvq_0ed68ecd7abe8f60",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_259e580fdbc42986",
+    "issue_type": "extract_error",
+    "stage": "live_news_v1_legal",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "live news legal completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMicEFVX3lxTE5QYU9aVVd5UEt6SHFZcm9TVERHOTBqRE5YbHlpOXR1VTUzcWtNcGR2V1Jhai1fLXk3bUJyWC1lbEw0VUNxcFR0eklxclVHWENudzlZZWtkZEpUTkxvaDE0d0lScV9DYXZ2dFhzbEJlQ3Y",
+    "payload": {
+      "threshold": 0.8,
+      "completeness_score": 0.1667,
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ]
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:42:14.257360+00:00"
+  },
+  {
+    "id": "rvq_6b85bacfef84083f",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_c98ca4f5973f8d49",
+    "issue_type": "extract_error",
+    "stage": "live_news_v1_legal",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "live news legal completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMieEFVX3lxTE5tTW9iQy1QNXd2ZUU2OE5kZmZWMWlkem9tRDRMZXpVcVRVNXgxSGVicUxKdVBXX2QxeW5NYVBCQUp3NmdVRXF0c3VYZ19DT0F2UGtWVTZSYjdHa0J0SFFCOGM3N3lEM0JQMDJpZU5ybnBnY0ZRV2YwWdIBeEFVX3lxTFBXWWNrY1FkOUNlcWd3Z3hNZ1dkQ3JnbmNKcDFKVUpUN1k3SWt5UThzUVYxaDNMVkRzeDhTZV8yU2VTVHhlNVdFbllQVEl0QXZVYVVTOG85aDNMc0EzVVV4Nk1qZ1lUNVE0eTRIcS1FbTVrbk43RDc1Nw",
+    "payload": {
+      "threshold": 0.8,
+      "completeness_score": 0.1667,
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ]
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:42:14.257521+00:00"
+  },
+  {
+    "id": "rvq_425adff0eac7958b",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_f5aefbfbb344c0d1",
+    "issue_type": "extract_error",
+    "stage": "live_news_v1_legal",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "live news legal completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMiVkFVX3lxTE5mZnp1cU5sXzNkMk52b1Y4bWpsaXhoZUswNEVsaDN4RERfV2RyTFdOY1hackVlbWFwWlBRaFFITkZOeDRiWFo2Sll4UWNaTEt1aFJoYzh30gGGAkFVX3lxTE16ZVBkOUM3T2hYWm5LOEhjNDlFRXNfbWpqbUhqQjBBdlJocTg3dnJXb3VvZ0FTR2lkbjFGMHRPZlBuTVo0Q2w0M3NZVmhZTjdzLWlzdkFKb1RJVmNkMUpFX1lsMDZOa2Z4MmQwTUlxVm1EdGJxUTUxR2hmeUNnU0JBN1h0OXllZXFpZlo4Ry03U3hMN3ZDbExRUklHcUE4cHV6R2hBODdkYnJWd1VYMWEwaGRUcFNnLXNLa3BRd1p5TERzTHVfNkNhQjV1bzFWLTBpcmYzM0RZMnZrQ1M3dzVTNEVicFFxbHB0UFJYQTFTUzNicXNfNEFoaGk2SHFtdXU0b3RTVXc",
+    "payload": {
+      "threshold": 0.8,
+      "completeness_score": 0.1667,
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ]
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:42:14.257697+00:00"
+  },
+  {
+    "id": "rvq_bb1f6d0d864b636d",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_136dffa93edf3413",
+    "issue_type": "extract_error",
+    "stage": "live_news_v1_legal",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "live news legal completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMidEFVX3lxTE0tR240RHM3eWhpWHhBUmFDZzl1eUFIRjJZN0JGU185MXBaanpESmxwTUREYThKU3h6anpJRklRelduaHR1UjBLSFhlbDhoNkhJN284eS1RS2lmTm5wUTZXWXZLNFBNWm1vOW03YS1wTmdaRjB5",
+    "payload": {
+      "threshold": 0.8,
+      "completeness_score": 0.1667,
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ]
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:42:14.257861+00:00"
+  },
+  {
+    "id": "rvq_65d4d9e5fb8297ec",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_444bed2fb448053a",
+    "issue_type": "extract_error",
+    "stage": "live_news_v1_legal",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "live news legal completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMiT0FVX3lxTE1TR0RwR3pLa1lTTXY0XzFmaF81SFA3NXhhcHNLWWhTczVrQUtJcDJtOUxaNGxYdnNueXRBU19VSTAzVGpselZMTXVHWUJfYTg",
+    "payload": {
+      "threshold": 0.8,
+      "completeness_score": 0.1667,
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ]
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:42:14.258014+00:00"
+  },
+  {
+    "id": "rvq_5ac425df6ff343d7",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_82f9da3ac3360057",
+    "issue_type": "extract_error",
+    "stage": "live_news_v1_legal",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "live news legal completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMieEFVX3lxTE5YR2RWdVVLempqS2xCZU9WR083VHZWcEFjRnpqUUJpbWd3YjVINFBsNlU2UVRyNHU0UEg0YnBIRl9MLTkwaldWaDVPeE1XVnVKVWdGNlFXNTR5UFlfakR6bXZ4V0hTcVBrNU9oaEpPdWJjY2tpa1I4UQ",
+    "payload": {
+      "threshold": 0.8,
+      "completeness_score": 0.1667,
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ]
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:42:14.258169+00:00"
+  },
+  {
+    "id": "rvq_99a42cdbf747df37",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_6348089eeaf5b9f8",
+    "issue_type": "extract_error",
+    "stage": "extract",
+    "error_code": "NO_TITLE_CANDIDATE_SIGNAL",
+    "error_message": "no candidate/value pair extracted",
+    "source_url": "https://news.google.com/rss/articles/CBMiUkFVX3lxTE1lS3hWUFprb0RROTRHT1FzUHo5QmpBOGdLU3RvNnQxQlJjYVBMakk3NmdXaUZpY19aWXY4U1dxMHhjQVlJanB1UHY1QURTVHRWNHc",
+    "payload": {
+      "article_id": "art-fallback_7c6ab91d35687cc8"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:42:14.258333+00:00"
+  },
+  {
+    "id": "rvq_545dbb76ea68fb54",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_6348089eeaf5b9f8",
+    "issue_type": "extract_error",
+    "stage": "live_news_v1_legal",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "live news legal completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMiUkFVX3lxTE1lS3hWUFprb0RROTRHT1FzUHo5QmpBOGdLU3RvNnQxQlJjYVBMakk3NmdXaUZpY19aWXY4U1dxMHhjQVlJanB1UHY1QURTVHRWNHc",
+    "payload": {
+      "threshold": 0.8,
+      "completeness_score": 0.1667,
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ]
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:42:14.258365+00:00"
+  },
+  {
+    "id": "rvq_ace6c7c7d0f18d38",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_85c4e876cf8b2a2a",
+    "issue_type": "extract_error",
+    "stage": "live_news_v1_legal",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "live news legal completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMiUkFVX3lxTFBxZHRodk44MXJxVnVlSFRnUkxoQi0yR0tUSmRFdE80LVFmazhtdmdHcjhQQmlXNG92bEZySVpGVG5LaGZNQ2JxUEdTN20zbVhpb3c",
+    "payload": {
+      "threshold": 0.8,
+      "completeness_score": 0.1667,
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ]
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:42:14.258513+00:00"
+  },
+  {
+    "id": "rvq_ffe0760303773775",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_297e45acd1bc8bec",
+    "issue_type": "extract_error",
+    "stage": "live_news_v1_legal",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "live news legal completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMiUkFVX3lxTE8zQ29Gc1hUUnRvSXNrdjBsbW1VSERKTVJLa3NPZHFETnkyLUVnMHYwVm9OMFMzVUJBeTBtN192eTZXUThkM1U0RkE5Yk1PUk0yNmc",
+    "payload": {
+      "threshold": 0.8,
+      "completeness_score": 0.1667,
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ]
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:42:14.258688+00:00"
+  },
+  {
+    "id": "rvq_9f5845a2aa5f629b",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_0f585774f2b41565",
+    "issue_type": "extract_error",
+    "stage": "live_news_v1_legal",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "live news legal completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMiVEFVX3lxTE5rS0JxZXRJT3piMlN2VW5tWnpDVmtZNmFGRDJUZ0dnb0k2NjFsWTRVZkY4NDNHb0pSendnS0FqVUhpMG9JRkhwYUo5Nk92SnZSQWNacw",
+    "payload": {
+      "threshold": 0.8,
+      "completeness_score": 0.1667,
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ]
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:42:14.258851+00:00"
+  },
+  {
+    "id": "rvq_f3dc3bd44da271f8",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_0cc203a71a596743",
+    "issue_type": "extract_error",
+    "stage": "live_news_v1_legal",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "live news legal completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMib0FVX3lxTFBVb1NSZjJ1enV6eDFDLWppUzM4eGlsc2RKRDVxY0pfSmxOUTBLcE1MbGZ0VGdqcVhUMVhHZTBzWk5xanF6Znl4Ym9icFMtX0xweWhsdTlVSzNURjVGUXdsQ1AzTC0xdXJDZDBjaG5TMA",
+    "payload": {
+      "threshold": 0.8,
+      "completeness_score": 0.1667,
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ]
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:42:14.258995+00:00"
+  },
+  {
+    "id": "rvq_ec06d5f9e1f1d300",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_57d26088f1d9972c",
+    "issue_type": "extract_error",
+    "stage": "live_news_v1_legal",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "live news legal completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMiZ0FVX3lxTE9VTlluWEJ1dFcydUhIa2M4YlhNSVloa1JmNkdtRHVEbGgxQzl5THhmaEY5Vlk3WTFIQTRUYmdVZjQ1SjRHRGF3YnA0MlFQQVB1UE1MY3lBdlVZM3IyS3FyMGhaelNaWFk",
+    "payload": {
+      "threshold": 0.8,
+      "completeness_score": 0.1667,
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ]
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:42:14.259176+00:00"
+  },
+  {
+    "id": "rvq_7ffb8434eb4cffec",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_7f29a3027242a383",
+    "issue_type": "extract_error",
+    "stage": "live_news_v1_legal",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "live news legal completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMimwFBVV95cUxPMjFRclBzZnhwdWlFY1l1QU1aRHNzem5UM0kzSW9LQjVldFNHeGg5ajlkZ1MycDYzek5RbWFTLVl5RjFlTlBLSzV4LXR1M1VmdTR3akpvTEp0SkFaR3h3Q0lIdEhDR0VkOFNJRWZEYXYtNEJGcHhuTEJOTG5zSEItZG04UWNUM2JsZUJsLUJnNXZYZExjSjRfQk0wQQ",
+    "payload": {
+      "threshold": 0.8,
+      "completeness_score": 0.1667,
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ]
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:42:14.259351+00:00"
+  },
+  {
+    "id": "rvq_b2608c88307a6073",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_debd6bb9da6779e7",
+    "issue_type": "extract_error",
+    "stage": "live_news_v1_legal",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "live news legal completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMiWkFVX3lxTFB2YUZpOFMxY2JtNEIwQi1GSTMwd0hkT1pzcDM3WWlKWnB6dE1vRDhDZzB2RVZfQjRQemJ6WkdrSDlIdXNmNm5hSnB0cjdKTEEtOE9JNjdtc3lJdw",
+    "payload": {
+      "threshold": 0.8,
+      "completeness_score": 0.1667,
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ]
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:42:14.259492+00:00"
+  },
+  {
+    "id": "rvq_6c8df4d04d278daf",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_5ab631e8fc7413b4",
+    "issue_type": "extract_error",
+    "stage": "extract",
+    "error_code": "POLICY_ONLY_SIGNAL",
+    "error_message": "no candidate/value pair extracted",
+    "source_url": "https://news.google.com/rss/articles/CBMibkFVX3lxTE5VZ1UzR1k0dzJRRGgxdDl4QkR3bzBEUjFpc0hSc1Z5ZFFQWnU0VGg0NHJBeFFJLUE3RHhycFVjaUc2Q0RmQ3lNUkU2cU1lT3d0RlQxNGZuWjhFUVZvYUtWa0JSWE8xbkoxczc3VHFB0gFyQVVfeXFMTVYtemZ5RlluSnhqRklvaEZBdm0zMFh3MlBhN2NYYVFWM1F1MUpBajhsMFZZdHdfZGE1WVJMUHZRdUQ3SEVfWW1JYTJqbXBKN1Vnd1VET016bV9EX0lwZEpmeXFLTUp2b3BZaU9qOUxyTkFR",
+    "payload": {
+      "article_id": "art-fallback_94ab95000f9ab683"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:42:14.259714+00:00"
+  },
+  {
+    "id": "rvq_8e176b1eb6e29142",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_5ab631e8fc7413b4",
+    "issue_type": "extract_error",
+    "stage": "live_news_v1_legal",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "live news legal completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMibkFVX3lxTE5VZ1UzR1k0dzJRRGgxdDl4QkR3bzBEUjFpc0hSc1Z5ZFFQWnU0VGg0NHJBeFFJLUE3RHhycFVjaUc2Q0RmQ3lNUkU2cU1lT3d0RlQxNGZuWjhFUVZvYUtWa0JSWE8xbkoxczc3VHFB0gFyQVVfeXFMTVYtemZ5RlluSnhqRklvaEZBdm0zMFh3MlBhN2NYYVFWM1F1MUpBajhsMFZZdHdfZGE1WVJMUHZRdUQ3SEVfWW1JYTJqbXBKN1Vnd1VET016bV9EX0lwZEpmeXFLTUp2b3BZaU9qOUxyTkFR",
+    "payload": {
+      "threshold": 0.8,
+      "completeness_score": 0.1667,
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ]
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:42:14.259749+00:00"
+  },
+  {
+    "id": "rvq_b08ed9f7935d3bf3",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_bf18847149fb4b56",
+    "issue_type": "extract_error",
+    "stage": "live_news_v1_legal",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "live news legal completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMiT0FVX3lxTE9nVmxoSnkzMUNfX1V5YTZyYktkSm5WUEk0ZGVyOEZxc3Y2cVF4cko5NjdsUklaLUpROGVRUGh4NFVzY2s0T3JWcjI1ZXgzNVE",
+    "payload": {
+      "threshold": 0.8,
+      "completeness_score": 0.1667,
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ]
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:42:14.259897+00:00"
+  },
+  {
+    "id": "rvq_0c5d447f0c89f544",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_09aef8cf8f7252e5",
+    "issue_type": "extract_error",
+    "stage": "live_news_v1_legal",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "live news legal completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMiT0FVX3lxTE54TGg4cF9nTG9rU3M2X0FGWGVKMllQRGMtUmNUNzJTREJCYUxRdFo0ZVBtTEgxc2ZiYnJiWG1yLWM5UXBDZHJFZld2OTl6a1E",
+    "payload": {
+      "threshold": 0.8,
+      "completeness_score": 0.1667,
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ]
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:42:14.260103+00:00"
+  },
+  {
+    "id": "rvq_5ef847456858a756",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_3ac1b89163285638",
+    "issue_type": "extract_error",
+    "stage": "live_news_v1_legal",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "live news legal completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMiT0FVX3lxTE9Nc1VkNEhQaDhxVkpJZ1ZfWHl0SXhJeG1DSHZHRnM0bmlZbV9na3hrS2t1V3BBeElBcFYzOEhHTWFLUklNcVU1V3RIdVVVZmM",
+    "payload": {
+      "threshold": 0.8,
+      "completeness_score": 0.1667,
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ]
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:42:14.260303+00:00"
+  },
+  {
+    "id": "rvq_de0055fce02c2fed",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_c5fd83f12d656982",
+    "issue_type": "extract_error",
+    "stage": "extract",
+    "error_code": "NO_TITLE_CANDIDATE_SIGNAL",
+    "error_message": "no candidate/value pair extracted",
+    "source_url": "https://news.google.com/rss/articles/CBMid0FVX3lxTE90WTBqQ1BTb1dLYm90TUhacW82V2NxZGNMY1VNRGJmdHZ1MWFfOU0xX2I1LXFUUlZuWlNQWXFWRWl4UXBiVTBJYkNJZjRRUXF5TVpvZkJBaVhmU0lDVWtGalp5aDAxUGhKUGZJaTRRVGxzbXNtWkdR0gFmQVVfeXFMT01DbmstNW4zeEU5Tm9CMnpjeElNdUFRa1JYQmdpaGJGQWJLT2NMMndBYTdxV0VNYmhNa2Fyb0t2a0ZtelV0THlidk9GaEpNNV9lZ1JPLTNTaF9iVmxRQnhGTkItbFln",
+    "payload": {
+      "article_id": "art-fallback_8b6c859ad67480dd"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:42:14.260439+00:00"
+  },
+  {
+    "id": "rvq_96008fd84aaa3ecc",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_c5fd83f12d656982",
+    "issue_type": "extract_error",
+    "stage": "live_news_v1_legal",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "live news legal completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMid0FVX3lxTE90WTBqQ1BTb1dLYm90TUhacW82V2NxZGNMY1VNRGJmdHZ1MWFfOU0xX2I1LXFUUlZuWlNQWXFWRWl4UXBiVTBJYkNJZjRRUXF5TVpvZkJBaVhmU0lDVWtGalp5aDAxUGhKUGZJaTRRVGxzbXNtWkdR0gFmQVVfeXFMT01DbmstNW4zeEU5Tm9CMnpjeElNdUFRa1JYQmdpaGJGQWJLT2NMMndBYTdxV0VNYmhNa2Fyb0t2a0ZtelV0THlidk9GaEpNNV9lZ1JPLTNTaF9iVmxRQnhGTkItbFln",
+    "payload": {
+      "threshold": 0.8,
+      "completeness_score": 0.1667,
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ]
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:42:14.260469+00:00"
+  },
+  {
+    "id": "rvq_172dcdbb5b6c6c05",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_04f52b0dbb2a3f38",
+    "issue_type": "extract_error",
+    "stage": "live_news_v1_legal",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "live news legal completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMiUEFVX3lxTE9XUDhsQXlSS2d5SDZXTUJITU9nRnRpa1l3NXNVUENyMkdQZG04T0s5UG9SXzlySXJ2YlZ4ejN4Nmg3TzhJSDFXMWd5U0loM0Mw",
+    "payload": {
+      "threshold": 0.8,
+      "completeness_score": 0.1667,
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ]
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:42:14.260677+00:00"
+  },
+  {
+    "id": "rvq_a195c55a77147123",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_d8cd4d8f6a0f22b8",
+    "issue_type": "extract_error",
+    "stage": "live_news_v1_legal",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "live news legal completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMiZkFVX3lxTE9oNUFjcktRS0p1ZENLRHVJdTdiQlZCVkY1T0dOWU55MjBBOUlKU3ZXWGZrVDBqeTlLMDFUUVJmNzc1anJ5VVJDNHdyUjR3TWhmZi1GRkR6WkczRHVpU01jWldPM3pldw",
+    "payload": {
+      "threshold": 0.8,
+      "completeness_score": 0.1667,
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ]
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:42:14.260838+00:00"
+  },
+  {
+    "id": "rvq_1bcf0c9d5f49f96d",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_62b73089a352ef4b",
+    "issue_type": "extract_error",
+    "stage": "live_news_v1_legal",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "live news legal completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMid0FVX3lxTE00bnR0cThIMG9qNFFQRERXbnE3LTNmd2JKcTh0c196VjJSUGEyVXd0WkE1TS1zeHc0bzk4aEtzUFVEWEc5VlBGSFBja1R6Y1JobW5mby1SWWFSUjEtM0p1b204OG9GNWRsMGgxXzBZOWFERnNrajRz",
+    "payload": {
+      "threshold": 0.8,
+      "completeness_score": 0.1667,
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ]
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:42:14.261000+00:00"
+  },
+  {
+    "id": "rvq_36b5771182778256",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_3b0cf776632dd287",
+    "issue_type": "extract_error",
+    "stage": "live_news_v1_legal",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "live news legal completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMieEFVX3lxTE1Tdmg3TFdqS3NUN21RSTVtdXU2RG90czEtQmN0MWs1RFpabTYzOFctYXdGYU1DZExRMUZ2S2xfY3gydkJ3VjdyTTAwZ2F1ak5RWHN1d3A2ZXJiYnlnaW1nNm40Z2NJZHhSZUsyaEp5TUhVUGR6bXA4X9IBeEFVX3lxTE5INHczQnc2WlFxcF9iel9LN1doU01jOXJjbm9FS1kwTU9kZ0FTcHkzTzV2OWlLYmJiX1otNnNqTk5xMGMtdm5TNnRnYnlYR3VMaEp5UVZ2aUV3bnUwTVkxLXVhT01oRjJDRmVuNGlDOG80NlZscllVYg",
+    "payload": {
+      "threshold": 0.8,
+      "completeness_score": 0.1667,
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ]
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:42:14.261144+00:00"
+  },
+  {
+    "id": "rvq_ad1ffcb36f2f3c9c",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_d513d499f4698d34",
+    "issue_type": "extract_error",
+    "stage": "live_news_v1_legal",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "live news legal completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMib0FVX3lxTE5sRDhVVG5DV0xxZTFDbExIM3I0MXdGTnUtY3BCWmdCRndlcmdid1NVX0oxQjNYdGtTeXk4aFlDLVZMbHIwNWZwdnBtdXQxMGFJMnpHaVdjenZNTXp5eWJRMWNQd1d3c1FfVTh4ekhxbw",
+    "payload": {
+      "threshold": 0.8,
+      "completeness_score": 0.1667,
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ]
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:42:14.261331+00:00"
+  },
+  {
+    "id": "rvq_9f58f6f09c03e4d1",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_7a093d267de2d6f7",
+    "issue_type": "extract_error",
+    "stage": "live_news_v1_legal",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "live news legal completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMiZ0FVX3lxTE5QSHRHTU84ejRWemFhbTJMTVFYeXhtcnljV3otMWltOXk1Vk9rX2Jmd29meVo4LXpaa2NCeC02WUg3TTRiUlZwZjVBVjRYemxBNi1IbVFBNmJpaGVHZllRMVNRbTIwTlk",
+    "payload": {
+      "threshold": 0.8,
+      "completeness_score": 0.1667,
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ]
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:42:14.261494+00:00"
+  },
+  {
+    "id": "rvq_71f211e0296d6671",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_0715ab45c5380b9c",
+    "issue_type": "extract_error",
+    "stage": "live_news_v1_legal",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "live news legal completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMicEFVX3lxTE1UTGpubjRpUklYVl8yS01Vai03NVB0ekRfU1k2LTlESXNsdFR1REJ4SUtDTC1lNEtsR3hBNHpacEFpRUR4RVRQUUNlbXloUWtfV3k4TzRYTnVlaHNvbVJwa2JDazJ2a1lRTTR6bl84M0k",
+    "payload": {
+      "threshold": 0.8,
+      "completeness_score": 0.1667,
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ]
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:42:14.261697+00:00"
+  },
+  {
+    "id": "rvq_851df5894957a530",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_73e9db6baf85b5d3",
+    "issue_type": "extract_error",
+    "stage": "live_news_v1_legal",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "live news legal completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMiUkFVX3lxTE1BaU42T0NXektTMGdZOTlQRVVxTXRRRWZpLWh1alN1dkpOaEdHbk5keG56U3dwd2tVTlFrVHJKNDNrMGpoZGowa2UxNTdvWHBJcFE",
+    "payload": {
+      "threshold": 0.8,
+      "completeness_score": 0.1667,
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ]
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:42:14.261870+00:00"
+  },
+  {
+    "id": "rvq_df97cd7581a71e3c",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_9720c0cca1ab37ca",
+    "issue_type": "extract_error",
+    "stage": "live_news_v1_legal",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "live news legal completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMiUEFVX3lxTE5ZVmw4S0lqNUl2blhORDJNaDhNYXRuOU5YVjEtbDB2X2JnUFRHaUlLamktTVIwRERxRFRvUU8tZUNJN3BSMHVFWHp3Skl4UTVW",
+    "payload": {
+      "threshold": 0.8,
+      "completeness_score": 0.1667,
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ]
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:42:14.262029+00:00"
+  },
+  {
+    "id": "rvq_4847ba3b79f9c2f7",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_7e3a173859cf577d",
+    "issue_type": "extract_error",
+    "stage": "live_news_v1_legal",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "live news legal completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMiVEFVX3lxTE1IVU9vU0VXNTM3RndSNUpkTzFmVWJCYWNXRzdkNjJoQ19SeEZ6ZzBVenIzUXpBTlFRckVNZVVIQXAzR1dXVmIyY1lJa3JjVHRJYnBUQw",
+    "payload": {
+      "threshold": 0.8,
+      "completeness_score": 0.1667,
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ]
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:42:14.262184+00:00"
+  },
+  {
+    "id": "rvq_cc111e0100b478a4",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_3f6ca2ed23cdeb99",
+    "issue_type": "extract_error",
+    "stage": "extract",
+    "error_code": "NO_TITLE_CANDIDATE_SIGNAL",
+    "error_message": "no candidate/value pair extracted",
+    "source_url": "https://news.google.com/rss/articles/CBMiW0FVX3lxTE43YUpldmVfcHp3QlZFeWNTTFQ2UllWLXFscm91WGdRRVJYNTVxYXdSVlVlLWJjczc5VTZvQ0wzb2VTZlBWTzktc0kyOVkwUi1Wa3dzTlltOFlUakk",
+    "payload": {
+      "article_id": "art-fallback_728caae6c54f13ba"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:42:14.262309+00:00"
+  },
+  {
+    "id": "rvq_4353cb72c8c4ac05",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_3f6ca2ed23cdeb99",
+    "issue_type": "extract_error",
+    "stage": "live_news_v1_legal",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "live news legal completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMiW0FVX3lxTE43YUpldmVfcHp3QlZFeWNTTFQ2UllWLXFscm91WGdRRVJYNTVxYXdSVlVlLWJjczc5VTZvQ0wzb2VTZlBWTzktc0kyOVkwUi1Wa3dzTlltOFlUakk",
+    "payload": {
+      "threshold": 0.8,
+      "completeness_score": 0.1667,
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ]
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:42:14.262338+00:00"
+  },
+  {
+    "id": "rvq_6adef64ec87b59af",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_9d438b8ddd2dce8e",
+    "issue_type": "extract_error",
+    "stage": "live_news_v1_legal",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "live news legal completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMiX0FVX3lxTE9GWVBudXBmWV8wR3pnY1RmTGRtcVZLVDFRQ0VZVmdWdmZSdnpvSFZ3S1RwdzBGS2NVMjFJM3hqczEyNlZzMzVsUTVzdkhsWUc2QnQ0UmNkQUtqd2ZMQURF",
+    "payload": {
+      "threshold": 0.8,
+      "completeness_score": 0.1667,
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ]
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:42:14.262471+00:00"
+  },
+  {
+    "id": "rvq_d73d08cb03744cbe",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_2a69111033285a20",
+    "issue_type": "extract_error",
+    "stage": "extract",
+    "error_code": "NO_TITLE_CANDIDATE_SIGNAL",
+    "error_message": "no candidate/value pair extracted",
+    "source_url": "https://news.google.com/rss/articles/CBMiYEFVX3lxTE5iM0Z6YzdVTU1hNHZHb0dXRWJxb0dPU2RoQlV1bHQ5Vk93OXlGQW1najU3TEE0UVVSd2RYT0s5Q0VYVnBnR2hscV9ac1pFUng5RjZSUUlpNjdtRHFRV25pMw",
+    "payload": {
+      "article_id": "art-fallback_2dc9ce7301e19e54"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:42:14.262659+00:00"
+  },
+  {
+    "id": "rvq_b1058e4c7be6db1e",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_2a69111033285a20",
+    "issue_type": "extract_error",
+    "stage": "live_news_v1_legal",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "live news legal completeness below threshold",
+    "source_url": "https://news.google.com/rss/articles/CBMiYEFVX3lxTE5iM0Z6YzdVTU1hNHZHb0dXRWJxb0dPU2RoQlV1bHQ5Vk93OXlGQW1najU3TEE0UVVSd2RYT0s5Q0VYVnBnR2hscV9ac1pFUng5RjZSUUlpNjdtRHFRV25pMw",
+    "payload": {
+      "threshold": 0.8,
+      "completeness_score": 0.1667,
+      "missing_fields": [
+        "sponsor",
+        "survey_period",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ]
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:42:14.262694+00:00"
+  },
+  {
+    "id": "rvq_1fd2e94d8e4c54af",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_53efed5986b625b8",
+    "issue_type": "extract_error",
+    "stage": "live_news_v1_legal",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "live news legal completeness below threshold",
+    "source_url": "https://www.newsis.com/view/NISX20260224_0003524306",
+    "payload": {
+      "threshold": 0.8,
+      "completeness_score": 0.3333,
+      "missing_fields": [
+        "sponsor",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ]
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:42:14.265735+00:00"
+  },
+  {
+    "id": "rvq_f9015beb86fc6d0c",
+    "entity_type": "poll_observation",
+    "entity_id": "obs_2ed7ab2c5d4f26ae",
+    "issue_type": "extract_error",
+    "stage": "live_news_v1_legal",
+    "error_code": "LEGAL_COMPLETENESS_BELOW_THRESHOLD",
+    "error_message": "live news legal completeness below threshold",
+    "source_url": "https://www.newsis.com/view/NISX20260224_0003524095",
+    "payload": {
+      "threshold": 0.8,
+      "completeness_score": 0.3333,
+      "missing_fields": [
+        "sponsor",
+        "sample_size",
+        "response_rate",
+        "margin_of_error"
+      ]
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:42:14.268580+00:00"
+  },
+  {
+    "id": "rvq_d872976839357e04",
+    "entity_type": "article",
+    "entity_id": "art_f64295cd58a1fc70",
+    "issue_type": "mapping_error",
+    "stage": "extract",
+    "error_code": "REGION_OFFICE_NOT_MAPPED",
+    "error_message": "failed to map region_code/office_type to CommonCodeService and standard enum",
+    "source_url": "https://www.khan.co.kr/article/202602231725001/",
+    "payload": {
+      "title": "윤석열 절연 논의 막은 ‘입틀막 의총’, 반발 퇴장…선거 D-100 길 잃은 국민의힘 - 경향신문"
+    },
+    "status": "pending",
+    "created_at": "2026-02-24T05:42:14.269002+00:00"
+  }
+]


### PR DESCRIPTION
Report-Path: Collector_reports/2026-02-24_s5_live_news_post_green_quality_postcheck_report.md

## 작업 요약
- #246 완료 후 first green run(`22338262595`) 아티팩트 기반 품질 post-check 수행
- 분석 대상 3종 아티팩트:
  - `collector_live_news_v1_report.json`
  - `collector_live_news_v1_review_queue_candidates.json`
  - `collector_live_news_v1_ingest_runner_report.json`
- 지표표(ingest_count, threshold_miss_rate, fallback_fetch_count, review_queue_mix) 산출
- completeness/threshold miss 분포 요약
- 다음 튜닝 우선순위 2개 제안

## 산출물
- `Collector_reports/2026-02-24_s5_live_news_post_green_quality_postcheck_report.md`
- `data/verification/issue248_live_news_postcheck_summary.json`
- `data/verification/issue248_run_22338262595_artifacts/collector-live-news-artifacts/*`

## 핵심 지표
- ingest_count: 37
- threshold_miss_rate: 1.0000
- fallback_fetch_count: 63
- review_queue_mix:
  - fetch_error 63 (59.43%)
  - extract_error 42 (39.62%)
  - mapping_error 1 (0.94%)

Closes #248
