### PR TITLE
[COLLECTOR][P0] #272 기사 시점 컷오프 고정

### DIFF
--- a/Collector_reports/2026-02-26_s7_article_cutoff_gate_report.md
+++ b/Collector_reports/2026-02-26_s7_article_cutoff_gate_report.md
@@ -1,0 +1,62 @@
+# [COLLECTOR][P0] #272 기사 시점 컷오프 고정 보고서
+
+## 1) 작업 개요
+- 이슈: `#272 [COLLECTOR][P0] 기사 시점 컷오프 고정(2025-12-01 이후만 허용)`
+- 목표: `published_at >= 2025-12-01T00:00:00+09:00` 고정 정책을 discovery/ingest/API 노출 경로에 반영하고, backfill cleanup 실행 SQL과 증빙 산출물 제공.
+
+## 2) 반영 범위
+- 단일 정책 소스 추가
+  - `app/services/cutoff_policy.py`
+  - 컷오프 상수: `ARTICLE_PUBLISHED_AT_CUTOFF_ISO = 2025-12-01T00:00:00+09:00`
+- discovery 게이트 반영
+  - `src/pipeline/discovery_v11.py`
+  - 기사 `published_at`가 컷오프 이전이면 `mapping_error`로 review_queue 라우팅 후 제외
+  - 메트릭 추가: `cutoff_excluded_count`
+- ingest 게이트 반영
+  - `app/services/ingest_service.py`
+  - `article` 소스 레코드에 대해 컷오프 이전 `published_at` 차단
+  - 차단 건은 `ingestion_error`로 review_queue 기록
+- API 노출 보호 반영
+  - `app/api/routes.py`
+  - summary/map-latest/big-matches/matchup 응답에서 컷오프 이전 기사 기반 행 제외
+- backfill cleanup 증빙/실행 템플릿 추가
+  - `scripts/generate_collector_article_cutoff_cleanup_v1.py`
+  - 필터링 payload + report 생성, DB cleanup SQL 템플릿 동봉
+
+## 3) 테스트 결과
+- 실행:  
+  `PYTHONPATH=. /Users/gimtaehun/election2026_codex/.venv/bin/python -m pytest -q tests/test_cutoff_policy.py tests/test_discovery_v11.py tests/test_ingest_service.py tests/test_api_routes.py tests/test_collector_article_cutoff_cleanup_v1_script.py`
+- 결과: `33 passed`
+
+## 4) 산출물 및 증빙
+- 코드
+  - `app/services/cutoff_policy.py`
+  - `src/pipeline/discovery_v11.py`
+  - `app/services/ingest_service.py`
+  - `app/api/routes.py`
+  - `scripts/generate_collector_article_cutoff_cleanup_v1.py`
+- 테스트
+  - `tests/test_cutoff_policy.py`
+  - `tests/test_discovery_v11.py`
+  - `tests/test_ingest_service.py`
+  - `tests/test_api_routes.py`
+  - `tests/test_collector_article_cutoff_cleanup_v1_script.py`
+- 데이터 증빙
+  - `data/collector_article_cutoff_cleanup_v1_report.json`
+  - `data/collector_article_cutoff_cleanup_v1_report_live30.json`
+  - `data/sample_ingest_article_cutoff_filtered.json`
+  - `data/collector_live_news_v1_payload_30_article_cutoff_filtered.json`
+
+## 5) 완료 기준 점검
+- 새 ingest에서 컷오프 이전 데이터 적재 0건:
+  - ingest 단계 차단 로직 반영 완료 (`app/services/ingest_service.py`)
+- API 노출 컷오프 위반 0건:
+  - dashboard/matchup 응답 레이어 필터 반영 완료 (`app/api/routes.py`)
+- 기존 데이터 정리(backfill cleanup):
+  - 삭제/정리 SQL 템플릿 제공 완료 (`data/collector_article_cutoff_cleanup_v1_report*.json` 내 `backfill_cleanup_sql`)
+
+## 6) 의사결정 요청
+- 정책 해석 확인 필요:
+  - 현재 정책은 `published_at`이 존재하는 경우에만 컷오프 이전을 차단합니다.
+  - `published_at` 미기재(`null`) 기사도 차단 대상으로 확장할지 확정 요청.
+  - 확정 시 `cutoff_policy.py` 기준으로 strict 모드(`null`도 차단) 즉시 전환 가능.

--- a/app/services/cutoff_policy.py
+++ b/app/services/cutoff_policy.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from email.utils import parsedate_to_datetime
+from typing import Any
+
+KST = timezone(timedelta(hours=9))
+ARTICLE_PUBLISHED_AT_CUTOFF_KST = datetime(2025, 12, 1, 0, 0, 0, tzinfo=KST)
+ARTICLE_PUBLISHED_AT_CUTOFF_ISO = ARTICLE_PUBLISHED_AT_CUTOFF_KST.isoformat(timespec="seconds")
+
+
+def parse_datetime_like(value: Any) -> datetime | None:
+    if value is None:
+        return None
+
+    if isinstance(value, datetime):
+        parsed = value
+    else:
+        raw = str(value).strip()
+        if not raw:
+            return None
+        try:
+            parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        except ValueError:
+            try:
+                parsed = parsedate_to_datetime(raw)
+            except (TypeError, ValueError):
+                return None
+
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=KST)
+    return parsed.astimezone(KST)
+
+
+def published_at_cutoff_reason(published_at: Any) -> str:
+    parsed = parse_datetime_like(published_at)
+    if parsed is None:
+        return "PASS"
+    if parsed < ARTICLE_PUBLISHED_AT_CUTOFF_KST:
+        return "PUBLISHED_AT_BEFORE_CUTOFF"
+    return "PASS"
+
+
+def is_article_published_at_allowed(published_at: Any) -> bool:
+    return published_at_cutoff_reason(published_at) == "PASS"
+
+
+def has_article_source(source_channel: str | None, source_channels: list[str] | None) -> bool:
+    channels = list(source_channels or [])
+    if not channels and source_channel:
+        channels.append(source_channel)
+    if not channels:
+        return True
+    return "article" in {x.strip().lower() for x in channels if x}

--- a/data/collector_article_cutoff_cleanup_v1_report.json
+++ b/data/collector_article_cutoff_cleanup_v1_report.json
@@ -1,0 +1,27 @@
+{
+  "policy": {
+    "published_at_cutoff_kst": "2025-12-01T00:00:00+09:00",
+    "applies_to_source_channel": "article"
+  },
+  "counts": {
+    "input_record_count": 1,
+    "kept_record_count": 1,
+    "cutoff_violation_count": 0
+  },
+  "cutoff_violation_preview": [],
+  "acceptance_checks": {
+    "filtered_payload_has_no_cutoff_violation": true
+  },
+  "backfill_cleanup_sql": {
+    "count_violation_rows": "SELECT COUNT(*)::int AS violation_count FROM poll_observations o LEFT JOIN articles a ON a.id = o.article_id WHERE ((o.source_channel = 'article') OR COALESCE('article' = ANY(o.source_channels), FALSE)) AND (a.published_at IS NULL OR a.published_at < %(cutoff)s::timestamptz);",
+    "delete_poll_observations": "WITH target AS (SELECT o.id FROM poll_observations o LEFT JOIN articles a ON a.id = o.article_id WHERE ((o.source_channel = 'article') OR COALESCE('article' = ANY(o.source_channels), FALSE)) AND (a.published_at IS NULL OR a.published_at < %(cutoff)s::timestamptz)) DELETE FROM poll_observations o USING target t WHERE o.id = t.id;",
+    "delete_orphan_articles": "DELETE FROM articles a WHERE (a.published_at IS NULL OR a.published_at < %(cutoff)s::timestamptz) AND NOT EXISTS (SELECT 1 FROM poll_observations o WHERE o.article_id = a.id);",
+    "cleanup_candidates_article_published_at": "UPDATE candidates SET article_published_at = NULL, updated_at = NOW() WHERE article_published_at < %(cutoff)s::timestamptz;",
+    "sql_params_example": "{\"cutoff\": \"2025-12-01T00:00:00+09:00\"}"
+  },
+  "output_paths": {
+    "input": "data/sample_ingest.json",
+    "filtered_payload": "data/sample_ingest_article_cutoff_filtered.json",
+    "report": "data/collector_article_cutoff_cleanup_v1_report.json"
+  }
+}

--- a/data/collector_article_cutoff_cleanup_v1_report_live30.json
+++ b/data/collector_article_cutoff_cleanup_v1_report_live30.json
@@ -1,0 +1,27 @@
+{
+  "policy": {
+    "published_at_cutoff_kst": "2025-12-01T00:00:00+09:00",
+    "applies_to_source_channel": "article"
+  },
+  "counts": {
+    "input_record_count": 30,
+    "kept_record_count": 30,
+    "cutoff_violation_count": 0
+  },
+  "cutoff_violation_preview": [],
+  "acceptance_checks": {
+    "filtered_payload_has_no_cutoff_violation": true
+  },
+  "backfill_cleanup_sql": {
+    "count_violation_rows": "SELECT COUNT(*)::int AS violation_count FROM poll_observations o LEFT JOIN articles a ON a.id = o.article_id WHERE ((o.source_channel = 'article') OR COALESCE('article' = ANY(o.source_channels), FALSE)) AND (a.published_at IS NULL OR a.published_at < %(cutoff)s::timestamptz);",
+    "delete_poll_observations": "WITH target AS (SELECT o.id FROM poll_observations o LEFT JOIN articles a ON a.id = o.article_id WHERE ((o.source_channel = 'article') OR COALESCE('article' = ANY(o.source_channels), FALSE)) AND (a.published_at IS NULL OR a.published_at < %(cutoff)s::timestamptz)) DELETE FROM poll_observations o USING target t WHERE o.id = t.id;",
+    "delete_orphan_articles": "DELETE FROM articles a WHERE (a.published_at IS NULL OR a.published_at < %(cutoff)s::timestamptz) AND NOT EXISTS (SELECT 1 FROM poll_observations o WHERE o.article_id = a.id);",
+    "cleanup_candidates_article_published_at": "UPDATE candidates SET article_published_at = NULL, updated_at = NOW() WHERE article_published_at < %(cutoff)s::timestamptz;",
+    "sql_params_example": "{\"cutoff\": \"2025-12-01T00:00:00+09:00\"}"
+  },
+  "output_paths": {
+    "input": "data/collector_live_news_v1_payload_30.json",
+    "filtered_payload": "data/collector_live_news_v1_payload_30_article_cutoff_filtered.json",
+    "report": "data/collector_article_cutoff_cleanup_v1_report_live30.json"
+  }
+}

--- a/data/collector_live_news_v1_payload_30_article_cutoff_filtered.json
+++ b/data/collector_live_news_v1_payload_30_article_cutoff_filtered.json
@@ -1,0 +1,2735 @@
+{
+  "run_type": "collector_live_news_v1",
+  "extractor_version": "collector-live-news-v1",
+  "llm_model": null,
+  "records": [
+    {
+      "article": {
+        "url": "https://www.khan.co.kr/article/202602231023001/",
+        "title": "경기지사 후보 조사서 추미애 20%·김동연 15%···오차범위 내 접전 - 경향신문",
+        "publisher": "경향신문",
+        "published_at": "2026-02-23T10:23:00+09:00",
+        "raw_text": "경기지사 후보 조사서 추미애 20%·김동연 15%···오차범위 내 접전 - 경향신문 창간 80주년 경향신문 오피니언 정치 경제 사회 국제 문화 라이프 경기지사 후보 조사서 추미애 20%·김동연 15%···오차범위 내 접전 myNews --> 로그인 검색 메뉴 댓글 0 공유하기 뉴스플리 글자크기 기사듣기 완독 닫기 검색 경향신문 메뉴 펼치기 메뉴 접기 오피니언 전체 사설 여적 기자메모 칼럼 만평 독자마당 정치 전체 청와대 국회·정당 국방·외교 북한·한반도 선거 정치 일반 경제 전체 금융·재테크 산업 IT·가전 부동산 자동차 생활경제 취업·창업 경제 일반 사회 전체 사건·사고 법원·검찰 교육·입시 노동 보건·복지 미디어 젠더 사회 일반 국제 전체 미국·중남미 일본 중국·대만 유럽 아시아·호주 중동·아프리카 국제 일반 문화 전체 책 연극·클래식 학술·문화재 종교 미술·건축 대중음악 영화 방송 문화 일반 스포츠 지역 과학·환경 라이프 사람 ENGLISH 뉴스레터 영상 플랫 사진+ 인터랙티브 이슈 기획·연재 경향티비 스튜디오 경향 암호명 3701 최신 기사 실시간 랭킹 기사 구독신청 기사제보 지면보기 RSS 보도자료 알림 경향신문 앱 스포츠경향 주간경향 레이디경향 facebook youtube x instagram google RSS 공유하기 닫기 카카오톡 카카오톡 페이스북 페이스북 X X 밴드 밴드 --> 블로그 블로그 --> URL 복사 URL 복사 이메일 이메일 보기 설정 닫기 글자 크기 보통 보통 크게 크게 아주 크게 아주 크게 컬러 모드 라이트 라이트 다크 다크 베이지 베이지 그린 그린 컬러 모드 닫기 라이트 라이트 다크 다크 베이지 베이지 그린 그린 본문 요약 닫기 다가오는 6·3 지방선거를 앞두고 실시된 경기지사 후보 적합도 여론조사에서 추미애 더불어민주당 의원과 현역인 김동연 경기지사가 오차범위 내 접전을 벌이고 있다는 결과가 나왔다. 민주당 후보 적합도 조사 결과를 보면 김 지사가 27%, 추 의원이 21%를 각각 얻으며 오차범위 내에서 경쟁을 벌이고 있는 것으로 나타났다. 민주당을 지지한다고 밝힌 응답자들 중에선 추 의원이 35%, 김 지사가 28%였다. 인공지능 기술로 자동 요약된 내용입니다. 전체 내용을 이해하기 위해 본문과 함께 읽는 것을 추천합니다. (제공 = 경향신문&NAVER MEDIA API) 내 뉴스플리에 저장 닫기 정치 경기지사 후보 조사서 추미애 20%·김동연 15%···오차범위 내 ",
+        "raw_hash": "84b8bf443acc64672c16b1f0c5a1bde46ca1598f15da2daabc3743589667f7ae"
+      },
+      "region": {
+        "region_code": "41-000",
+        "sido_name": "경기도",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:지사가",
+          "name_ko": "지사가",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:의원이",
+          "name_ko": "의원이",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:추미애",
+          "name_ko": "추미애",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:김동연",
+          "name_ko": "김동연",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:지사",
+          "name_ko": "지사",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:의원",
+          "name_ko": "의원",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:응답자의",
+          "name_ko": "응답자의",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:응답률이",
+          "name_ko": "응답률이",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:표본오차는",
+          "name_ko": "표본오차는",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:응답률은",
+          "name_ko": "응답률은",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_3923340f5af55d45",
+        "survey_name": "경기지사 후보 조사서 추미애 20%·김동연 15%···오차범위 내 접전 - 경향신문",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": "2026-02-23",
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "41-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|41-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.3333,
+        "legal_filled_count": 2,
+        "legal_required_count": 6,
+        "date_resolution": "relative_day",
+        "date_inference_mode": "relative_published_at",
+        "date_inference_confidence": 0.9,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "지사가",
+          "value_raw": "27%",
+          "value_min": 27.0,
+          "value_max": 27.0,
+          "value_mid": 27.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "의원이",
+          "value_raw": "21%",
+          "value_min": 21.0,
+          "value_max": 21.0,
+          "value_mid": 21.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "의원이",
+          "value_raw": "35%",
+          "value_min": 35.0,
+          "value_max": 35.0,
+          "value_mid": 35.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "지사가",
+          "value_raw": "28%",
+          "value_min": 28.0,
+          "value_max": 28.0,
+          "value_mid": 28.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "추미애",
+          "value_raw": "20%",
+          "value_min": 20.0,
+          "value_max": 20.0,
+          "value_mid": 20.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "김동연",
+          "value_raw": "15%",
+          "value_min": 15.0,
+          "value_max": 15.0,
+          "value_mid": 15.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "지사",
+          "value_raw": "27%",
+          "value_min": 27.0,
+          "value_max": 27.0,
+          "value_mid": 27.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "의원",
+          "value_raw": "21%",
+          "value_min": 21.0,
+          "value_max": 21.0,
+          "value_mid": 21.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "응답자의",
+          "value_raw": "20%",
+          "value_min": 20.0,
+          "value_max": 20.0,
+          "value_mid": 20.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "응답률이",
+          "value_raw": "54%",
+          "value_min": 54.0,
+          "value_max": 54.0,
+          "value_mid": 54.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "표본오차는",
+          "value_raw": "95%",
+          "value_min": 95.0,
+          "value_max": 95.0,
+          "value_mid": 95.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "응답률은",
+          "value_raw": "11.1%",
+          "value_min": 11.1,
+          "value_max": 11.1,
+          "value_mid": 11.1,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiWkFVX3lxTE9HamZYd25pRGI3UmxSZGpRRHFHaDF0dDJ2RHJyNG5qaE9ybWFDb0F5OUQ2Mk5EVDU1bk9mZWpEUk84MXk1LU9DT3Rhdm92MTBJbjBOME4zYlVDd9IBX0FVX3lxTE5fd1ZmcUxyQ21BWWRBTnhjUWRfMVkzVnNjamFvbXY3bktLekpjNDNFam5rckZlVHQwQ2xKMlRFSTFvRDZIV2JYY3plTkhVeEd3eEE0MGdISmFuZ0JDNE84",
+        "title": "경기지사 후보 조사서 추미애 20%·김동연 15%···오차범위 내 접전",
+        "publisher": "경향신문",
+        "published_at": null,
+        "raw_text": "경기지사 후보 조사서 추미애 20%·김동연 15%···오차범위 내 접전 - 경향신문 경기지사 후보 조사서 추미애 20%·김동연 15%···오차범위 내 접전 &nbsp;&nbsp; 경향신문 지방선거 경기지사 여론조사",
+        "raw_hash": "raw_481d7e296c2722f9"
+      },
+      "region": {
+        "region_code": "41-000",
+        "sido_name": "경기도",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:추미애",
+          "name_ko": "추미애",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:김동연",
+          "name_ko": "김동연",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_1a9d3bc2062fbfd4",
+        "survey_name": "경기지사 후보 조사서 추미애 20%·김동연 15%···오차범위 내 접전",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "41-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|41-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "추미애",
+          "value_raw": "20%",
+          "value_min": 20.0,
+          "value_max": 20.0,
+          "value_mid": 20.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "김동연",
+          "value_raw": "15%",
+          "value_min": 15.0,
+          "value_max": 15.0,
+          "value_mid": 15.0,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMib0FVX3lxTFBJc3BDSGVxWFV6cXZaUXBjdy1ZX3JSODJpbXVlNnhTcFpNZEFITmV6MkFEUHlDZEw4cUtYVGZhVVpUWEN6amVNQ29YMFdjclh0Xy1seV9pbmlIV01mWlduZTE1T08yZ1V1dkExSHRUMA",
+        "title": "[경기도지사 여론조사] 민주 후보적합도… 김동연 35%vs추미애 22%",
+        "publisher": "중부일보",
+        "published_at": null,
+        "raw_text": "[경기도지사 여론조사] 민주 후보적합도… 김동연 35%vs추미애 22% - 중부일보 [경기도지사 여론조사] 민주 후보적합도… 김동연 35%vs추미애 22% &nbsp;&nbsp; 중부일보 지방선거 경기지사 오차범위",
+        "raw_hash": "raw_00f9484f8734db67"
+      },
+      "region": {
+        "region_code": "41-000",
+        "sido_name": "경기도",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:김동연",
+          "name_ko": "김동연",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:추미애",
+          "name_ko": "추미애",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_1b476b3c9acf3ed0",
+        "survey_name": "[경기도지사 여론조사] 민주 후보적합도… 김동연 35%vs추미애 22%",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "41-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|41-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "김동연",
+          "value_raw": "35%",
+          "value_min": 35.0,
+          "value_max": 35.0,
+          "value_mid": 35.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "추미애",
+          "value_raw": "22%",
+          "value_min": 22.0,
+          "value_max": 22.0,
+          "value_mid": 22.0,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMicEFVX3lxTE5QYU9aVVd5UEt6SHFZcm9TVERHOTBqRE5YbHlpOXR1VTUzcWtNcGR2V1Jhai1fLXk3bUJyWC1lbEw0VUNxcFR0eklxclVHWENudzlZZWtkZEpUTkxvaDE0d0lScV9DYXZ2dFhzbEJlQ3Y",
+        "title": "[6·3 지방선거 여론조사-성남시] 성남시장 신상진 35% 김병욱 32%…오차 내 접전",
+        "publisher": "인천일보",
+        "published_at": null,
+        "raw_text": "[6·3 지방선거 여론조사-성남시] 성남시장 신상진 35% 김병욱 32%…오차 내 접전 - 인천일보 [6·3 지방선거 여론조사-성남시] 성남시장 신상진 35% 김병욱 32%…오차 내 접전 &nbsp;&nbsp; 인천일보 지방선거 경기지사 가상대결",
+        "raw_hash": "raw_896bf07c5bf3bf82"
+      },
+      "region": {
+        "region_code": "41-000",
+        "sido_name": "경기도",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:신상진",
+          "name_ko": "신상진",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:김병욱",
+          "name_ko": "김병욱",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_259e580fdbc42986",
+        "survey_name": "[6·3 지방선거 여론조사-성남시] 성남시장 신상진 35% 김병욱 32%…오차 내 접전",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "41-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|41-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "신상진",
+          "value_raw": "35%",
+          "value_min": 35.0,
+          "value_max": 35.0,
+          "value_mid": 35.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "김병욱",
+          "value_raw": "32%",
+          "value_min": 32.0,
+          "value_max": 32.0,
+          "value_mid": 32.0,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMimwFBVV95cUxPMjFRclBzZnhwdWlFY1l1QU1aRHNzem5UM0kzSW9LQjVldFNHeGg5ajlkZ1MycDYzek5RbWFTLVl5RjFlTlBLSzV4LXR1M1VmdTR3akpvTEp0SkFaR3h3Q0lIdEhDR0VkOFNJRWZEYXYtNEJGcHhuTEJOTG5zSEItZG04UWNUM2JsZUJsLUJnNXZYZExjSjRfQk0wQQ",
+        "title": "[서울시장 후보 지지도] 정원오 30.8%-박주민 13.1%...정 49.0%-오 37.2%, 박 48.2%-오 35.2%",
+        "publisher": "오마이뉴스",
+        "published_at": null,
+        "raw_text": "[서울시장 후보 지지도] 정원오 30.8%-박주민 13.1%...정 49.0%-오 37.2%, 박 48.2%-오 35.2% - 오마이뉴스 [서울시장 후보 지지도] 정원오 30.8%-박주민 13.1%...정 49.0%-오 37.2%, 박 48.2%-오 35.2% &nbsp;&nbsp; 오마이뉴스 지방선거 서울시장 여론조사",
+        "raw_hash": "raw_2b8e009364939875"
+      },
+      "region": {
+        "region_code": "11-000",
+        "sido_name": "서울특별시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:정원오",
+          "name_ko": "정원오",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:박주민",
+          "name_ko": "박주민",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_7f29a3027242a383",
+        "survey_name": "[서울시장 후보 지지도] 정원오 30.8%-박주민 13.1%...정 49.0%-오 37.2%, 박 48.2%-오 35.2%",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "11-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|11-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "정원오",
+          "value_raw": "30.8%",
+          "value_min": 30.8,
+          "value_max": 30.8,
+          "value_mid": 30.8,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "박주민",
+          "value_raw": "13.1%",
+          "value_min": 13.1,
+          "value_max": 13.1,
+          "value_mid": 13.1,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMieEFVX3lxTE5tTW9iQy1QNXd2ZUU2OE5kZmZWMWlkem9tRDRMZXpVcVRVNXgxSGVicUxKdVBXX2QxeW5NYVBCQUp3NmdVRXF0c3VYZ19DT0F2UGtWVTZSYjdHa0J0SFFCOGM3N3lEM0JQMDJpZU5ybnBnY0ZRV2YwWdIBeEFVX3lxTFBXWWNrY1FkOUNlcWd3Z3hNZ1dkQ3JnbmNKcDFKVUpUN1k3SWt5UThzUVYxaDNMVkRzeDhTZV8yU2VTVHhlNVdFbllQVEl0QXZVYVVTOG85aDNMc0EzVVV4Nk1qZ1lUNVE0eTRIcS1FbTVrbk43RDc1Nw",
+        "title": "[MBC여론조사] 서울시장 가상 대결서‥정원오 40% VS 오세훈 36%",
+        "publisher": "MBC 뉴스",
+        "published_at": null,
+        "raw_text": "[MBC여론조사] 서울시장 가상 대결서‥정원오 40% VS 오세훈 36% - MBC 뉴스 [MBC여론조사] 서울시장 가상 대결서‥정원오 40% VS 오세훈 36% &nbsp;&nbsp; MBC 뉴스 지방선거 서울시장 가상대결",
+        "raw_hash": "raw_a5fb06f2255166eb"
+      },
+      "region": {
+        "region_code": "11-000",
+        "sido_name": "서울특별시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:정원오",
+          "name_ko": "정원오",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:오세훈",
+          "name_ko": "오세훈",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_c98ca4f5973f8d49",
+        "survey_name": "[MBC여론조사] 서울시장 가상 대결서‥정원오 40% VS 오세훈 36%",
+        "pollster": "MBC",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "11-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|11-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "정원오",
+          "value_raw": "40%",
+          "value_min": 40.0,
+          "value_max": 40.0,
+          "value_mid": 40.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "오세훈",
+          "value_raw": "36%",
+          "value_min": 36.0,
+          "value_max": 36.0,
+          "value_mid": 36.0,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiVkFVX3lxTE5mZnp1cU5sXzNkMk52b1Y4bWpsaXhoZUswNEVsaDN4RERfV2RyTFdOY1hackVlbWFwWlBRaFFITkZOeDRiWFo2Sll4UWNaTEt1aFJoYzh30gGGAkFVX3lxTE16ZVBkOUM3T2hYWm5LOEhjNDlFRXNfbWpqbUhqQjBBdlJocTg3dnJXb3VvZ0FTR2lkbjFGMHRPZlBuTVo0Q2w0M3NZVmhZTjdzLWlzdkFKb1RJVmNkMUpFX1lsMDZOa2Z4MmQwTUlxVm1EdGJxUTUxR2hmeUNnU0JBN1h0OXllZXFpZlo4Ry03U3hMN3ZDbExRUklHcUE4cHV6R2hBODdkYnJWd1VYMWEwaGRUcFNnLXNLa3BRd1p5TERzTHVfNkNhQjV1bzFWLTBpcmYzM0RZMnZrQ1M3dzVTNEVicFFxbHB0UFJYQTFTUzNicXNfNEFoaGk2SHFtdXU0b3RTVXc",
+        "title": "[설 연휴 여론조사] 정원오 38% 오세훈 36%…서울시장 오차내 '팽팽'",
+        "publisher": "데일리안",
+        "published_at": null,
+        "raw_text": "[설 연휴 여론조사] 정원오 38% 오세훈 36%…서울시장 오차내 '팽팽' - 데일리안 [설 연휴 여론조사] 정원오 38% 오세훈 36%…서울시장 오차내 '팽팽' &nbsp;&nbsp; 데일리안 지방선거 서울시장 오차범위",
+        "raw_hash": "raw_5dd517bdc3c5c82d"
+      },
+      "region": {
+        "region_code": "11-000",
+        "sido_name": "서울특별시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:정원오",
+          "name_ko": "정원오",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:오세훈",
+          "name_ko": "오세훈",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_f5aefbfbb344c0d1",
+        "survey_name": "[설 연휴 여론조사] 정원오 38% 오세훈 36%…서울시장 오차내 '팽팽'",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "11-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|11-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "정원오",
+          "value_raw": "38%",
+          "value_min": 38.0,
+          "value_max": 38.0,
+          "value_mid": 38.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "오세훈",
+          "value_raw": "36%",
+          "value_min": 36.0,
+          "value_max": 36.0,
+          "value_mid": 36.0,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMidEFVX3lxTE0tR240RHM3eWhpWHhBUmFDZzl1eUFIRjJZN0JGU185MXBaanpESmxwTUREYThKU3h6anpJRklRelduaHR1UjBLSFhlbDhoNkhJN284eS1RS2lmTm5wUTZXWXZLNFBNWm1vOW03YS1wTmdaRjB5",
+        "title": "부산시장여론조사 전재수 43.3% 또 앞서, 박형준은 34.6%",
+        "publisher": "오마이뉴스",
+        "published_at": null,
+        "raw_text": "부산시장여론조사 전재수 43.3% 또 앞서, 박형준은 34.6% - 오마이뉴스 부산시장여론조사 전재수 43.3% 또 앞서, 박형준은 34.6% &nbsp;&nbsp; 오마이뉴스 지방선거 부산시장 오차범위",
+        "raw_hash": "raw_321af2cbddc97dc8"
+      },
+      "region": {
+        "region_code": "26-000",
+        "sido_name": "부산광역시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:전재수",
+          "name_ko": "전재수",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:박형준은",
+          "name_ko": "박형준은",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_136dffa93edf3413",
+        "survey_name": "부산시장여론조사 전재수 43.3% 또 앞서, 박형준은 34.6%",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "26-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|26-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "전재수",
+          "value_raw": "43.3%",
+          "value_min": 43.3,
+          "value_max": 43.3,
+          "value_mid": 43.3,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "박형준은",
+          "value_raw": "34.6%",
+          "value_min": 34.6,
+          "value_max": 34.6,
+          "value_mid": 34.6,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiT0FVX3lxTE1TR0RwR3pLa1lTTXY0XzFmaF81SFA3NXhhcHNLWWhTczVrQUtJcDJtOUxaNGxYdnNueXRBU19VSTAzVGpselZMTXVHWUJfYTg",
+        "title": "부산시장 여론조사, 전재수 46.7% vs 박형준 38.4%…오차범위 밖 격차",
+        "publisher": "v.daum.net",
+        "published_at": null,
+        "raw_text": "부산시장 여론조사, 전재수 46.7% vs 박형준 38.4%…오차범위 밖 격차 - v.daum.net 부산시장 여론조사, 전재수 46.7% vs 박형준 38.4%…오차범위 밖 격차 &nbsp;&nbsp; v.daum.net 지방선거 부산시장 오차범위",
+        "raw_hash": "raw_ebc4aa67475cc50f"
+      },
+      "region": {
+        "region_code": "26-000",
+        "sido_name": "부산광역시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:전재수",
+          "name_ko": "전재수",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:박형준",
+          "name_ko": "박형준",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_444bed2fb448053a",
+        "survey_name": "부산시장 여론조사, 전재수 46.7% vs 박형준 38.4%…오차범위 밖 격차",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "26-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|26-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "전재수",
+          "value_raw": "46.7%",
+          "value_min": 46.7,
+          "value_max": 46.7,
+          "value_mid": 46.7,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "박형준",
+          "value_raw": "38.4%",
+          "value_min": 38.4,
+          "value_max": 38.4,
+          "value_mid": 38.4,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMieEFVX3lxTE5YR2RWdVVLempqS2xCZU9WR083VHZWcEFjRnpqUUJpbWd3YjVINFBsNlU2UVRyNHU0UEg0YnBIRl9MLTkwaldWaDVPeE1XVnVKVWdGNlFXNTR5UFlfakR6bXZ4V0hTcVBrNU9oaEpPdWJjY2tpa1I4UQ",
+        "title": "전재수 43.4% vs 박형준 32.3%… 오차범위 밖 격차 [6·3 지방선거 여론조사]",
+        "publisher": "부산일보사",
+        "published_at": null,
+        "raw_text": "전재수 43.4% vs 박형준 32.3%… 오차범위 밖 격차 [6·3 지방선거 여론조사] - 부산일보사 전재수 43.4% vs 박형준 32.3%… 오차범위 밖 격차 [6·3 지방선거 여론조사] &nbsp;&nbsp; 부산일보사 지방선거 부산시장 오차범위",
+        "raw_hash": "raw_720c32cdb6eda98c"
+      },
+      "region": {
+        "region_code": "26-000",
+        "sido_name": "부산광역시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:전재수",
+          "name_ko": "전재수",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:박형준",
+          "name_ko": "박형준",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_82f9da3ac3360057",
+        "survey_name": "전재수 43.4% vs 박형준 32.3%… 오차범위 밖 격차 [6·3 지방선거 여론조사]",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "26-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|26-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "전재수",
+          "value_raw": "43.4%",
+          "value_min": 43.4,
+          "value_max": 43.4,
+          "value_mid": 43.4,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "박형준",
+          "value_raw": "32.3%",
+          "value_min": 32.3,
+          "value_max": 32.3,
+          "value_mid": 32.3,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiUkFVX3lxTE1lS3hWUFprb0RROTRHT1FzUHo5QmpBOGdLU3RvNnQxQlJjYVBMakk3NmdXaUZpY19aWXY4U1dxMHhjQVlJanB1UHY1QURTVHRWNHc",
+        "title": "[경인일보 여론조사] “야권에 적합한 경기도지사 후보 없다” 54%",
+        "publisher": "경인일보",
+        "published_at": null,
+        "raw_text": "[경인일보 여론조사] “야권에 적합한 경기도지사 후보 없다” 54% - 경인일보 [경인일보 여론조사] “야권에 적합한 경기도지사 후보 없다” 54% &nbsp;&nbsp; 경인일보 지방선거 경기지사 여론조사",
+        "raw_hash": "raw_420eeb5b61ef0d3c"
+      },
+      "region": {
+        "region_code": "41-000",
+        "sido_name": "경기도",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [],
+      "observation": {
+        "observation_key": "obs_6348089eeaf5b9f8",
+        "survey_name": "[경인일보 여론조사] “야권에 적합한 경기도지사 후보 없다” 54%",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "41-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|41-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": []
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiUkFVX3lxTFBxZHRodk44MXJxVnVlSFRnUkxoQi0yR0tUSmRFdE80LVFmazhtdmdHcjhQQmlXNG92bEZySVpGVG5LaGZNQ2JxUEdTN20zbVhpb3c",
+        "title": "[경인일보 여론조사] 김동연 27% vs 추미애 21% 오차범위 내 양강구도",
+        "publisher": "경인일보",
+        "published_at": null,
+        "raw_text": "[경인일보 여론조사] 김동연 27% vs 추미애 21% 오차범위 내 양강구도 - 경인일보 [경인일보 여론조사] 김동연 27% vs 추미애 21% 오차범위 내 양강구도 &nbsp;&nbsp; 경인일보 지방선거 경기지사 오차범위",
+        "raw_hash": "raw_0fec332ae9d099e7"
+      },
+      "region": {
+        "region_code": "41-000",
+        "sido_name": "경기도",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:김동연",
+          "name_ko": "김동연",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:추미애",
+          "name_ko": "추미애",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_85c4e876cf8b2a2a",
+        "survey_name": "[경인일보 여론조사] 김동연 27% vs 추미애 21% 오차범위 내 양강구도",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "41-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|41-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "김동연",
+          "value_raw": "27%",
+          "value_min": 27.0,
+          "value_max": 27.0,
+          "value_mid": 27.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "추미애",
+          "value_raw": "21%",
+          "value_min": 21.0,
+          "value_max": 21.0,
+          "value_mid": 21.0,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiUkFVX3lxTE8zQ29Gc1hUUnRvSXNrdjBsbW1VSERKTVJLa3NPZHFETnkyLUVnMHYwVm9OMFMzVUJBeTBtN192eTZXUThkM1U0RkE5Yk1PUk0yNmc",
+        "title": "[경인일보 여론조사] 민주당내 인천시장 후보 적합도, 박찬대 43% 당내 압도적",
+        "publisher": "경인일보",
+        "published_at": null,
+        "raw_text": "[경인일보 여론조사] 민주당내 인천시장 후보 적합도, 박찬대 43% 당내 압도적 - 경인일보 [경인일보 여론조사] 민주당내 인천시장 후보 적합도, 박찬대 43% 당내 압도적 &nbsp;&nbsp; 경인일보 지방선거 인천시장 여론조사",
+        "raw_hash": "raw_7b179e23d089dd5a"
+      },
+      "region": {
+        "region_code": "28-000",
+        "sido_name": "인천광역시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:박찬대",
+          "name_ko": "박찬대",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_297e45acd1bc8bec",
+        "survey_name": "[경인일보 여론조사] 민주당내 인천시장 후보 적합도, 박찬대 43% 당내 압도적",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "28-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|28-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "박찬대",
+          "value_raw": "43%",
+          "value_min": 43.0,
+          "value_max": 43.0,
+          "value_mid": 43.0,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMicEFVX3lxTE9TYVNqLXN0aW1lemlIME05b25KX09HNFYydlg1Zk9iaUgyZ2kwcG12b0tTVHRtSEZNVTBoRm1xYS1zMlVCQzZaSnVYZjJlWjNZSkI2cUZlUVZ4TlY1M1BJUUFLd09UV2hiV0taaERtbi0",
+        "title": "[여론조사] 인천시장 양자대결 박찬대 51.2%, 유정복 37.1% 오차 밖 앞서",
+        "publisher": "인천투데이",
+        "published_at": null,
+        "raw_text": "[여론조사] 인천시장 양자대결 박찬대 51.2%, 유정복 37.1% 오차 밖 앞서 - 인천투데이 [여론조사] 인천시장 양자대결 박찬대 51.2%, 유정복 37.1% 오차 밖 앞서 &nbsp;&nbsp; 인천투데이 지방선거 인천시장 지지율",
+        "raw_hash": "raw_022407da52efd8ad"
+      },
+      "region": {
+        "region_code": "28-000",
+        "sido_name": "인천광역시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:박찬대",
+          "name_ko": "박찬대",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:유정복",
+          "name_ko": "유정복",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_ff78dcd3a82e1ee0",
+        "survey_name": "[여론조사] 인천시장 양자대결 박찬대 51.2%, 유정복 37.1% 오차 밖 앞서",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "28-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|28-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "박찬대",
+          "value_raw": "51.2%",
+          "value_min": 51.2,
+          "value_max": 51.2,
+          "value_mid": 51.2,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "유정복",
+          "value_raw": "37.1%",
+          "value_min": 37.1,
+          "value_max": 37.1,
+          "value_mid": 37.1,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiVEFVX3lxTE5rS0JxZXRJT3piMlN2VW5tWnpDVmtZNmFGRDJUZ0dnb0k2NjFsWTRVZkY4NDNHb0pSendnS0FqVUhpMG9JRkhwYUo5Nk92SnZSQWNacw",
+        "title": "[6·3 지방선거 여론조사-수원특례시] 수원시장 이재준 31.5%…국힘 안교재·이봉준 추격",
+        "publisher": "v.daum.net",
+        "published_at": null,
+        "raw_text": "[6·3 지방선거 여론조사-수원특례시] 수원시장 이재준 31.5%…국힘 안교재·이봉준 추격 - v.daum.net [6·3 지방선거 여론조사-수원특례시] 수원시장 이재준 31.5%…국힘 안교재·이봉준 추격 &nbsp;&nbsp; v.daum.net 지방선거 인천시장 가상대결",
+        "raw_hash": "raw_9789c415120c0b69"
+      },
+      "region": {
+        "region_code": "28-000",
+        "sido_name": "인천광역시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:이재준",
+          "name_ko": "이재준",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_0f585774f2b41565",
+        "survey_name": "[6·3 지방선거 여론조사-수원특례시] 수원시장 이재준 31.5%…국힘 안교재·이봉준 추격",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "28-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|28-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "이재준",
+          "value_raw": "31.5%",
+          "value_min": 31.5,
+          "value_max": 31.5,
+          "value_mid": 31.5,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMib0FVX3lxTFBVb1NSZjJ1enV6eDFDLWppUzM4eGlsc2RKRDVxY0pfSmxOUTBLcE1MbGZ0VGdqcVhUMVhHZTBzWk5xanF6Znl4Ym9icFMtX0xweWhsdTlVSzNURjVGUXdsQ1AzTC0xdXJDZDBjaG5TMA",
+        "title": "인천시장 여론조사서 유정복 36.8% vs 박찬대 52.1%",
+        "publisher": "중부일보",
+        "published_at": null,
+        "raw_text": "인천시장 여론조사서 유정복 36.8% vs 박찬대 52.1% - 중부일보 인천시장 여론조사서 유정복 36.8% vs 박찬대 52.1% &nbsp;&nbsp; 중부일보 지방선거 인천시장 가상대결",
+        "raw_hash": "raw_465fb12f6e7974a4"
+      },
+      "region": {
+        "region_code": "28-000",
+        "sido_name": "인천광역시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:유정복",
+          "name_ko": "유정복",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:박찬대",
+          "name_ko": "박찬대",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_0cc203a71a596743",
+        "survey_name": "인천시장 여론조사서 유정복 36.8% vs 박찬대 52.1%",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "28-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|28-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "유정복",
+          "value_raw": "36.8%",
+          "value_min": 36.8,
+          "value_max": 36.8,
+          "value_mid": 36.8,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "박찬대",
+          "value_raw": "52.1%",
+          "value_min": 52.1,
+          "value_max": 52.1,
+          "value_mid": 52.1,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiZ0FVX3lxTE9VTlluWEJ1dFcydUhIa2M4YlhNSVloa1JmNkdtRHVEbGgxQzl5THhmaEY5Vlk3WTFIQTRUYmdVZjQ1SjRHRGF3YnA0MlFQQVB1UE1MY3lBdlVZM3IyS3FyMGhaelNaWFk",
+        "title": "[6·3 지방선거] 인천시장 여론조사...민주 박찬대 40.5% ‘압도’, 국힘 유정복 29.2% 1위",
+        "publisher": "M이코노미뉴스",
+        "published_at": null,
+        "raw_text": "[6·3 지방선거] 인천시장 여론조사...민주 박찬대 40.5% ‘압도’, 국힘 유정복 29.2% 1위 - M이코노미뉴스 [6·3 지방선거] 인천시장 여론조사...민주 박찬대 40.5% ‘압도’, 국힘 유정복 29.2% 1위 &nbsp;&nbsp; M이코노미뉴스 지방선거 인천시장 가상대결",
+        "raw_hash": "raw_47a5c84614475252"
+      },
+      "region": {
+        "region_code": "28-000",
+        "sido_name": "인천광역시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:박찬대",
+          "name_ko": "박찬대",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:유정복",
+          "name_ko": "유정복",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_57d26088f1d9972c",
+        "survey_name": "[6·3 지방선거] 인천시장 여론조사...민주 박찬대 40.5% ‘압도’, 국힘 유정복 29.2% 1위",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "28-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|28-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "박찬대",
+          "value_raw": "40.5%",
+          "value_min": 40.5,
+          "value_max": 40.5,
+          "value_mid": 40.5,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "유정복",
+          "value_raw": "29.2%",
+          "value_min": 29.2,
+          "value_max": 29.2,
+          "value_mid": 29.2,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiT0FVX3lxTE1hbjFpMFNxZGdfSnNlZ1NmTmdyVkpqbUJOMC1YQmp4cV9HWWRVOWZ4VzBTdEVsamdhN21JalI3NWY3eWdTTE5xS0FjT3drQTQ",
+        "title": "[6·3 지방선거 여론조사-성남시] 성남시장 신상진 35% 김병욱 32%…오차 내 접전",
+        "publisher": "v.daum.net",
+        "published_at": null,
+        "raw_text": "[6·3 지방선거 여론조사-성남시] 성남시장 신상진 35% 김병욱 32%…오차 내 접전 - v.daum.net [6·3 지방선거 여론조사-성남시] 성남시장 신상진 35% 김병욱 32%…오차 내 접전 &nbsp;&nbsp; v.daum.net 지방선거 인천시장 오차범위",
+        "raw_hash": "raw_e49585072da15aa7"
+      },
+      "region": {
+        "region_code": "28-000",
+        "sido_name": "인천광역시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:신상진",
+          "name_ko": "신상진",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:김병욱",
+          "name_ko": "김병욱",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_a12b7fcd9b903160",
+        "survey_name": "[6·3 지방선거 여론조사-성남시] 성남시장 신상진 35% 김병욱 32%…오차 내 접전",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "28-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|28-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "신상진",
+          "value_raw": "35%",
+          "value_min": 35.0,
+          "value_max": 35.0,
+          "value_mid": 35.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "김병욱",
+          "value_raw": "32%",
+          "value_min": 32.0,
+          "value_max": 32.0,
+          "value_mid": 32.0,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMicEFVX3lxTE5SVTdnNi1DU3hFdmF1S3ZjbHdidU9tOVktNE1TZ095c2hMdmMxODNHckNxd0ZSQjVtYUZHeVg0TExGUU1jUUotdTFRUUJRZldLb1BSeTFueGhSM1p2WURuZnBUa3JHLVh3Q3FCcXJhdnM",
+        "title": "[6·3 지방선거 여론조사-시흥시] 시흥시장 임병택 27.3%-김윤식 22.3%…오차 내 박빙",
+        "publisher": "인천일보",
+        "published_at": null,
+        "raw_text": "[6·3 지방선거 여론조사-시흥시] 시흥시장 임병택 27.3%-김윤식 22.3%…오차 내 박빙 - 인천일보 [6·3 지방선거 여론조사-시흥시] 시흥시장 임병택 27.3%-김윤식 22.3%…오차 내 박빙 &nbsp;&nbsp; 인천일보 지방선거 인천시장 오차범위",
+        "raw_hash": "raw_3ef508d4ef79bd90"
+      },
+      "region": {
+        "region_code": "28-000",
+        "sido_name": "인천광역시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:임병택",
+          "name_ko": "임병택",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:김윤식",
+          "name_ko": "김윤식",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_3937ad1c6457214f",
+        "survey_name": "[6·3 지방선거 여론조사-시흥시] 시흥시장 임병택 27.3%-김윤식 22.3%…오차 내 박빙",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "28-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|28-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "임병택",
+          "value_raw": "27.3%",
+          "value_min": 27.3,
+          "value_max": 27.3,
+          "value_mid": 27.3,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "김윤식",
+          "value_raw": "22.3%",
+          "value_min": 22.3,
+          "value_max": 22.3,
+          "value_mid": 22.3,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiVEFVX3lxTE94Y2dsVWhMMENURWtmMmNOaGFpWUZBdG1GY3lzYlY3enFsOUthWkFkT0hrb1JnN09iMW5rUzliWFJQU1hXaHllQ1NwY0lSVkFnb1p5TQ",
+        "title": "[6·3 지방선거 여론조사-시흥시] 시흥시 정당 지지도, 민주당 46.9%로 오차범위 밖 우세…국민의힘 30.2%",
+        "publisher": "v.daum.net",
+        "published_at": null,
+        "raw_text": "[6·3 지방선거 여론조사-시흥시] 시흥시 정당 지지도, 민주당 46.9%로 오차범위 밖 우세…국민의힘 30.2% - v.daum.net [6·3 지방선거 여론조사-시흥시] 시흥시 정당 지지도, 민주당 46.9%로 오차범위 밖 우세…국민의힘 30.2% &nbsp;&nbsp; v.daum.net 지방선거 인천시장 오차범위",
+        "raw_hash": "raw_afc59770cc22bf10"
+      },
+      "region": {
+        "region_code": "28-000",
+        "sido_name": "인천광역시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [],
+      "observation": {
+        "observation_key": "obs_056d1438fa2bc3ff",
+        "survey_name": "[6·3 지방선거 여론조사-시흥시] 시흥시 정당 지지도, 민주당 46.9%로 오차범위 밖 우세…국민의힘 30.2%",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "28-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|28-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": []
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiWkFVX3lxTFB2YUZpOFMxY2JtNEIwQi1GSTMwd0hkT1pzcDM3WWlKWnB6dE1vRDhDZzB2RVZfQjRQemJ6WkdrSDlIdXNmNm5hSnB0cjdKTEEtOE9JNjdtc3lJdw",
+        "title": "서울시장 가상대결 정원오 40% vs 오세훈 36%…오차범위 내 접전",
+        "publisher": "뉴스1",
+        "published_at": null,
+        "raw_text": "서울시장 가상대결 정원오 40% vs 오세훈 36%…오차범위 내 접전 - 뉴스1 서울시장 가상대결 정원오 40% vs 오세훈 36%…오차범위 내 접전 &nbsp;&nbsp; 뉴스1 지방선거 서울시장 가상대결",
+        "raw_hash": "raw_a7e6b633020e0e2f"
+      },
+      "region": {
+        "region_code": "11-000",
+        "sido_name": "서울특별시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:정원오",
+          "name_ko": "정원오",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:오세훈",
+          "name_ko": "오세훈",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_debd6bb9da6779e7",
+        "survey_name": "서울시장 가상대결 정원오 40% vs 오세훈 36%…오차범위 내 접전",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "11-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|11-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "정원오",
+          "value_raw": "40%",
+          "value_min": 40.0,
+          "value_max": 40.0,
+          "value_mid": 40.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "오세훈",
+          "value_raw": "36%",
+          "value_min": 36.0,
+          "value_max": 36.0,
+          "value_mid": 36.0,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMibkFVX3lxTE5VZ1UzR1k0dzJRRGgxdDl4QkR3bzBEUjFpc0hSc1Z5ZFFQWnU0VGg0NHJBeFFJLUE3RHhycFVjaUc2Q0RmQ3lNUkU2cU1lT3d0RlQxNGZuWjhFUVZvYUtWa0JSWE8xbkoxczc3VHFB0gFyQVVfeXFMTVYtemZ5RlluSnhqRklvaEZBdm0zMFh3MlBhN2NYYVFWM1F1MUpBajhsMFZZdHdfZGE1WVJMUHZRdUQ3SEVfWW1JYTJqbXBKN1Vnd1VET016bV9EX0lwZEpmeXFLTUp2b3BZaU9qOUxyTkFR",
+        "title": "[6·3 지방선거] '설민심'은 여권 우세, 李 지지율 60% 상회·국정안정론 과반…정치권, 6월 지선 모드 전환",
+        "publisher": "폴리뉴스 Polinews",
+        "published_at": null,
+        "raw_text": "[6·3 지방선거] '설민심'은 여권 우세, 李 지지율 60% 상회·국정안정론 과반…정치권, 6월 지선 모드 전환 - 폴리뉴스 Polinews [6·3 지방선거] '설민심'은 여권 우세, 李 지지율 60% 상회·국정안정론 과반…정치권, 6월 지선 모드 전환 &nbsp;&nbsp; 폴리뉴스 Polinews 지방선거 서울시장 가상대결",
+        "raw_hash": "raw_5e087796393a073e"
+      },
+      "region": {
+        "region_code": "11-000",
+        "sido_name": "서울특별시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [],
+      "observation": {
+        "observation_key": "obs_5ab631e8fc7413b4",
+        "survey_name": "[6·3 지방선거] '설민심'은 여권 우세, 李 지지율 60% 상회·국정안정론 과반…정치권, 6월 지선 모드 전환",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "11-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|11-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": []
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiT0FVX3lxTE9nVmxoSnkzMUNfX1V5YTZyYktkSm5WUEk0ZGVyOEZxc3Y2cVF4cko5NjdsUklaLUpROGVRUGh4NFVzY2s0T3JWcjI1ZXgzNVE",
+        "title": "부산시장 후보 가상 대결…전재수 40%·박형준 30%",
+        "publisher": "v.daum.net",
+        "published_at": null,
+        "raw_text": "부산시장 후보 가상 대결…전재수 40%·박형준 30% - v.daum.net 부산시장 후보 가상 대결…전재수 40%·박형준 30% &nbsp;&nbsp; v.daum.net 지방선거 부산시장 가상대결",
+        "raw_hash": "raw_0432a859f4f454d7"
+      },
+      "region": {
+        "region_code": "26-000",
+        "sido_name": "부산광역시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:전재수",
+          "name_ko": "전재수",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:박형준",
+          "name_ko": "박형준",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_bf18847149fb4b56",
+        "survey_name": "부산시장 후보 가상 대결…전재수 40%·박형준 30%",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "26-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|26-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "전재수",
+          "value_raw": "40%",
+          "value_min": 40.0,
+          "value_max": 40.0,
+          "value_mid": 40.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "박형준",
+          "value_raw": "30%",
+          "value_min": 30.0,
+          "value_max": 30.0,
+          "value_mid": 30.0,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiT0FVX3lxTE54TGg4cF9nTG9rU3M2X0FGWGVKMllQRGMtUmNUNzJTREJCYUxRdFo0ZVBtTEgxc2ZiYnJiWG1yLWM5UXBDZHJFZld2OTl6a1E",
+        "title": "[경기도지사 후보 지지도] 추미애 20.3%, 김동연 17.6%, 한준호 13.8%...김은혜와 가상대결 모두 오차밖 승리",
+        "publisher": "v.daum.net",
+        "published_at": null,
+        "raw_text": "[경기도지사 후보 지지도] 추미애 20.3%, 김동연 17.6%, 한준호 13.8%...김은혜와 가상대결 모두 오차밖 승리 - v.daum.net [경기도지사 후보 지지도] 추미애 20.3%, 김동연 17.6%, 한준호 13.8%...김은혜와 가상대결 모두 오차밖 승리 &nbsp;&nbsp; v.daum.net 지방선거 경기지사 가상대결",
+        "raw_hash": "raw_1f96daf64e47c377"
+      },
+      "region": {
+        "region_code": "41-000",
+        "sido_name": "경기도",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:추미애",
+          "name_ko": "추미애",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:김동연",
+          "name_ko": "김동연",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:한준호",
+          "name_ko": "한준호",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_09aef8cf8f7252e5",
+        "survey_name": "[경기도지사 후보 지지도] 추미애 20.3%, 김동연 17.6%, 한준호 13.8%...김은혜와 가상대결 모두 오차밖 승리",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "41-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|41-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "추미애",
+          "value_raw": "20.3%",
+          "value_min": 20.3,
+          "value_max": 20.3,
+          "value_mid": 20.3,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "김동연",
+          "value_raw": "17.6%",
+          "value_min": 17.6,
+          "value_max": 17.6,
+          "value_mid": 17.6,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "한준호",
+          "value_raw": "13.8%",
+          "value_min": 13.8,
+          "value_max": 13.8,
+          "value_mid": 13.8,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiT0FVX3lxTE9Nc1VkNEhQaDhxVkpJZ1ZfWHl0SXhJeG1DSHZHRnM0bmlZbV9na3hrS2t1V3BBeElBcFYzOEhHTWFLUklNcVU1V3RIdVVVZmM",
+        "title": "[경기도지사 후보 지지도] 추미애 27.0% - 김동연 21.2% - 한준호 17.2%... 오차범위 내 각축",
+        "publisher": "v.daum.net",
+        "published_at": null,
+        "raw_text": "[경기도지사 후보 지지도] 추미애 27.0% - 김동연 21.2% - 한준호 17.2%... 오차범위 내 각축 - v.daum.net [경기도지사 후보 지지도] 추미애 27.0% - 김동연 21.2% - 한준호 17.2%... 오차범위 내 각축 &nbsp;&nbsp; v.daum.net 지방선거 경기지사 오차범위",
+        "raw_hash": "raw_b2b0a6f611e53fb8"
+      },
+      "region": {
+        "region_code": "41-000",
+        "sido_name": "경기도",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:추미애",
+          "name_ko": "추미애",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:김동연",
+          "name_ko": "김동연",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:한준호",
+          "name_ko": "한준호",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_3ac1b89163285638",
+        "survey_name": "[경기도지사 후보 지지도] 추미애 27.0% - 김동연 21.2% - 한준호 17.2%... 오차범위 내 각축",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "41-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|41-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "추미애",
+          "value_raw": "27.0%",
+          "value_min": 27.0,
+          "value_max": 27.0,
+          "value_mid": 27.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "김동연",
+          "value_raw": "21.2%",
+          "value_min": 21.2,
+          "value_max": 21.2,
+          "value_mid": 21.2,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "한준호",
+          "value_raw": "17.2%",
+          "value_min": 17.2,
+          "value_max": 17.2,
+          "value_mid": 17.2,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMia0FVX3lxTE8tUG1uOHA3ZWJCRy1iMVo0REtRemFjLS1BYWdPVmN3emZxSzFJd2x3NTNsdWF3Z0w3THJjdWQ5dDdRb0xiODlPendYRjlRMkc3ejVHN1FGd2hfWUJ0V2tqLU5aMnFsalFxUE1v",
+        "title": "차기 인천시장, 민주 박찬대 51.2% vs. 국힘 유정복 37.1% 오차범위 밖",
+        "publisher": "프레시안",
+        "published_at": null,
+        "raw_text": "차기 인천시장, 민주 박찬대 51.2% vs. 국힘 유정복 37.1% 오차범위 밖 - 프레시안 차기 인천시장, 민주 박찬대 51.2% vs. 국힘 유정복 37.1% 오차범위 밖 &nbsp;&nbsp; 프레시안 지방선거 인천시장 가상대결",
+        "raw_hash": "raw_bccd4d4bacd2319f"
+      },
+      "region": {
+        "region_code": "28-000",
+        "sido_name": "인천광역시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:박찬대",
+          "name_ko": "박찬대",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:유정복",
+          "name_ko": "유정복",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_f319176068c072a1",
+        "survey_name": "차기 인천시장, 민주 박찬대 51.2% vs. 국힘 유정복 37.1% 오차범위 밖",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "28-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|28-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "박찬대",
+          "value_raw": "51.2%",
+          "value_min": 51.2,
+          "value_max": 51.2,
+          "value_mid": 51.2,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "유정복",
+          "value_raw": "37.1%",
+          "value_min": 37.1,
+          "value_max": 37.1,
+          "value_mid": 37.1,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://www.newsis.com/view/NISX20260224_0003523855",
+        "title": "조경태 \"입막음 의총…장동혁 지도부 독재 더 심해\" :: 공감언론 뉴시스 ::",
+        "publisher": "뉴시스",
+        "published_at": "2026-02-24T11:22:25+09:00",
+        "raw_text": "조경태 \"입막음 의총…장동혁 지도부 독재 더 심해\" :: 공감언론 뉴시스 :: --> 2026.02.24 (화) 서울 4.4℃ K-Artprice 프라임뉴시스 위클리뉴시스 실시간 정치 국제 경제 금융 산업 IT·바이오 사회 수도권 지방 문화 스포츠 연예 광장 포토 TV뉴시스 제휴 콘텐츠 밀양 산불, 20시간 만에 주불 진화…산불영향구역 143㏊ [속보]삼성전자, 20만원 돌파…사상최고가 [속보]국회 법사위, 與 주도로 전남광주 통합특별법 통과 [속보]SK하이닉스, 장중 100만원 돌파…5%↑ [속보] 중국, 20개 日 기업 수출제한 목록 추가…미쓰비시 등 포함 [속보]코스피, 5900선 재돌파 [속보]이 대통령 \"공론화 거쳐 두달 안에 촉법소년 하향 문제 결정\" [속보]'무기징역' 윤석열, 1심 판결 불복해 항소 [속보]김건희특검, '도이치 주가조작 주포' 이준수 징역 1년6개월 구형 '1억 공천헌금' 강선우, 체포안 통과시 3월 초 영장심사 [속보] 경찰, '김병기 차남 취업 청탁 의혹' 빗썸 본사 등 2곳 압수수색 [속보]대법원, 내일 '사법개혁 3법' 관련 전국 법원장회의 소집 [속보]코스피 0.13% 오른 5853.48 출발 밀양 산불 이틀째, 진화율 70%…\"확산 저지 총력\" [속보]서울 강남 은마아파트 화재 1시간 20분만 완진…1명 사망·3명 부상 [속보]뉴욕 증시, 트럼프發 관세·AI 우려 하락 마감…다우지수 1.66% ↓ 경남 강수량 10~40mm·눈 최대 10cm…산불 진화 '단비' [속보] 英 경찰, 엡스타인 파일 관련 피터 맨델슨 전 주미 대사 체포 [속보] \"유럽의회, 미국과 무역합의 동결\"-AFP --> 정치 정치최신 청와대 국회/정당 국방/외교 북한 행정 지방정가 지방선거 --> 조경태 \"입막음 의총…장동혁 지도부 독재 더 심해\" 등록 2026.02.24 10:54:19 수정 2026.02.24 11:22:25 작게 크게 [서울=뉴시스] 고승민 기자 = 조경태 국민의힘 의원이 27일 서울 여의도 국회에서 열린 농림축산식품해양수산위원회의 수산업협동조합중앙회 등 국정감사에서 질의하고 있다. 2025.10.27. [email protected] [서울=뉴시스]김건민 인턴 기자 = 국민의힘 최다선(6선)인 조경태 의원이 장동혁 당대표를 비롯한 당 지도부를 향해 \"당 지도부에서는 민주주의를 이야기하고 독재를 막아야 된다고 이야기하는데 본인들이 하는 행태는 심하면 심하지 덜하지 않다\"고 직격했다",
+        "raw_hash": "e08b14414601faca96c27aa52a0d08ecfc7d4313f3f823666d5d2001232dccd4"
+      },
+      "region": {
+        "region_code": "11-140",
+        "sido_name": "서울특별시",
+        "sigungu_name": "중구",
+        "admin_level": "sigungu",
+        "parent_region_code": "11-000"
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:기대감에",
+          "name_ko": "기대감에",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:코스피",
+          "name_ko": "코스피",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:진화율",
+          "name_ko": "진화율",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_906321b1cfa7df2a",
+        "survey_name": "조경태 \"입막음 의총…장동혁 지도부 독재 더 심해\" :: 공감언론 뉴시스 ::",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": "2026-02-23",
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "11-140",
+        "office_type": "기초의회",
+        "matchup_id": "20260603|기초의회|11-140",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.3333,
+        "legal_filled_count": 2,
+        "legal_required_count": 6,
+        "date_resolution": "relative_day",
+        "date_inference_mode": "relative_published_at",
+        "date_inference_confidence": 0.95,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "기대감에",
+          "value_raw": "24%",
+          "value_min": 24.0,
+          "value_max": 24.0,
+          "value_mid": 24.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "코스피",
+          "value_raw": "0.13%",
+          "value_min": 0.13,
+          "value_max": 0.13,
+          "value_mid": 0.13,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "진화율",
+          "value_raw": "70%",
+          "value_min": 70.0,
+          "value_max": 70.0,
+          "value_mid": 70.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "진화율",
+          "value_raw": "51%",
+          "value_min": 51.0,
+          "value_max": 51.0,
+          "value_mid": 51.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "진화율",
+          "value_raw": "85%",
+          "value_min": 85.0,
+          "value_max": 85.0,
+          "value_mid": 85.0,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMid0FVX3lxTE90WTBqQ1BTb1dLYm90TUhacW82V2NxZGNMY1VNRGJmdHZ1MWFfOU0xX2I1LXFUUlZuWlNQWXFWRWl4UXBiVTBJYkNJZjRRUXF5TVpvZkJBaVhmU0lDVWtGalp5aDAxUGhKUGZJaTRRVGxzbXNtWkdR0gFmQVVfeXFMT01DbmstNW4zeEU5Tm9CMnpjeElNdUFRa1JYQmdpaGJGQWJLT2NMMndBYTdxV0VNYmhNa2Fyb0t2a0ZtelV0THlidk9GaEpNNV9lZ1JPLTNTaF9iVmxRQnhGTkItbFln",
+        "title": "정원오-오세훈 서울시장 대결… 44%:31%, 40%:36%, 38%:36%",
+        "publisher": "동아일보",
+        "published_at": null,
+        "raw_text": "정원오-오세훈 서울시장 대결… 44%:31%, 40%:36%, 38%:36% - 동아일보 정원오-오세훈 서울시장 대결… 44%:31%, 40%:36%, 38%:36% &nbsp;&nbsp; 동아일보 지방선거 서울시장 여론조사",
+        "raw_hash": "raw_3bc0623f651ff25a"
+      },
+      "region": {
+        "region_code": "11-000",
+        "sido_name": "서울특별시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [],
+      "observation": {
+        "observation_key": "obs_c5fd83f12d656982",
+        "survey_name": "정원오-오세훈 서울시장 대결… 44%:31%, 40%:36%, 38%:36%",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "11-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|11-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": []
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiZkFVX3lxTE9oNUFjcktRS0p1ZENLRHVJdTdiQlZCVkY1T0dOWU55MjBBOUlKU3ZXWGZrVDBqeTlLMDFUUVJmNzc1anJ5VVJDNHdyUjR3TWhmZi1GRkR6WkczRHVpU01jWldPM3pldw",
+        "title": "[6·3 지방선거 여론조사]서울·부산·강원서 여당 '우세'…국정안정론 50%대 중반",
+        "publisher": "이로운넷",
+        "published_at": null,
+        "raw_text": "[6·3 지방선거 여론조사]서울·부산·강원서 여당 '우세'…국정안정론 50%대 중반 - 이로운넷 [6·3 지방선거 여론조사]서울·부산·강원서 여당 '우세'…국정안정론 50%대 중반 &nbsp;&nbsp; 이로운넷 지방선거 서울시장 여론조사",
+        "raw_hash": "raw_72adbb846abfc849"
+      },
+      "region": {
+        "region_code": "11-000",
+        "sido_name": "서울특별시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:국정안정론",
+          "name_ko": "국정안정론",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_d8cd4d8f6a0f22b8",
+        "survey_name": "[6·3 지방선거 여론조사]서울·부산·강원서 여당 '우세'…국정안정론 50%대 중반",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "11-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|11-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "국정안정론",
+          "value_raw": "50%대",
+          "value_min": 50.0,
+          "value_max": 59.0,
+          "value_mid": 54.5,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMiUEFVX3lxTE5ZVmw4S0lqNUl2blhORDJNaDhNYXRuOU5YVjEtbDB2X2JnUFRHaUlLamktTVIwRERxRFRvUU8tZUNJN3BSMHVFWHp3Skl4UTVW",
+        "title": "[속보]서울시장 양자대결 정원오 50.5%·오세훈 40.3% ‘격차 확대’-조원씨앤아이",
+        "publisher": "문화일보",
+        "published_at": null,
+        "raw_text": "[속보]서울시장 양자대결 정원오 50.5%·오세훈 40.3% ‘격차 확대’-조원씨앤아이 - 문화일보 [속보]서울시장 양자대결 정원오 50.5%·오세훈 40.3% ‘격차 확대’-조원씨앤아이 &nbsp;&nbsp; 문화일보 지방선거 서울시장 여론조사",
+        "raw_hash": "raw_085c2021a1b389a8"
+      },
+      "region": {
+        "region_code": "11-000",
+        "sido_name": "서울특별시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:정원오",
+          "name_ko": "정원오",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:오세훈",
+          "name_ko": "오세훈",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_9720c0cca1ab37ca",
+        "survey_name": "[속보]서울시장 양자대결 정원오 50.5%·오세훈 40.3% ‘격차 확대’-조원씨앤아이",
+        "pollster": "조원씨앤아이",
+        "survey_start_date": null,
+        "survey_end_date": null,
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "11-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|11-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": 0.1667,
+        "legal_filled_count": 1,
+        "legal_required_count": 6,
+        "date_resolution": "missing",
+        "date_inference_mode": "published_at_missing",
+        "date_inference_confidence": 0.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "정원오",
+          "value_raw": "50.5%",
+          "value_min": 50.5,
+          "value_max": 50.5,
+          "value_mid": 50.5,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "오세훈",
+          "value_raw": "40.3%",
+          "value_min": 40.3,
+          "value_max": 40.3,
+          "value_mid": 40.3,
+          "is_missing": false
+        }
+      ]
+    }
+  ]
+}

--- a/data/sample_ingest_article_cutoff_filtered.json
+++ b/data/sample_ingest_article_cutoff_filtered.json
@@ -1,0 +1,78 @@
+{
+  "run_type": "manual",
+  "extractor_version": "manual-v1",
+  "llm_model": null,
+  "records": [
+    {
+      "article": {
+        "url": "https://example.com/poll-2026-02-18",
+        "title": "[6·3 지방선거 여론조사] 서울 접전",
+        "publisher": "샘플뉴스",
+        "published_at": "2026-02-18T19:34:00+09:00",
+        "raw_text": "서울시장 가상대결 정원오 40% 오세훈 36%",
+        "raw_hash": "samplehash1"
+      },
+      "region": {
+        "region_code": "11-000",
+        "sido_name": "서울특별시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand-jwo",
+          "name_ko": "정원오",
+          "party_name": "더불어민주당",
+          "gender": "M",
+          "birth_date": "1968-08-12",
+          "job": "구청장",
+          "career_summary": "성동구청장",
+          "election_history": "지방선거 출마"
+        },
+        {
+          "candidate_id": "cand-osh",
+          "name_ko": "오세훈",
+          "party_name": "국민의힘",
+          "gender": "M",
+          "birth_date": "1961-01-04",
+          "job": "서울시장",
+          "career_summary": "서울시장",
+          "election_history": "지방선거 출마"
+        }
+      ],
+      "observation": {
+        "observation_key": "obs-20260218-seoul-mbc",
+        "survey_name": "설 민심 여론조사",
+        "pollster": "MBC",
+        "survey_start_date": "2026-02-16",
+        "survey_end_date": "2026-02-18",
+        "sample_size": 1000,
+        "response_rate": 12.4,
+        "margin_of_error": null,
+        "region_code": "11-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|11-000",
+        "verified": true,
+        "source_grade": "B"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "정원오",
+          "value_raw": "40%"
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "오세훈",
+          "value_raw": "36%"
+        },
+        {
+          "option_type": "presidential_approval",
+          "option_name": "국정안정론",
+          "value_raw": "53~55%"
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/generate_collector_article_cutoff_cleanup_v1.py
+++ b/scripts/generate_collector_article_cutoff_cleanup_v1.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from app.services.cutoff_policy import (
+    ARTICLE_PUBLISHED_AT_CUTOFF_ISO,
+    has_article_source,
+    parse_datetime_like,
+    published_at_cutoff_reason,
+)
+
+DEFAULT_INPUT = "data/sample_ingest.json"
+DEFAULT_FILTERED_OUTPUT = "data/sample_ingest_article_cutoff_filtered.json"
+DEFAULT_REPORT_OUTPUT = "data/collector_article_cutoff_cleanup_v1_report.json"
+
+
+def build_backfill_cleanup_sql(cutoff_iso: str = ARTICLE_PUBLISHED_AT_CUTOFF_ISO) -> dict[str, str]:
+    where_clause = (
+        "((o.source_channel = 'article') OR COALESCE('article' = ANY(o.source_channels), FALSE)) "
+        "AND (a.published_at IS NULL OR a.published_at < %(cutoff)s::timestamptz)"
+    )
+    return {
+        "count_violation_rows": (
+            "SELECT COUNT(*)::int AS violation_count "
+            "FROM poll_observations o LEFT JOIN articles a ON a.id = o.article_id "
+            f"WHERE {where_clause};"
+        ),
+        "delete_poll_observations": (
+            "WITH target AS ("
+            "SELECT o.id FROM poll_observations o "
+            "LEFT JOIN articles a ON a.id = o.article_id "
+            f"WHERE {where_clause}"
+            ") "
+            "DELETE FROM poll_observations o USING target t "
+            "WHERE o.id = t.id;"
+        ),
+        "delete_orphan_articles": (
+            "DELETE FROM articles a "
+            "WHERE (a.published_at IS NULL OR a.published_at < %(cutoff)s::timestamptz) "
+            "AND NOT EXISTS (SELECT 1 FROM poll_observations o WHERE o.article_id = a.id);"
+        ),
+        "cleanup_candidates_article_published_at": (
+            "UPDATE candidates "
+            "SET article_published_at = NULL, updated_at = NOW() "
+            "WHERE article_published_at < %(cutoff)s::timestamptz;"
+        ),
+        "sql_params_example": json.dumps({"cutoff": cutoff_iso}, ensure_ascii=False),
+    }
+
+
+def _is_record_allowed(record: dict[str, Any]) -> tuple[bool, str]:
+    observation = record.get("observation") or {}
+    article = record.get("article") or {}
+    if not has_article_source(
+        source_channel=observation.get("source_channel"),
+        source_channels=observation.get("source_channels"),
+    ):
+        return True, "PASS"
+    reason = published_at_cutoff_reason(article.get("published_at"))
+    return reason == "PASS", reason
+
+
+def apply_article_cutoff(records: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    kept: list[dict[str, Any]] = []
+    rejected: list[dict[str, Any]] = []
+    for record in records:
+        allowed, reason = _is_record_allowed(record)
+        if allowed:
+            kept.append(record)
+            continue
+        parsed_published_at = parse_datetime_like((record.get("article") or {}).get("published_at"))
+        rejected.append(
+            {
+                "observation_key": (record.get("observation") or {}).get("observation_key"),
+                "source_channel": (record.get("observation") or {}).get("source_channel"),
+                "source_channels": (record.get("observation") or {}).get("source_channels"),
+                "published_at": (record.get("article") or {}).get("published_at"),
+                "published_at_kst": (
+                    parsed_published_at.isoformat(timespec="seconds")
+                    if parsed_published_at is not None
+                    else None
+                ),
+                "reason": reason,
+            }
+        )
+    return kept, rejected
+
+
+def generate_cleanup_outputs(
+    *,
+    input_path: str = DEFAULT_INPUT,
+    filtered_output_path: str = DEFAULT_FILTERED_OUTPUT,
+    report_output_path: str = DEFAULT_REPORT_OUTPUT,
+) -> dict[str, Any]:
+    raw_payload = json.loads(Path(input_path).read_text(encoding="utf-8"))
+    records = raw_payload.get("records") or []
+    kept_records, rejected_records = apply_article_cutoff(records)
+
+    filtered_payload = dict(raw_payload)
+    filtered_payload["records"] = kept_records
+    Path(filtered_output_path).write_text(
+        json.dumps(filtered_payload, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    report = {
+        "policy": {
+            "published_at_cutoff_kst": ARTICLE_PUBLISHED_AT_CUTOFF_ISO,
+            "applies_to_source_channel": "article",
+        },
+        "counts": {
+            "input_record_count": len(records),
+            "kept_record_count": len(kept_records),
+            "cutoff_violation_count": len(rejected_records),
+        },
+        "cutoff_violation_preview": rejected_records[:20],
+        "acceptance_checks": {
+            "filtered_payload_has_no_cutoff_violation": len(rejected_records) == 0,
+        },
+        "backfill_cleanup_sql": build_backfill_cleanup_sql(ARTICLE_PUBLISHED_AT_CUTOFF_ISO),
+        "output_paths": {
+            "input": input_path,
+            "filtered_payload": filtered_output_path,
+            "report": report_output_path,
+        },
+    }
+    Path(report_output_path).write_text(
+        json.dumps(report, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return report
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate article cutoff cleanup report and filtered payload")
+    parser.add_argument("--input", default=DEFAULT_INPUT, help="Input ingest payload path")
+    parser.add_argument("--filtered-output", default=DEFAULT_FILTERED_OUTPUT, help="Filtered payload output path")
+    parser.add_argument("--report-output", default=DEFAULT_REPORT_OUTPUT, help="Cleanup report output path")
+    args = parser.parse_args()
+
+    report = generate_cleanup_outputs(
+        input_path=args.input,
+        filtered_output_path=args.filtered_output,
+        report_output_path=args.report_output,
+    )
+    print(
+        json.dumps(
+            {
+                "counts": report["counts"],
+                "acceptance_checks": report["acceptance_checks"],
+                "report": args.report_output,
+                "filtered_payload": args.filtered_output,
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_collector_article_cutoff_cleanup_v1_script.py
+++ b/tests/test_collector_article_cutoff_cleanup_v1_script.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+
+from scripts.generate_collector_article_cutoff_cleanup_v1 import (
+    apply_article_cutoff,
+    build_backfill_cleanup_sql,
+    generate_cleanup_outputs,
+)
+
+
+def test_apply_article_cutoff_rejects_only_records_before_cutoff():
+    records = [
+        {
+            "article": {"published_at": "2025-11-30T23:59:59+09:00"},
+            "observation": {"observation_key": "obs-old", "source_channel": "article", "source_channels": ["article"]},
+        },
+        {
+            "article": {"published_at": None},
+            "observation": {"observation_key": "obs-missing", "source_channel": "article", "source_channels": ["article"]},
+        },
+        {
+            "article": {"published_at": None},
+            "observation": {"observation_key": "obs-nesdc", "source_channel": "nesdc", "source_channels": ["nesdc"]},
+        },
+        {
+            "article": {"published_at": "2025-12-01T00:00:00+09:00"},
+            "observation": {"observation_key": "obs-pass", "source_channel": "article", "source_channels": ["article"]},
+        },
+    ]
+
+    kept, rejected = apply_article_cutoff(records)
+
+    assert len(kept) == 3
+    assert len(rejected) == 1
+    reasons = {row["reason"] for row in rejected}
+    assert reasons == {"PUBLISHED_AT_BEFORE_CUTOFF"}
+
+
+def test_build_backfill_cleanup_sql_contains_cutoff_where_clause():
+    sql = build_backfill_cleanup_sql()
+    assert "poll_observations" in sql["delete_poll_observations"]
+    assert "articles" in sql["delete_orphan_articles"]
+    assert "candidates" in sql["cleanup_candidates_article_published_at"]
+    assert "cutoff" in sql["sql_params_example"]
+
+
+def test_generate_cleanup_outputs_writes_filtered_payload_and_report(tmp_path):
+    input_path = tmp_path / "input.json"
+    filtered_path = tmp_path / "filtered.json"
+    report_path = tmp_path / "report.json"
+    input_payload = {
+        "run_type": "manual",
+        "extractor_version": "manual-v1",
+        "records": [
+            {
+                "article": {"published_at": "2025-11-30T23:59:59+09:00"},
+                "observation": {"observation_key": "obs-old", "source_channel": "article", "source_channels": ["article"]},
+                "options": [],
+            },
+            {
+                "article": {"published_at": "2025-12-01T00:00:00+09:00"},
+                "observation": {"observation_key": "obs-pass", "source_channel": "article", "source_channels": ["article"]},
+                "options": [],
+            },
+        ],
+    }
+    input_path.write_text(json.dumps(input_payload, ensure_ascii=False), encoding="utf-8")
+
+    report = generate_cleanup_outputs(
+        input_path=str(input_path),
+        filtered_output_path=str(filtered_path),
+        report_output_path=str(report_path),
+    )
+
+    assert report["counts"]["input_record_count"] == 2
+    assert report["counts"]["kept_record_count"] == 1
+    assert report["counts"]["cutoff_violation_count"] == 1
+
+    filtered = json.loads(filtered_path.read_text(encoding="utf-8"))
+    assert len(filtered["records"]) == 1
+    assert filtered["records"][0]["observation"]["observation_key"] == "obs-pass"

--- a/tests/test_cutoff_policy.py
+++ b/tests/test_cutoff_policy.py
@@ -1,0 +1,35 @@
+from datetime import datetime, timezone
+
+from app.services.cutoff_policy import (
+    ARTICLE_PUBLISHED_AT_CUTOFF_KST,
+    has_article_source,
+    is_article_published_at_allowed,
+    parse_datetime_like,
+    published_at_cutoff_reason,
+)
+
+
+def test_parse_datetime_like_supports_iso_and_rfc2822():
+    iso = parse_datetime_like("2025-12-01T00:00:00+09:00")
+    rfc = parse_datetime_like("Mon, 01 Dec 2025 00:00:00 +0900")
+
+    assert iso == ARTICLE_PUBLISHED_AT_CUTOFF_KST
+    assert rfc == ARTICLE_PUBLISHED_AT_CUTOFF_KST
+
+
+def test_parse_datetime_like_normalizes_to_kst():
+    parsed = parse_datetime_like(datetime(2025, 11, 30, 15, 0, 0, tzinfo=timezone.utc))
+    assert parsed == ARTICLE_PUBLISHED_AT_CUTOFF_KST
+
+
+def test_cutoff_reason_and_allowance():
+    assert published_at_cutoff_reason(None) == "PASS"
+    assert published_at_cutoff_reason("2025-11-30T23:59:59+09:00") == "PUBLISHED_AT_BEFORE_CUTOFF"
+    assert published_at_cutoff_reason("2025-12-01T00:00:00+09:00") == "PASS"
+    assert is_article_published_at_allowed("2025-12-01T00:00:00+09:00") is True
+
+
+def test_has_article_source_defaults_to_true_without_source_fields():
+    assert has_article_source(None, None) is True
+    assert has_article_source("article", None) is True
+    assert has_article_source("nesdc", ["nesdc"]) is False

--- a/tests/test_discovery_v11.py
+++ b/tests/test_discovery_v11.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 
 from src.pipeline.collector import PollCollector
+from src.pipeline.contracts import Article, stable_id
 from src.pipeline.discovery_v11 import (
     DiscoveryCandidateV11,
     DiscoveryPipelineV11,
@@ -71,3 +72,69 @@ def test_report_payload_contains_v1_vs_v11_delta(tmp_path):
     assert payload["metrics_v1"]["fetch_fail_rate"] == 1.0
     assert payload["metrics_v11"]["fetch_fail_rate"] == 0.0
     assert payload["metrics_comparison"]["fetch_fail_rate_delta"] == -1.0
+
+
+class _StubCollector:
+    user_agent = "stub-agent"
+
+    def __init__(self, published_at: str | None):
+        self.published_at = published_at
+
+    def _canonicalize_url(self, url: str) -> str:
+        return url
+
+    def fetch(self, url: str):
+        return (
+            Article(
+                id=stable_id("art", url),
+                url=url,
+                title="서울시장 여론조사",
+                publisher="테스트",
+                published_at=self.published_at,
+                snippet="서울시장 여론조사",
+                collected_at="2026-02-26T00:00:00+09:00",
+                raw_hash=stable_id("raw", url),
+                raw_text="서울시장 여론조사 결과 42%",
+            ),
+            None,
+        )
+
+    def classify(self, _: str):
+        return "POLL_REPORT", 0.98
+
+
+def _candidate(url: str) -> DiscoveryCandidateV11:
+    return DiscoveryCandidateV11(
+        url=url,
+        resolved_url=url,
+        title="서울시장 여론조사",
+        published_at_raw="Thu, 26 Feb 2026 09:00:00 +0900",
+        query="지방선거 서울시장 여론조사",
+        source_type="publisher_rss",
+        summary="후보 지지율",
+    )
+
+
+def test_run_excludes_article_before_fixed_cutoff(monkeypatch):
+    pipeline = DiscoveryPipelineV11(_StubCollector("2025-11-30T23:59:59+09:00"))
+    monkeypatch.setattr(pipeline, "_discover_from_publisher_feed", lambda **_: ([_candidate("https://example.com/old")], []))
+    monkeypatch.setattr(pipeline, "_discover_from_google_rss", lambda **_: ([], []))
+
+    result = pipeline.run(target_count=1, per_feed_limit=1)
+
+    assert len(result.valid_candidates) == 0
+    assert len(result.cutoff_excluded_candidates) == 1
+    assert result.metrics()["cutoff_excluded_count"] == 1
+    assert any(x.error_code == "PUBLISHED_AT_BEFORE_CUTOFF" for x in result.review_queue)
+
+
+def test_run_accepts_article_on_or_after_fixed_cutoff(monkeypatch):
+    pipeline = DiscoveryPipelineV11(_StubCollector("2025-12-01T00:00:00+09:00"))
+    monkeypatch.setattr(pipeline, "_discover_from_publisher_feed", lambda **_: ([_candidate("https://example.com/new")], []))
+    monkeypatch.setattr(pipeline, "_discover_from_google_rss", lambda **_: ([], []))
+
+    result = pipeline.run(target_count=1, per_feed_limit=1)
+
+    assert len(result.valid_candidates) == 1
+    assert len(result.cutoff_excluded_candidates) == 0
+    assert result.metrics()["cutoff_excluded_count"] == 0


### PR DESCRIPTION
## 작업 요약
- 고정 정책 단일화: `published_at >= 2025-12-01T00:00:00+09:00`
- discovery 단계 컷오프 게이트 추가 (이전 기사 제외 + review_queue `mapping_error` 라우팅)
- ingest 단계 컷오프 게이트 추가 (article 소스에서 이전 기사 차단 + review_queue `ingestion_error`)
- API 노출 보호 추가 (`summary/map-latest/big-matches/matchup`)
- backfill cleanup SQL 템플릿 + filtered payload/report 산출 스크립트 추가
- Report-Path: `Collector_reports/2026-02-26_s7_article_cutoff_gate_report.md`

## 변경 파일
- `app/services/cutoff_policy.py`
- `src/pipeline/discovery_v11.py`
- `app/services/ingest_service.py`
- `app/api/routes.py`
- `scripts/generate_collector_article_cutoff_cleanup_v1.py`
- `Collector_reports/2026-02-26_s7_article_cutoff_gate_report.md`

## 산출물
- `data/collector_article_cutoff_cleanup_v1_report.json`
- `data/collector_article_cutoff_cleanup_v1_report_live30.json`
- `data/sample_ingest_article_cutoff_filtered.json`
- `data/collector_live_news_v1_payload_30_article_cutoff_filtered.json`

## 테스트
- `PYTHONPATH=. /Users/gimtaehun/election2026_codex/.venv/bin/python -m pytest -q tests/test_cutoff_policy.py tests/test_discovery_v11.py tests/test_ingest_service.py tests/test_api_routes.py tests/test_collector_article_cutoff_cleanup_v1_script.py`
- 결과: `33 passed`

## 이슈
- Closes #272
