### PR TITLE
[COLLECTOR][#282] 옵션 타입 분리: 국정평가 vs 선거성격

### DIFF
--- a/Collector_reports/2026-02-26_issue282_option_type_classifier_report.md
+++ b/Collector_reports/2026-02-26_issue282_option_type_classifier_report.md
@@ -1,0 +1,68 @@
+# 2026-02-26 Issue #282 Option Type Classifier Report
+
+## 1. 대상 이슈
+- Issue: #282 `[COLLECTOR][P0] 옵션 타입 엄밀화: 국정평가 vs 선거성격 분류기`
+- URL: https://github.com/iAmSomething/2026-/issues/282
+
+## 2. 구현 요약
+- `presidential_approval` 입력을 정규화 단계에서 분기:
+  - `president_job_approval`: 대통령 직무/국정수행 평가 신호
+  - `election_frame`: 국정안정/정부견제/선거성격 신호
+- 모호 문항은 자동 분류하지 않고 `needs_manual_review=true`로 유지.
+- ingest 단계에서 모호 문항을 `review_queue(issue_type=mapping_error)`로 자동 라우팅.
+- 대시보드 요약 쿼리는 신/구 타입을 모두 조회하도록 확장.
+- API 요약 응답은 신타입(`president_job_approval`, `election_frame`)을 우선 반영하고, `presidential_approval`는 deprecated 호환 필드로 유지.
+
+## 3. 변경 파일
+- 코드
+  - `app/services/ingest_input_normalization.py`
+  - `app/services/ingest_service.py`
+  - `app/services/repository.py`
+  - `app/api/routes.py`
+  - `scripts/generate_collector_live_coverage_v2_pack.py`
+- 테스트
+  - `tests/test_normalize_ingest_payload_for_schedule.py`
+  - `tests/test_ingest_service.py`
+  - `tests/test_api_routes.py`
+  - `tests/test_collector_live_coverage_v2_pack_script.py`
+- 데이터 샘플/아티팩트
+  - `data/sample_ingest.json`
+  - `data/sample_ingest_article_cutoff_filtered.json`
+  - `data/collector_freshness_hotfix_v1_payload.json`
+  - `data/collector_live_coverage_v2_payload.json`
+  - `data/collector_live_coverage_v2_report.json`
+
+## 4. 검증 결과
+- 실행:
+  - `PYTHONPATH=. /Users/gimtaehun/election2026_codex/.venv/bin/pytest -q tests/test_normalize_ingest_payload_for_schedule.py tests/test_ingest_service.py tests/test_repository_dashboard_summary_scope.py tests/test_collector_live_coverage_v2_pack_script.py`
+  - `PYTHONPATH=. /Users/gimtaehun/election2026_codex/.venv/bin/pytest -q tests/test_api_routes.py`
+  - `PYTHONPATH=. /Users/gimtaehun/election2026_codex/.venv/bin/pytest -q tests/test_ingest_adapter.py`
+- 결과:
+  - `18 passed`
+  - `15 passed`
+  - `1 passed`
+
+## 5. 산출물 상태
+- `collector_live_coverage_v2_report.json` 기준:
+  - `option_type_counts.party_support = 2`
+  - `option_type_counts.election_frame = 2`
+  - `option_type_counts.presidential_approval = 0`
+  - `acceptance_checks` 전체 `true`
+
+## 6. 수용 기준 대비
+1. 동일 기사에서 국정평가 문항/선거성격 문항 분리 저장
+- 충족: 분류 규칙 코드 반영 + ingest/API 테스트 추가
+
+2. `국정안정론/국정견제론`가 `president_job_approval`로 저장되지 않음
+- 충족: 샘플/아티팩트 `election_frame` 전환 확인
+
+3. 모호 문항은 수동검토 라우팅
+- 충족: `needs_manual_review=true` + `review_queue(issue_type=mapping_error)` 테스트 검증
+
+## 7. 의사결정 필요사항
+1. `presidential_approval` deprecated 필드 제거 시점 확정 필요
+- 현재는 API 하위호환을 위해 유지했습니다.
+- 제거 릴리즈(버전/날짜) 확정 시, QA/스크립트(`smoke`, `contract suite`) 키셋도 함께 정리 가능합니다.
+
+2. 이슈 본문의 `collector_summary_nonempty_*` 보정 파일 반영 범위 확인 필요
+- 현재 `#282` 브랜치에는 해당 파일이 존재하지 않아, 동일 계열의 active 샘플/운영 payload(`sample_ingest*`, `collector_live_coverage_v2_payload`, `collector_freshness_hotfix_v1_payload`)를 우선 정리했습니다.

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -254,6 +254,10 @@ def get_dashboard_summary(
         )
         if row["option_type"] == "party_support":
             party_support.append(point)
+        elif row["option_type"] == "president_job_approval":
+            president_job_approval.append(point)
+        elif row["option_type"] == "election_frame":
+            election_frame.append(point)
         elif row["option_type"] == "presidential_approval":
             bucket = _classify_presidential_option(point.option_name)
             if bucket == "president_job_approval":
@@ -261,13 +265,15 @@ def get_dashboard_summary(
             else:
                 election_frame.append(point)
 
+    deprecated_presidential_approval = list(president_job_approval)
+
     return DashboardSummaryOut(
         as_of=as_of,
         data_source=_derive_dashboard_data_source(eligible_rows),
         party_support=party_support,
         president_job_approval=president_job_approval,
         election_frame=election_frame,
-        presidential_approval=president_job_approval,
+        presidential_approval=deprecated_presidential_approval,
         presidential_approval_deprecated=True,
         scope_breakdown=ScopeBreakdownOut(**_build_scope_breakdown(eligible_rows)),
     )

--- a/app/services/ingest_input_normalization.py
+++ b/app/services/ingest_input_normalization.py
@@ -7,6 +7,30 @@ ALLOWED_PARTY_INFERENCE_SOURCES = {"name_rule", "article_context", "manual"}
 TRUE_TOKENS = {"1", "true", "yes", "y", "on"}
 FALSE_TOKENS = {"0", "false", "no", "n", "off"}
 MISSING_TOKENS = {"", "-", "na", "n/a", "none", "null", "미기재", "미상", "unknown"}
+PRESIDENT_JOB_APPROVAL_KEYWORDS = (
+    "대통령",
+    "국정수행",
+    "국정평가",
+    "직무",
+    "긍정",
+    "부정",
+    "잘한다",
+    "잘못",
+    "못한다",
+)
+ELECTION_FRAME_KEYWORDS = (
+    "선거성격",
+    "국정안정",
+    "국정견제",
+    "안정론",
+    "견제론",
+    "정부견제",
+    "여당힘",
+    "야당견제",
+    "정권교체",
+    "정권재창출",
+    "정권심판",
+)
 AUDIENCE_SCOPE_ALIASES = {
     "national": "national",
     "nation": "national",
@@ -23,6 +47,44 @@ AUDIENCE_SCOPE_ALIASES = {
     "시군구": "local",
     "기초": "local",
 }
+
+
+def _normalized_option_text(*parts: Any) -> str:
+    chunks: list[str] = []
+    for part in parts:
+        if not isinstance(part, str):
+            continue
+        token = re.sub(r"\s+", "", part.strip().lower())
+        if token:
+            chunks.append(token)
+    return " ".join(chunks)
+
+
+def normalize_option_type(
+    option_type: Any,
+    option_name: Any,
+    *,
+    question_text: Any = None,
+) -> tuple[str, bool, str | None]:
+    normalized_type = str(option_type or "").strip().lower()
+    if normalized_type == "candidate":
+        return "candidate", False, None
+    if normalized_type in {"candidate_matchup", "party_support", "president_job_approval", "election_frame"}:
+        return normalized_type, False, None
+    if normalized_type != "presidential_approval":
+        return normalized_type, False, None
+
+    normalized_text = _normalized_option_text(option_name, question_text)
+    has_job_approval_signal = any(keyword in normalized_text for keyword in PRESIDENT_JOB_APPROVAL_KEYWORDS)
+    has_election_frame_signal = any(keyword in normalized_text for keyword in ELECTION_FRAME_KEYWORDS)
+
+    if has_job_approval_signal and not has_election_frame_signal:
+        return "president_job_approval", False, None
+    if has_election_frame_signal and not has_job_approval_signal:
+        return "election_frame", False, None
+    if has_job_approval_signal and has_election_frame_signal:
+        return "presidential_approval", True, "AMBIGUOUS_OPTION_TYPE_SIGNAL"
+    return "presidential_approval", True, "UNCLASSIFIED_PRESIDENTIAL_OPTION"
 
 
 def _normalize_party_inferred(value: Any, party_name: str | None) -> bool:
@@ -115,6 +177,16 @@ def normalize_candidate_fields(candidate: dict[str, Any]) -> dict[str, Any]:
 
 
 def normalize_option_fields(option: dict[str, Any]) -> dict[str, Any]:
+    normalized_option_type, needs_manual_review, reason = normalize_option_type(
+        option.get("option_type"),
+        option.get("option_name"),
+        question_text=option.get("question_text") or option.get("evidence_text"),
+    )
+    option["option_type"] = normalized_option_type
+    if needs_manual_review:
+        option["needs_manual_review"] = True
+        option["manual_review_reason"] = reason
+
     option_name = option.get("option_name")
     inferred = _normalize_party_inferred(option.get("party_inferred"), option_name)
     option["party_inferred"] = inferred

--- a/app/services/repository.py
+++ b/app/services/repository.py
@@ -383,7 +383,12 @@ class PostgresRepository:
                     MAX(o.survey_end_date) AS max_date
                 FROM poll_options po
                 JOIN poll_observations o ON o.id = po.observation_id
-                WHERE po.option_type IN ('party_support', 'presidential_approval')
+                WHERE po.option_type IN (
+                    'party_support',
+                    'president_job_approval',
+                    'election_frame',
+                    'presidential_approval'
+                )
                   AND o.verified = TRUE
                   {as_of_filter}
                 GROUP BY po.option_type, o.audience_scope
@@ -409,7 +414,12 @@ class PostgresRepository:
               ON l.option_type = po.option_type
              AND l.max_date = o.survey_end_date
              AND l.audience_scope IS NOT DISTINCT FROM o.audience_scope
-            WHERE po.option_type IN ('party_support', 'presidential_approval')
+            WHERE po.option_type IN (
+                'party_support',
+                'president_job_approval',
+                'election_frame',
+                'presidential_approval'
+            )
             ORDER BY po.option_type, po.option_name
         """
 

--- a/data/collector_freshness_hotfix_v1_payload.json
+++ b/data/collector_freshness_hotfix_v1_payload.json
@@ -97,13 +97,13 @@
       },
       "options": [
         {
-          "option_type": "presidential_approval",
+          "option_type": "election_frame",
           "option_name": "국정안정론",
           "value_raw": "47.0%",
           "is_missing": false
         },
         {
-          "option_type": "presidential_approval",
+          "option_type": "election_frame",
           "option_name": "국정견제론",
           "value_raw": "45.0%",
           "is_missing": false

--- a/data/collector_live_coverage_v2_payload.json
+++ b/data/collector_live_coverage_v2_payload.json
@@ -95,13 +95,13 @@
       },
       "options": [
         {
-          "option_type": "presidential_approval",
+          "option_type": "election_frame",
           "option_name": "국정안정론",
           "value_raw": "47.0%",
           "is_missing": false
         },
         {
-          "option_type": "presidential_approval",
+          "option_type": "election_frame",
           "option_name": "국정견제론",
           "value_raw": "45.0%",
           "is_missing": false

--- a/data/collector_live_coverage_v2_report.json
+++ b/data/collector_live_coverage_v2_report.json
@@ -23,7 +23,7 @@
   },
   "option_type_counts": {
     "party_support": 2,
-    "presidential_approval": 2,
+    "election_frame": 2,
     "candidate_matchup": 58
   },
   "local_candidate_party_fill_rate": 0.28,

--- a/data/sample_ingest.json
+++ b/data/sample_ingest.json
@@ -68,7 +68,7 @@
           "value_raw": "36%"
         },
         {
-          "option_type": "presidential_approval",
+          "option_type": "election_frame",
           "option_name": "국정안정론",
           "value_raw": "53~55%"
         }

--- a/data/sample_ingest_article_cutoff_filtered.json
+++ b/data/sample_ingest_article_cutoff_filtered.json
@@ -68,7 +68,7 @@
           "value_raw": "36%"
         },
         {
-          "option_type": "presidential_approval",
+          "option_type": "election_frame",
           "option_name": "국정안정론",
           "value_raw": "53~55%"
         }

--- a/tests/test_collector_live_coverage_v2_pack_script.py
+++ b/tests/test_collector_live_coverage_v2_pack_script.py
@@ -29,6 +29,8 @@ def test_build_live_coverage_v2_pack_required_meta_and_party_fill() -> None:
         assert obs["margin_of_error"] is not None
 
     assert out["report"]["local_candidate_party_fill_rate"] >= 0.2
+    assert out["report"]["option_type_counts"].get("presidential_approval", 0) == 0
+    assert out["report"]["option_type_counts"].get("election_frame", 0) >= 1
 
 
 def test_build_live_coverage_v2_pack_idempotent_for_fixed_date() -> None:


### PR DESCRIPTION
## Summary
- split presidential_approval into president_job_approval and election_frame in ingest normalization
- keep ambiguous options as manual-review and route to review_queue(issue_type=mapping_error)
- expand dashboard summary query to read both new and legacy option types
- preserve API backward compatibility via deprecated presidential_approval field
- sanitize contaminated sample payload artifacts to remove frame->job contamination

## Linked Issue
- Closes #282

## Report-Path
Report-Path: Collector_reports/2026-02-26_issue282_option_type_classifier_report.md

## Test
- PYTHONPATH=. /Users/gimtaehun/election2026_codex/.venv/bin/pytest -q tests/test_normalize_ingest_payload_for_schedule.py tests/test_ingest_service.py tests/test_repository_dashboard_summary_scope.py tests/test_collector_live_coverage_v2_pack_script.py
- PYTHONPATH=. /Users/gimtaehun/election2026_codex/.venv/bin/pytest -q tests/test_api_routes.py
- PYTHONPATH=. /Users/gimtaehun/election2026_codex/.venv/bin/pytest -q tests/test_ingest_adapter.py
