### PR TITLE
[COLLECTOR] #252 법정필수항목 completeness 개선 v1

### DIFF
--- a/Collector_reports/2026-02-24_s6_live_news_legal_completeness_v1_report.md
+++ b/Collector_reports/2026-02-24_s6_live_news_legal_completeness_v1_report.md
@@ -1,0 +1,78 @@
+# [COLLECTOR][S6] 법정필수항목 completeness 개선 v1 보고서 (#252)
+
+## 1) 목표
+- 기사 추출기 기반 법정필수 6항목(`pollster/sponsor/survey_period/sample_size/response_rate/margin_of_error`) 보강
+- NESDC 보강 메타 결합으로 자동 보강 가능한 필드 채움
+- `review_queue`에 결측 근거 필드 명시
+
+## 2) 반영 내용
+1. live-news 보강 레이어 추가
+- 파일: `scripts/generate_collector_live_news_v1_pack.py`
+- 기사 본문 규칙 보강:
+  - sponsor: `의뢰기관/의뢰처` 패턴
+  - sample_size: `표본수/N=` 패턴
+  - response_rate: `응답률` 패턴
+  - margin_of_error: `오차범위/±` 패턴
+- NESDC 보강 결합:
+  - `data/collector_nesdc_safe_collect_v1.json` 기반 pollster 인덱스 생성
+  - observation pollster 매칭 후 `sample_size/response_rate/margin_of_error/survey_period` 보강
+
+2. completeness 결측 근거 명시
+- `CompletenessResult`에 `missing_field_reasons` 추가
+- `LEGAL_COMPLETENESS_BELOW_THRESHOLD` review_queue payload에
+  - `missing_field_reasons`
+  - `enrichment_applied_fields`
+  - `enrichment_sources`
+  포함
+
+3. 리포트 지표 보강
+- `report.legal_enrichment` 추가:
+  - `nesdc_pollster_index_count`
+  - `enriched_observation_count`
+  - `enriched_field_counts`
+  - `enrichment_source_counts`
+
+## 3) 테스트
+- 수정: `tests/test_collector_live_news_v1_pack_script.py`
+- 신규 검증:
+  - 기사 규칙 보강으로 completeness 개선
+  - NESDC 메타 보강으로 completeness 개선
+  - threshold miss review_queue payload에 `missing_field_reasons` 포함
+
+실행:
+```bash
+PYTHONPATH=. /Users/gimtaehun/election2026_codex/.venv/bin/pytest -q \
+  tests/test_collector_live_news_v1_pack_script.py \
+  tests/test_nesdc_live_v1_pack_script.py \
+  tests/test_nesdc_safe_collect_v1_script.py
+```
+결과: `15 passed`
+
+## 4) 최근 green 아티팩트 기준 개선 증빙
+- 기준 run: `22338262595`
+- baseline 아티팩트:
+  - `data/verification/issue248_run_22338262595_artifacts/collector-live-news-artifacts/collector_live_news_v1_report.json`
+  - `data/verification/issue248_run_22338262595_artifacts/collector-live-news-artifacts/collector_live_news_v1_payload.json`
+- 재평가 요약:
+  - `data/verification/issue252_postgreen_completeness_recompute.json`
+
+지표 비교:
+- `threshold_miss_rate`: `1.0000 -> 0.9189`
+- `threshold_miss_count`: `37 -> 34`
+- `avg legal completeness`: `0.1802 -> 0.2388`
+- `max legal completeness`: `0.3333 -> 0.8333`
+
+보강 적용 통계:
+- `enriched_observation_count`: `5`
+- `enrichment_source_counts`:
+  - `article_pattern`: `5`
+  - `nesdc_meta`: `8`
+
+## 5) 완료 기준 충족 여부
+- 최근 green 아티팩트 기준 `threshold_miss_rate < 1.0`: 충족(`0.9189`)
+- 최소 1개 런에서 `avg legal completeness` 개선 증빙: 충족(`0.1802 -> 0.2388`)
+- `Collector_reports/` 보고서 제출: 충족
+
+## 6) 의사결정 필요사항
+1. `threshold_miss_rate`가 여전히 높아(0.9189) sponsor/survey_period 고도화 2차 규칙 적용 여부 결정 필요
+2. 본문 규칙 보강 vs discovery 품질게이트(#253) 우선순위 조정 필요

--- a/data/verification/issue252_postgreen_completeness_recompute.json
+++ b/data/verification/issue252_postgreen_completeness_recompute.json
@@ -1,0 +1,29 @@
+{
+  "run_id": 22338262595,
+  "baseline": {
+    "threshold_miss_count": 37,
+    "threshold_miss_rate": 1.0,
+    "avg_legal_completeness": 0.1802
+  },
+  "recomputed_with_issue252_rules": {
+    "threshold": 0.8,
+    "observation_count": 37,
+    "threshold_miss_count": 34,
+    "threshold_miss_rate": 0.9189,
+    "avg_legal_completeness": 0.2388,
+    "min_legal_completeness": 0.1667,
+    "max_legal_completeness": 0.8333,
+    "missing_field_counts": {
+      "sponsor": 34,
+      "survey_period": 32,
+      "sample_size": 34,
+      "response_rate": 34,
+      "margin_of_error": 32
+    },
+    "enriched_observation_count": 5,
+    "enrichment_source_counts": {
+      "article_pattern": 5,
+      "nesdc_meta": 8
+    }
+  }
+}

--- a/scripts/generate_collector_live_news_v1_pack.py
+++ b/scripts/generate_collector_live_news_v1_pack.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 import json
 from pathlib import Path
+import re
 from typing import Any
 
 from src.pipeline.collector import CollectorOutput, PollCollector
@@ -17,6 +18,7 @@ OUT_OUTPUT = "data/collector_live_news_v1_output.json"
 OUT_PAYLOAD = "data/collector_live_news_v1_payload.json"
 OUT_REPORT = "data/collector_live_news_v1_report.json"
 OUT_REVIEW_QUEUE = "data/collector_live_news_v1_review_queue_candidates.json"
+DEFAULT_NESDC_ENRICH_PATH = "data/collector_nesdc_safe_collect_v1.json"
 
 REQUIRED_FIELDS: tuple[str, ...] = (
     "pollster",
@@ -28,6 +30,21 @@ REQUIRED_FIELDS: tuple[str, ...] = (
 )
 
 DEFAULT_THRESHOLD = 0.8
+SPONSOR_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"(?:의뢰(?:기관|처)?|의뢰자)\s*[:：]?\s*([A-Za-z0-9가-힣·\-\(\)\s]{2,40})"),
+    re.compile(r"([A-Za-z0-9가-힣·\-\(\)\s]{2,40})\s*(?:의뢰로|의뢰를 받아)"),
+)
+SAMPLE_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"(?:표본(?:수)?|조사(?:대상)?)[^\d]{0,12}([0-9][0-9,]{2,5})\s*명"),
+    re.compile(r"\bN\s*=\s*([0-9][0-9,]{2,5})\b", flags=re.IGNORECASE),
+)
+RESPONSE_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"응답률[^\d]{0,10}([0-9]+(?:\.[0-9]+)?)\s*%"),
+)
+MARGIN_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"오차범위[^\d]{0,14}(?:±|\+/-)?\s*([0-9]+(?:\.[0-9]+)?)\s*%?\s*[pP]?"),
+    re.compile(r"(?:±|\+/-)\s*([0-9]+(?:\.[0-9]+)?)\s*%?\s*[pP]"),
+)
 
 
 @dataclass(frozen=True)
@@ -36,6 +53,7 @@ class CompletenessResult:
     filled_count: int
     required_count: int
     missing_fields: list[str]
+    missing_field_reasons: dict[str, str]
 
 
 class _PipelineAdapter:
@@ -63,28 +81,253 @@ def _is_valid_numeric(name: str, value: Any) -> bool:
     return False
 
 
+def _parse_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value if value > 0 else None
+    if isinstance(value, float):
+        if value <= 0:
+            return None
+        return int(value)
+    text = str(value)
+    m = re.search(r"([0-9][0-9,]*)", text)
+    if not m:
+        return None
+    digits = m.group(1).replace(",", "")
+    try:
+        parsed = int(digits)
+    except ValueError:
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _parse_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        parsed = float(value)
+        return parsed if parsed > 0 else None
+    text = str(value)
+    m = re.search(r"([0-9]+(?:\.[0-9]+)?)", text)
+    if not m:
+        return None
+    try:
+        parsed = float(m.group(1))
+    except ValueError:
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _extract_first(text: str, patterns: tuple[re.Pattern[str], ...]) -> str | None:
+    for pat in patterns:
+        m = pat.search(text)
+        if not m:
+            continue
+        value = re.sub(r"\s+", " ", m.group(1)).strip(" ,.;:)]")
+        if value:
+            return value
+    return None
+
+
+def _extract_sample_size_from_text(text: str) -> int | None:
+    for pat in SAMPLE_PATTERNS:
+        m = pat.search(text)
+        if not m:
+            continue
+        parsed = _parse_int(m.group(1))
+        if parsed is not None:
+            return parsed
+    return None
+
+
+def _extract_response_rate_from_text(text: str) -> float | None:
+    for pat in RESPONSE_PATTERNS:
+        m = pat.search(text)
+        if not m:
+            continue
+        parsed = _parse_float(m.group(1))
+        if parsed is not None and parsed <= 100:
+            return parsed
+    return None
+
+
+def _extract_margin_of_error_from_text(text: str) -> float | None:
+    for pat in MARGIN_PATTERNS:
+        m = pat.search(text)
+        if not m:
+            continue
+        parsed = _parse_float(m.group(1))
+        if parsed is not None and parsed <= 100:
+            return parsed
+    return None
+
+
+def _extract_survey_date_candidates(text: str) -> tuple[str | None, str | None]:
+    dates = re.findall(r"(20[0-9]{2}-[0-9]{2}-[0-9]{2})", text)
+    if not dates:
+        return None, None
+    ordered = sorted(set(dates))
+    if len(ordered) == 1:
+        return None, ordered[0]
+    return ordered[0], ordered[-1]
+
+
+def _normalize_pollster(value: str) -> str:
+    text = value.lower().strip()
+    text = text.replace("주식회사", "").replace("(주)", "").replace("㈜", "")
+    text = re.sub(r"[^a-z0-9가-힣]", "", text)
+    return text
+
+
+def _load_nesdc_enrichment_index(path: str | None) -> dict[str, list[dict[str, Any]]]:
+    if not path:
+        return {}
+    file_path = Path(path)
+    if not file_path.exists():
+        return {}
+
+    payload = json.loads(file_path.read_text(encoding="utf-8"))
+    index: dict[str, list[dict[str, Any]]] = {}
+    for row in payload.get("records") or []:
+        pollster_raw = str(row.get("pollster") or "").strip()
+        key = _normalize_pollster(pollster_raw)
+        if not key:
+            continue
+        legal_meta = row.get("legal_meta") or {}
+        start_date, end_date = _extract_survey_date_candidates(str(legal_meta.get("survey_datetime") or ""))
+        item = {
+            "pollster": pollster_raw,
+            "sample_size": _parse_int(legal_meta.get("sample_size")),
+            "response_rate": _parse_float(legal_meta.get("response_rate")),
+            "margin_of_error": (
+                _extract_margin_of_error_from_text(str(legal_meta.get("margin_of_error") or ""))
+                or _parse_float(legal_meta.get("margin_of_error"))
+            ),
+            "survey_start_date": start_date,
+            "survey_end_date": end_date,
+        }
+        index.setdefault(key, []).append(item)
+    return index
+
+
+def _pick_nesdc_enrichment(
+    *,
+    observation: dict[str, Any],
+    entries: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    obs_date = str(observation.get("survey_end_date") or observation.get("survey_start_date") or "")
+    if not entries:
+        return None
+    if not obs_date:
+        return entries[0]
+
+    def score(entry: dict[str, Any]) -> tuple[int, int]:
+        entry_date = str(entry.get("survey_end_date") or entry.get("survey_start_date") or "")
+        exact = 0 if entry_date and entry_date == obs_date else 1
+        completeness = 0
+        if entry.get("sample_size") is not None:
+            completeness += 1
+        if entry.get("response_rate") is not None:
+            completeness += 1
+        if entry.get("margin_of_error") is not None:
+            completeness += 1
+        return (exact, -completeness)
+
+    return sorted(entries, key=score)[0]
+
+
+def _apply_observation_enrichment(
+    *,
+    observation: dict[str, Any],
+    article_text: str,
+    nesdc_index: dict[str, list[dict[str, Any]]],
+) -> dict[str, str]:
+    applied: dict[str, str] = {}
+
+    sponsor = str(observation.get("sponsor") or "").strip()
+    if not sponsor:
+        parsed_sponsor = _extract_first(article_text, SPONSOR_PATTERNS)
+        if parsed_sponsor:
+            observation["sponsor"] = parsed_sponsor
+            applied["sponsor"] = "article_pattern"
+
+    if not _is_valid_numeric("sample_size", observation.get("sample_size")):
+        parsed_sample = _extract_sample_size_from_text(article_text)
+        if parsed_sample is not None:
+            observation["sample_size"] = parsed_sample
+            applied["sample_size"] = "article_pattern"
+
+    if not _is_valid_numeric("response_rate", observation.get("response_rate")):
+        parsed_rate = _extract_response_rate_from_text(article_text)
+        if parsed_rate is not None:
+            observation["response_rate"] = parsed_rate
+            applied["response_rate"] = "article_pattern"
+
+    if not _is_valid_numeric("margin_of_error", observation.get("margin_of_error")):
+        parsed_margin = _extract_margin_of_error_from_text(article_text)
+        if parsed_margin is not None:
+            observation["margin_of_error"] = parsed_margin
+            applied["margin_of_error"] = "article_pattern"
+
+    pollster_key = _normalize_pollster(str(observation.get("pollster") or ""))
+    nesdc_entries = nesdc_index.get(pollster_key) or []
+    best = _pick_nesdc_enrichment(observation=observation, entries=nesdc_entries)
+    if not best:
+        return applied
+
+    if not _is_valid_numeric("sample_size", observation.get("sample_size")) and best.get("sample_size") is not None:
+        observation["sample_size"] = best["sample_size"]
+        applied["sample_size"] = "nesdc_meta"
+    if not _is_valid_numeric("response_rate", observation.get("response_rate")) and best.get("response_rate") is not None:
+        observation["response_rate"] = best["response_rate"]
+        applied["response_rate"] = "nesdc_meta"
+    if not _is_valid_numeric("margin_of_error", observation.get("margin_of_error")) and best.get("margin_of_error") is not None:
+        observation["margin_of_error"] = best["margin_of_error"]
+        applied["margin_of_error"] = "nesdc_meta"
+    if not observation.get("survey_start_date") and best.get("survey_start_date"):
+        observation["survey_start_date"] = best["survey_start_date"]
+        applied["survey_period"] = "nesdc_meta"
+    if not observation.get("survey_end_date") and best.get("survey_end_date"):
+        observation["survey_end_date"] = best["survey_end_date"]
+        applied["survey_period"] = "nesdc_meta"
+
+    return applied
+
+
 def _compute_completeness(observation: dict[str, Any]) -> CompletenessResult:
     missing: list[str] = []
+    reasons: dict[str, str] = {}
 
     pollster = str(observation.get("pollster") or "").strip()
     if not pollster:
         missing.append("pollster")
+        reasons["pollster"] = "empty_value"
 
     sponsor = str(observation.get("sponsor") or "").strip()
     if not sponsor:
         missing.append("sponsor")
+        reasons["sponsor"] = "empty_value"
 
     if not (observation.get("survey_start_date") or observation.get("survey_end_date")):
         missing.append("survey_period")
+        reasons["survey_period"] = "both_dates_missing"
 
     if not _is_valid_numeric("sample_size", observation.get("sample_size")):
         missing.append("sample_size")
+        reasons["sample_size"] = "missing_or_invalid_numeric"
 
     if not _is_valid_numeric("response_rate", observation.get("response_rate")):
         missing.append("response_rate")
+        reasons["response_rate"] = "missing_or_invalid_numeric"
 
     if not _is_valid_numeric("margin_of_error", observation.get("margin_of_error")):
         missing.append("margin_of_error")
+        reasons["margin_of_error"] = "missing_or_invalid_numeric"
 
     required_count = len(REQUIRED_FIELDS)
     filled_count = required_count - len(missing)
@@ -94,6 +337,7 @@ def _compute_completeness(observation: dict[str, Any]) -> CompletenessResult:
         filled_count=filled_count,
         required_count=required_count,
         missing_fields=missing,
+        missing_field_reasons=reasons,
     )
 
 
@@ -117,12 +361,14 @@ def build_collector_live_news_v1_pack(
     per_query_limit: int = 8,
     per_feed_limit: int = 30,
     threshold: float = DEFAULT_THRESHOLD,
+    nesdc_enrich_path: str | None = DEFAULT_NESDC_ENRICH_PATH,
     election_id: str = "20260603",
     pipeline: Any = None,
     collector: PollCollector | None = None,
 ) -> dict[str, Any]:
     pipeline_runner = pipeline or _PipelineAdapter()
     extractor = collector or PollCollector(election_id=election_id)
+    nesdc_index = _load_nesdc_enrichment_index(nesdc_enrich_path)
 
     discovery_result: DiscoveryResultV11 = pipeline_runner.run(
         target_count=target_count,
@@ -137,6 +383,9 @@ def build_collector_live_news_v1_pack(
     threshold_miss_count = 0
     threshold_routed_count = 0
     missing_counter: Counter[str] = Counter()
+    enriched_field_counter: Counter[str] = Counter()
+    enrichment_source_counter: Counter[str] = Counter()
+    enriched_observation_count = 0
 
     for candidate in discovery_result.valid_candidates:
         article = candidate.article
@@ -153,6 +402,24 @@ def build_collector_live_news_v1_pack(
 
         for obs in observations:
             obs_dict = obs.to_dict()
+            applied_enrichment = _apply_observation_enrichment(
+                observation=obs_dict,
+                article_text=article.raw_text,
+                nesdc_index=nesdc_index,
+            )
+            if applied_enrichment:
+                enriched_observation_count += 1
+                for field, source in applied_enrichment.items():
+                    enriched_field_counter[field] += 1
+                    enrichment_source_counter[source] += 1
+
+            obs.sponsor = str(obs_dict.get("sponsor") or "").strip() or None
+            obs.sample_size = _parse_int(obs_dict.get("sample_size"))
+            obs.response_rate = _parse_float(obs_dict.get("response_rate"))
+            obs.margin_of_error = _parse_float(obs_dict.get("margin_of_error"))
+            obs.survey_start_date = str(obs_dict.get("survey_start_date") or "").strip() or None
+            obs.survey_end_date = str(obs_dict.get("survey_end_date") or "").strip() or None
+
             completeness = _compute_completeness(obs_dict)
             obs.legal_completeness_score = completeness.score
             obs.legal_filled_count = completeness.filled_count
@@ -177,6 +444,9 @@ def build_collector_live_news_v1_pack(
                             "threshold": threshold,
                             "completeness_score": completeness.score,
                             "missing_fields": completeness.missing_fields,
+                            "missing_field_reasons": completeness.missing_field_reasons,
+                            "enrichment_applied_fields": sorted(applied_enrichment.keys()),
+                            "enrichment_sources": applied_enrichment,
                         },
                     )
                 )
@@ -219,6 +489,13 @@ def build_collector_live_news_v1_pack(
             "min_score": min(completeness_scores) if completeness_scores else 0.0,
             "max_score": max(completeness_scores) if completeness_scores else 0.0,
             "missing_field_counts": dict(missing_counter),
+        },
+        "legal_enrichment": {
+            "nesdc_enrich_path": nesdc_enrich_path,
+            "nesdc_pollster_index_count": len(nesdc_index),
+            "enriched_observation_count": enriched_observation_count,
+            "enriched_field_counts": dict(enriched_field_counter),
+            "enrichment_source_counts": dict(enrichment_source_counter),
         },
         "acceptance_checks": {
             "live_news_candidates_present": len(candidate_preview) > 0,


### PR DESCRIPTION
Report-Path: Collector_reports/2026-02-24_s6_live_news_legal_completeness_v1_report.md

## 작업 요약
- `scripts/generate_collector_live_news_v1_pack.py`에 법정필수항목 보강 레이어 추가
  - 기사 본문 규칙 보강: sponsor/sample_size/response_rate/margin_of_error
  - NESDC 메타 결합 보강: pollster 매칭으로 sample/response/margin/survey_period 보강
- completeness 결측 근거 필드 추가
  - `missing_field_reasons`
  - review_queue payload에 `enrichment_applied_fields`, `enrichment_sources` 포함
- report에 `legal_enrichment` 지표 추가

## 검증
```bash
PYTHONPATH=. /Users/gimtaehun/election2026_codex/.venv/bin/pytest -q \
  tests/test_collector_live_news_v1_pack_script.py \
  tests/test_nesdc_live_v1_pack_script.py \
  tests/test_nesdc_safe_collect_v1_script.py
```
- 15 passed

## 개선 증빙(최근 green 아티팩트 run 22338262595 기준)
- baseline: `threshold_miss_rate=1.0000`, `avg=0.1802`
- recompute(issue252 rules): `threshold_miss_rate=0.9189`, `avg=0.2388`
- evidence: `data/verification/issue252_postgreen_completeness_recompute.json`

Closes #252
