### PR TITLE
[COLLECTOR][#283] CommonCodeService 전수 동기화 강화

### DIFF
--- a/Collector_reports/2026-02-26_issue283_commoncode_master_sync_report.md
+++ b/Collector_reports/2026-02-26_issue283_commoncode_master_sync_report.md
@@ -1,0 +1,68 @@
+# 2026-02-26 Issue #283 CommonCodeService Master Sync Report
+
+## 1. 대상 이슈
+- Issue: #283 `[COLLECTOR][P0] CommonCodeService 전수 동기화: 선거구 마스터 구축`
+- URL: https://github.com/iAmSomething/2026-/issues/283
+
+## 2. 구현 요약
+- `CommonCodeService` 수집을 단일 페이지에서 다중 페이지 전수 수집으로 확장.
+  - `totalCount` + `numOfRows` 기반 페이지 순회.
+  - XML/JSON 모두 `totalCount` 파싱 지원.
+- code sync 스크립트에 기존 `regions` 대비 diff 계산 추가.
+  - `added_count`, `updated_count`, `unchanged_count`, `delete_candidate_count` 산출.
+- DB upsert를 변경건 중심으로 실행하도록 조정.
+  - 기존과 동일한 행은 upsert 생략.
+- 동기화 실패 시 `review_queue(issue_type=code_sync_error)` 자동 기록.
+  - `entity_type=code_sync_job`, `entity_id=common_codes_region_sync`.
+- sync 리포트 확장.
+  - `status`, `executed_at`, `diff.*`, `sample` 포함.
+
+## 3. 변경 파일
+- 코드
+  - `app/services/data_go_common_codes.py`
+  - `scripts/sync_common_codes.py`
+- 테스트
+  - `tests/test_sync_common_codes.py`
+  - `tests/test_sync_common_codes_script.py` (신규)
+- 문서
+  - `docs/04_DEPLOYMENT_AND_ENVIRONMENT.md`
+  - `docs/06_COLLECTOR_CONTRACTS.md`
+
+## 4. 검증 결과
+- 실행:
+  - `PYTHONPATH=. /Users/gimtaehun/election2026_codex/.venv/bin/pytest -q tests/test_sync_common_codes.py tests/test_sync_common_codes_script.py`
+  - `PYTHONPATH=. /Users/gimtaehun/election2026_codex/.venv/bin/pytest -q tests/test_repository_region_search_hardening.py tests/test_api_routes.py`
+  - `/Users/gimtaehun/election2026_codex/.venv/bin/python -m py_compile app/services/data_go_common_codes.py scripts/sync_common_codes.py`
+- 결과:
+  - `6 passed`
+  - `16 passed`
+  - `py_compile success`
+
+## 5. 수용 기준 대비
+1. CommonCodeService 기준 전수 반영(누락 0)
+- 충족 방향 반영: 페이지네이션 전수 수집 구현 완료.
+- 실제 누락 0은 운영 endpoint로 1회 sync 실행 후 `parsed_region_count`/DB 총건수 대조 필요.
+
+2. 지역 데이터가 없어도 `/regions/search` 결과 반환
+- 유지 충족: `regions` 마스터 기반 검색 구조 유지(`has_data`, `matchup_count` 보조필드).
+
+3. 회귀 테스트: 한글 질의(서울/연수/시흥) 200
+- 기존 API/검색 회귀 테스트 패스.
+- 운영 환경에서 `서울/연수/시흥` 3종 smoke는 QA gate에서 최종 확인 필요.
+
+4. code sync 리포트 생성(총건수/추가/수정/삭제 후보)
+- 충족: `data/common_codes_sync_report.json`에 `diff` 포함.
+
+5. 동기화 실패 시 review_queue `code_sync_error`
+- 충족: 스크립트 실패 핸들러에서 자동 기록.
+
+## 6. 의사결정 필요사항
+1. 운영 스케줄 확정 필요
+- 최소 1일 1회 요구사항 기준으로, 배치 스케줄러(예: cron/GitHub Actions/별도 job runner) 최종 선택 필요.
+
+2. 삭제 후보(`delete_candidate_count`) 적용 정책 확정 필요
+- 현재는 보고서에 후보로만 산출하며 자동 삭제는 수행하지 않음.
+- 자동 삭제 허용 여부(및 보호 룰: n회 연속 미검출 시 삭제 등) 결정 필요.
+
+3. endpoint 운영 구성 확정 필요
+- `COMMON_CODE_REGION_URL` 단일 endpoint 운영 vs `COMMON_CODE_SIGUNGU_URL` 분리 운영 확정 필요.

--- a/docs/04_DEPLOYMENT_AND_ENVIRONMENT.md
+++ b/docs/04_DEPLOYMENT_AND_ENVIRONMENT.md
@@ -57,15 +57,20 @@ pip install -r requirements.txt
 2. 권장 환경변수:
 - `DATA_GO_KR_KEY`
 - `COMMON_CODE_REGION_URL`
+- `COMMON_CODE_SIGUNGU_URL` (선택: 시군구 분리 endpoint 사용 시)
 - `COMMON_CODE_PARTY_URL`
 - `COMMON_CODE_ELECTION_URL`
 3. 실행 예시:
 ```bash
 PYTHONPATH=. .venv/bin/python scripts/sync_common_codes.py \
   --region-url "$COMMON_CODE_REGION_URL" \
+  --region-sigungu-url "$COMMON_CODE_SIGUNGU_URL" \
   --party-url "$COMMON_CODE_PARTY_URL" \
   --election-url "$COMMON_CODE_ELECTION_URL"
 ```
+4. 산출 리포트: `data/common_codes_sync_report.json`
+- `diff.added_count`, `diff.updated_count`, `diff.delete_candidate_count` 포함
+- 실패 시 `status=failed` + `review_queue(issue_type=code_sync_error)` 기록
 
 ### 선택
 1. `WinnerInfoInqireService2`

--- a/docs/06_COLLECTOR_CONTRACTS.md
+++ b/docs/06_COLLECTOR_CONTRACTS.md
@@ -112,9 +112,14 @@ PYTHONPATH=. .venv/bin/python scripts/evaluate_collector_real_precision.py
 ```bash
 PYTHONPATH=. .venv/bin/python scripts/sync_common_codes.py \
   --region-url "$COMMON_CODE_REGION_URL" \
+  --region-sigungu-url "$COMMON_CODE_SIGUNGU_URL" \
   --party-url "$COMMON_CODE_PARTY_URL" \
   --election-url "$COMMON_CODE_ELECTION_URL"
 ```
+- 동기화 리포트: `data/common_codes_sync_report.json`
+  - `parsed_region_count`, `upserted_region_count`
+  - `diff.added_count`, `diff.updated_count`, `diff.delete_candidate_count`
+- 동기화 실패 시 `review_queue`에 `issue_type=code_sync_error` 기록
 
 5. discovery v1 실행(후속 classify 입력 생성):
 ```bash

--- a/scripts/sync_common_codes.py
+++ b/scripts/sync_common_codes.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import argparse
+from datetime import datetime, timezone
 import json
 import os
 import sys
 from pathlib import Path
+from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
@@ -52,7 +54,7 @@ def _build_service(endpoint_url: str, args: argparse.Namespace) -> DataGoCommonC
 def _fetch_rows(args: argparse.Namespace) -> list[dict]:
     service_key = os.getenv("DATA_GO_KR_KEY", "").strip()
     if not service_key:
-        raise SystemExit("[FAIL] DATA_GO_KR_KEY is empty. Set env and retry.")
+        raise RuntimeError("DATA_GO_KR_KEY is empty. Set env and retry.")
 
     main_service = _build_service(args.region_url, args)
     main_items = main_service.fetch_items()
@@ -65,39 +67,159 @@ def _fetch_rows(args: argparse.Namespace) -> list[dict]:
     return build_region_rows([*main_items, *sigungu_items])
 
 
+def _load_existing_regions(repo: PostgresRepository) -> list[dict[str, Any]]:
+    with repo.conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT region_code, sido_name, sigungu_name, admin_level, parent_region_code
+            FROM regions
+            """
+        )
+        rows = cur.fetchall() or []
+    return [dict(row) for row in rows]
+
+
+def _compute_region_diff(existing_rows: list[dict[str, Any]], fetched_rows: list[dict[str, Any]]) -> dict[str, Any]:
+    existing_map = {str(row["region_code"]): row for row in existing_rows}
+    fetched_map = {str(row["region_code"]): row for row in fetched_rows}
+
+    added: list[str] = []
+    updated: list[str] = []
+    unchanged: list[str] = []
+    delete_candidates: list[str] = []
+
+    for code, row in fetched_map.items():
+        prev = existing_map.get(code)
+        if prev is None:
+            added.append(code)
+            continue
+        if not _region_rows_equal(prev, row):
+            updated.append(code)
+        else:
+            unchanged.append(code)
+
+    for code in existing_map:
+        if code not in fetched_map:
+            delete_candidates.append(code)
+
+    return {
+        "existing_total": len(existing_map),
+        "fetched_total": len(fetched_map),
+        "added_count": len(added),
+        "updated_count": len(updated),
+        "unchanged_count": len(unchanged),
+        "delete_candidate_count": len(delete_candidates),
+        "added_sample": sorted(added)[:20],
+        "updated_sample": sorted(updated)[:20],
+        "delete_candidate_sample": sorted(delete_candidates)[:20],
+    }
+
+
+def _region_rows_equal(existing: dict[str, Any], incoming: dict[str, Any]) -> bool:
+    for field in ("sido_name", "sigungu_name", "admin_level", "parent_region_code"):
+        if (existing.get(field) or None) != (incoming.get(field) or None):
+            return False
+    return True
+
+
+def _record_sync_error(args: argparse.Namespace, error: Exception) -> None:
+    try:
+        with get_connection() as conn:
+            repo = PostgresRepository(conn)
+            repo.insert_review_queue(
+                entity_type="code_sync_job",
+                entity_id="common_codes_region_sync",
+                issue_type="code_sync_error",
+                review_note=(
+                    f"{error.__class__.__name__}: {error} "
+                    f"(region_url={args.region_url}, region_sigungu_url={args.region_sigungu_url})"
+                )[:2000],
+            )
+    except Exception:
+        pass
+
+
 def _write_report(report_path: str, payload: dict) -> None:
     path = Path(report_path)
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
 
 
 def main() -> None:
     args = parse_args()
-    rows = _fetch_rows(args)
+    try:
+        rows = _fetch_rows(args)
+        if not rows:
+            raise RuntimeError("No region rows parsed from CommonCodeService response.")
 
-    if not rows:
-        raise SystemExit("[FAIL] No region rows parsed from CommonCodeService response.")
+        upserted = 0
+        diff = {
+            "existing_total": 0,
+            "fetched_total": len(rows),
+            "added_count": len(rows),
+            "updated_count": 0,
+            "unchanged_count": 0,
+            "delete_candidate_count": 0,
+            "added_sample": [row["region_code"] for row in rows[:20]],
+            "updated_sample": [],
+            "delete_candidate_sample": [],
+        }
+        if args.dry_run:
+            try:
+                with get_connection() as conn:
+                    repo = PostgresRepository(conn)
+                    existing_rows = _load_existing_regions(repo)
+                    diff = _compute_region_diff(existing_rows=existing_rows, fetched_rows=rows)
+            except Exception as exc:
+                diff["warning"] = f"dry_run without DB diff: {exc.__class__.__name__}: {exc}"
+        else:
+            with get_connection() as conn:
+                repo = PostgresRepository(conn)
+                existing_rows = _load_existing_regions(repo)
+                diff = _compute_region_diff(existing_rows=existing_rows, fetched_rows=rows)
+                existing_map = {str(row["region_code"]): row for row in existing_rows}
+                changed_codes = {
+                    row["region_code"]
+                    for row in rows
+                    if str(row["region_code"]) not in existing_map
+                    or not _region_rows_equal(existing_map[str(row["region_code"])], row)
+                }
+                for row in rows:
+                    if row["region_code"] not in changed_codes:
+                        continue
+                    repo.upsert_region(row)
+                    upserted += 1
 
-    upserted = 0
-    if not args.dry_run:
-        with get_connection() as conn:
-            repo = PostgresRepository(conn)
-            for row in rows:
-                repo.upsert_region(row)
-                upserted += 1
-
-    report = {
-        "region_url": args.region_url,
-        "region_sigungu_url": args.region_sigungu_url,
-        "party_url": args.party_url,
-        "election_url": args.election_url,
-        "dry_run": args.dry_run,
-        "parsed_region_count": len(rows),
-        "upserted_region_count": upserted,
-        "sample": rows[:5],
-    }
-    _write_report(args.report_path, report)
-    print(json.dumps(report, ensure_ascii=False, indent=2))
+        report = {
+            "status": "success",
+            "executed_at": datetime.now(timezone.utc).isoformat(),
+            "region_url": args.region_url,
+            "region_sigungu_url": args.region_sigungu_url,
+            "party_url": args.party_url,
+            "election_url": args.election_url,
+            "dry_run": args.dry_run,
+            "parsed_region_count": len(rows),
+            "upserted_region_count": upserted,
+            "diff": diff,
+            "sample": rows[:5],
+        }
+        _write_report(args.report_path, report)
+        print(json.dumps(report, ensure_ascii=False, indent=2))
+    except Exception as exc:
+        _record_sync_error(args, exc)
+        report = {
+            "status": "failed",
+            "executed_at": datetime.now(timezone.utc).isoformat(),
+            "region_url": args.region_url,
+            "region_sigungu_url": args.region_sigungu_url,
+            "party_url": args.party_url,
+            "election_url": args.election_url,
+            "dry_run": args.dry_run,
+            "error": f"{exc.__class__.__name__}: {exc}",
+        }
+        _write_report(args.report_path, report)
+        print(json.dumps(report, ensure_ascii=False, indent=2))
+        raise SystemExit(f"[FAIL] {exc}") from exc
 
 
 if __name__ == "__main__":

--- a/tests/test_sync_common_codes.py
+++ b/tests/test_sync_common_codes.py
@@ -1,4 +1,9 @@
-from app.services.data_go_common_codes import build_region_rows, normalize_region_code
+from app.services.data_go_common_codes import (
+    DataGoCommonCodeConfig,
+    DataGoCommonCodeService,
+    build_region_rows,
+    normalize_region_code,
+)
 
 
 def test_normalize_region_code_accepts_major_formats():
@@ -29,3 +34,58 @@ def test_build_region_rows_parses_sido_and_sigungu_with_parent_link():
     assert as_map["11-110"]["parent_region_code"] == "11-000"
     assert as_map["26-710"]["sido_name"] == "부산광역시"
     assert as_map["26-710"]["parent_region_code"] == "26-000"
+
+
+def test_service_fetch_items_uses_total_count_for_pagination():
+    class _FakeService(DataGoCommonCodeService):
+        def __init__(self):
+            super().__init__(
+                DataGoCommonCodeConfig(
+                    endpoint_url="https://example.com/api",
+                    service_key="k",
+                    num_of_rows=2,
+                )
+            )
+            self.calls: list[int] = []
+
+        def _wait_for_rate_limit(self) -> None:
+            return None
+
+        def _fetch_once(self, *, page_no: int):  # type: ignore[override]
+            self.calls.append(page_no)
+            if page_no == 1:
+                return ([{"regionCode": "11-000"}, {"regionCode": "26-000"}], 3)
+            if page_no == 2:
+                return ([{"regionCode": "11-110"}], 3)
+            return ([], 3)
+
+    service = _FakeService()
+    out = service.fetch_items()
+
+    assert service.calls == [1, 2]
+    assert len(out) == 3
+
+
+def test_parse_xml_items_reads_total_count():
+    service = DataGoCommonCodeService(
+        DataGoCommonCodeConfig(
+            endpoint_url="https://example.com/api",
+            service_key="k",
+        )
+    )
+    xml = """
+    <response>
+      <header><resultCode>00</resultCode><resultMsg>NORMAL SERVICE.</resultMsg></header>
+      <body>
+        <totalCount>2</totalCount>
+        <items>
+          <item><ctprvnCd>11</ctprvnCd><ctprvnNm>서울특별시</ctprvnNm></item>
+          <item><ctprvnCd>26</ctprvnCd><ctprvnNm>부산광역시</ctprvnNm></item>
+        </items>
+      </body>
+    </response>
+    """
+    items, total_count = service._parse_xml_items(xml)
+
+    assert len(items) == 2
+    assert total_count == 2

--- a/tests/test_sync_common_codes_script.py
+++ b/tests/test_sync_common_codes_script.py
@@ -1,0 +1,83 @@
+from types import SimpleNamespace
+
+import scripts.sync_common_codes as sync_script
+
+
+def test_compute_region_diff_reports_add_update_delete_candidates():
+    existing_rows = [
+        {
+            "region_code": "11-000",
+            "sido_name": "서울특별시",
+            "sigungu_name": "전체",
+            "admin_level": "sido",
+            "parent_region_code": None,
+        },
+        {
+            "region_code": "11-110",
+            "sido_name": "서울특별시",
+            "sigungu_name": "종로구",
+            "admin_level": "sigungu",
+            "parent_region_code": "11-000",
+        },
+    ]
+    fetched_rows = [
+        {
+            "region_code": "11-000",
+            "sido_name": "서울특별시",
+            "sigungu_name": "전체",
+            "admin_level": "sido",
+            "parent_region_code": None,
+        },
+        {
+            "region_code": "11-110",
+            "sido_name": "서울특별시",
+            "sigungu_name": "종로구(개정)",
+            "admin_level": "sigungu",
+            "parent_region_code": "11-000",
+        },
+        {
+            "region_code": "26-000",
+            "sido_name": "부산광역시",
+            "sigungu_name": "전체",
+            "admin_level": "sido",
+            "parent_region_code": None,
+        },
+    ]
+
+    diff = sync_script._compute_region_diff(existing_rows=existing_rows, fetched_rows=fetched_rows)
+
+    assert diff["existing_total"] == 2
+    assert diff["fetched_total"] == 3
+    assert diff["added_count"] == 1
+    assert diff["updated_count"] == 1
+    assert diff["unchanged_count"] == 1
+    assert diff["delete_candidate_count"] == 0
+
+
+def test_record_sync_error_routes_code_sync_error_to_review_queue(monkeypatch):
+    captured: list[tuple[str, str, str, str]] = []
+
+    class _FakeConn:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):  # noqa: ANN001
+            return False
+
+    class _FakeRepo:
+        def __init__(self, conn):  # noqa: ARG002
+            pass
+
+        def insert_review_queue(self, entity_type, entity_id, issue_type, review_note):
+            captured.append((entity_type, entity_id, issue_type, review_note))
+
+    monkeypatch.setattr(sync_script, "get_connection", lambda: _FakeConn())
+    monkeypatch.setattr(sync_script, "PostgresRepository", _FakeRepo)
+
+    args = SimpleNamespace(region_url="https://region", region_sigungu_url="https://sigungu")
+    sync_script._record_sync_error(args, RuntimeError("forced-failure"))
+
+    assert captured
+    assert captured[0][0] == "code_sync_job"
+    assert captured[0][2] == "code_sync_error"
+    assert "forced-failure" in captured[0][3]


### PR DESCRIPTION
## Summary
- extend CommonCodeService fetch to multi-page full sync using totalCount + pageNo
- add sync diff report for regions master (added/updated/unchanged/delete candidates)
- upsert only changed region rows to reduce unnecessary writes
- route sync failures to review_queue as code_sync_error
- document sync contract updates (region-sigungu endpoint, report fields, failure routing)

## Linked Issue
- Closes #283

## Report-Path
Report-Path: Collector_reports/2026-02-26_issue283_commoncode_master_sync_report.md

## Test
- PYTHONPATH=. /Users/gimtaehun/election2026_codex/.venv/bin/pytest -q tests/test_sync_common_codes.py tests/test_sync_common_codes_script.py
- PYTHONPATH=. /Users/gimtaehun/election2026_codex/.venv/bin/pytest -q tests/test_repository_region_search_hardening.py tests/test_api_routes.py
- /Users/gimtaehun/election2026_codex/.venv/bin/python -m py_compile app/services/data_go_common_codes.py scripts/sync_common_codes.py
