### PR TITLE
[COLLECTOR][P0] 후보명 검증 게이트 v1(Data.go 후보자 매칭)

### DIFF
--- a/Collector_reports/2026-02-26_issue293_candidate_verify_gate_report.md
+++ b/Collector_reports/2026-02-26_issue293_candidate_verify_gate_report.md
@@ -1,0 +1,62 @@
+# 2026-02-26 Issue #293 Candidate Verify Gate v1 Report
+
+## 1. 대상 이슈
+- Issue: #293 `[COLLECTOR][P0] 후보명 검증 게이트 v1(Data.go 후보자 매칭)`
+- URL: https://github.com/iAmSomething/2026-/issues/293
+
+## 2. 구현 요약
+- 후보명 추출 1차 필터 강화:
+  - `오차는`, `응답률은`, `지지율은` 등 비후보 토큰을 후보 추출 단계에서 제외.
+- 후보 검증 2차 게이트 추가:
+  - ingest 시 `option_type in (candidate, candidate_matchup)`만 검증.
+  - Data.go 후보자 API 매칭 성공 시 `candidate_verified=true`, `candidate_verify_source=data_go` 저장.
+  - Data.go 미매칭이지만 기사 후보 목록(`record.candidates`) 매칭 시 `candidate_verify_source=article_context`로 통과.
+- 미검증 후보 라우팅:
+  - 노이즈 토큰/미검증 후보는 `candidate_verified=false`, `needs_manual_review=true`.
+  - `review_queue(issue_type=mapping_error)`로 자동 라우팅.
+- 저장/조회 계약 반영:
+  - `poll_options`에 `candidate_verified`, `candidate_verify_source`, `candidate_verify_confidence` 컬럼 추가.
+  - 후보 랭킹/매치업 조회에서 `candidate_verified=false` 옵션 기본 제외.
+
+## 3. 변경 파일
+- 코드
+  - `src/pipeline/collector.py`
+  - `app/services/ingest_service.py`
+  - `app/services/data_go_candidate.py`
+  - `app/services/ingest_input_normalization.py`
+  - `app/services/repository.py`
+  - `app/models/schemas.py`
+  - `db/schema.sql`
+- 테스트
+  - `tests/test_collector_extract.py`
+  - `tests/test_ingest_service.py`
+  - `tests/test_normalize_ingest_payload_for_schedule.py`
+  - `tests/test_schema_party_inference.py`
+  - `tests/test_bootstrap_ingest.py`
+
+## 4. 검증 결과
+- 실행:
+  - `../election2026_codex/.venv/bin/pytest -q tests/test_ingest_service.py tests/test_collector_extract.py tests/test_schema_party_inference.py tests/test_normalize_ingest_payload_for_schedule.py`
+  - `../election2026_codex/.venv/bin/pytest -q`
+- 결과:
+  - `30 passed`
+  - `173 passed`
+
+## 5. 수용 기준 대비
+1. 비후보 토큰이 matchup 옵션에 0건
+- 충족: 추출기 stopword 강화 + `tests/test_collector_extract.py`에서 `응답률은` 제외 검증.
+
+2. 비정상 옵션(`오차는`, `응답률은`) 재현 시 review_queue 이동
+- 충족: `tests/test_ingest_service.py`에서 `CANDIDATE_TOKEN_NOISE`가 `mapping_error`로 라우팅됨을 검증.
+
+3. 검증 실패 후보 기본 랭킹 제외
+- 충족: `app/services/repository.py` 조회 SQL에 `COALESCE(po.candidate_verified, TRUE) = TRUE` 필터 반영.
+
+## 6. 의사결정 필요사항
+1. `candidate_verify_confidence` 기준선 확정 필요
+- 현재 기본값: `data_go(0.82~0.98)`, `article_context(0.68)`, `manual(0.0/0.2)`.
+- QA/운영에서 사용할 통과 컷(예: 0.7/0.8) 확정이 필요합니다.
+
+2. 비후보 옵션(`party_support`, `election_frame` 등)의 `candidate_verify_source` 표준값 확정 필요
+- 현재는 비후보 옵션을 `candidate_verified=true`, `candidate_verify_source=manual`로 저장합니다.
+- 비후보는 `NULL`로 둘지(의미 분리), 현재처럼 `manual`로 고정할지 정책 확정이 필요합니다.

--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -170,6 +170,9 @@ class MatchupOptionOut(BaseModel):
     party_inferred: bool = False
     party_inference_source: Literal["name_rule", "article_context", "manual"] | None = None
     party_inference_confidence: float | None = None
+    candidate_verified: bool = True
+    candidate_verify_source: Literal["data_go", "article_context", "manual"] | None = None
+    candidate_verify_confidence: float | None = None
     needs_manual_review: bool = False
 
 
@@ -402,6 +405,9 @@ class PollOptionInput(BaseModel):
     party_inferred: bool = False
     party_inference_source: Literal["name_rule", "article_context", "manual"] | None = None
     party_inference_confidence: float | None = None
+    candidate_verified: bool = True
+    candidate_verify_source: Literal["data_go", "article_context", "manual"] | None = None
+    candidate_verify_confidence: float | None = None
     needs_manual_review: bool = False
 
 

--- a/app/services/ingest_service.py
+++ b/app/services/ingest_service.py
@@ -1,5 +1,8 @@
 from dataclasses import dataclass
+import re
+from typing import Any
 
+from app.config import get_settings
 from app.models.schemas import IngestPayload, PollOptionInput
 from app.services.cutoff_policy import (
     ARTICLE_PUBLISHED_AT_CUTOFF_ISO,
@@ -7,12 +10,29 @@ from app.services.cutoff_policy import (
     parse_datetime_like,
     published_at_cutoff_reason,
 )
+from app.services.data_go_candidate import DataGoCandidateConfig, DataGoCandidateService
 from app.services.errors import DuplicateConflictError
 from app.services.fingerprint import build_poll_fingerprint
 from app.services.ingest_input_normalization import normalize_option_type
 from app.services.normalization import normalize_percentage
 
 PARTY_INFERENCE_REVIEW_THRESHOLD = 0.8
+CANDIDATE_NOISE_TOKENS = {
+    "오차는",
+    "응답률은",
+    "지지율은",
+    "오차범위",
+    "표본오차",
+    "응답률",
+    "조사기관",
+    "여론조사",
+    "지지율",
+}
+DEFAULT_SG_TYPECODES = ("3", "4", "5")
+OFFICE_TYPE_TO_SG_TYPECODES = {
+    "광역자치단체장": ("3", "4"),
+    "기초자치단체장": ("4", "3", "5"),
+}
 
 
 @dataclass
@@ -29,6 +49,135 @@ def _infer_election_id(matchup_id: str) -> str:
     if ":" in matchup_id:
         return matchup_id.split(":", 1)[0]
     return "unknown"
+
+
+def _office_type_sg_types(office_type: str | None) -> tuple[str, ...]:
+    return OFFICE_TYPE_TO_SG_TYPECODES.get(office_type or "", DEFAULT_SG_TYPECODES)
+
+
+def _normalize_candidate_token(value: Any) -> str:
+    text = str(value or "").strip().lower()
+    text = re.sub(r"\s+", "", text)
+    return text
+
+
+def _looks_like_noise_candidate(option_name: str) -> bool:
+    token = _normalize_candidate_token(option_name)
+    if not token:
+        return True
+    if token in CANDIDATE_NOISE_TOKENS:
+        return True
+    if any(part in token for part in CANDIDATE_NOISE_TOKENS):
+        return True
+    if any(ch.isdigit() for ch in token):
+        return True
+    if "%" in token:
+        return True
+    if len(token) < 2:
+        return True
+    return False
+
+
+def _resolve_region_names(record) -> tuple[str | None, str | None]:
+    region = getattr(record, "region", None)
+    if region is None:
+        return None, None
+    sd_name = getattr(region, "sido_name", None)
+    sgg_name = getattr(region, "sigungu_name", None)
+    if sgg_name == "전체":
+        sgg_name = None
+    return sd_name, sgg_name
+
+
+def _build_candidate_service(
+    *,
+    record,
+    sg_typecode: str,
+) -> DataGoCandidateService | None:
+    try:
+        settings = get_settings()
+    except Exception:  # noqa: BLE001
+        return None
+
+    election_id = _infer_election_id(record.observation.matchup_id)
+    sd_name, sgg_name = _resolve_region_names(record)
+    cfg = DataGoCandidateConfig(
+        endpoint_url=settings.data_go_candidate_endpoint_url,
+        service_key=settings.data_go_kr_key,
+        sg_id=election_id if election_id != "unknown" else settings.data_go_candidate_sg_id,
+        sg_typecode=sg_typecode,
+        sd_name=sd_name or settings.data_go_candidate_sd_name,
+        sgg_name=sgg_name or settings.data_go_candidate_sgg_name,
+        timeout_sec=settings.data_go_candidate_timeout_sec,
+        max_retries=settings.data_go_candidate_max_retries,
+        cache_ttl_sec=settings.data_go_candidate_cache_ttl_sec,
+        requests_per_sec=settings.data_go_candidate_requests_per_sec,
+        num_of_rows=settings.data_go_candidate_num_of_rows,
+    )
+    service = DataGoCandidateService(cfg)
+    if not service.is_configured():
+        return None
+    return service
+
+
+def _apply_candidate_verification(
+    *,
+    option_payload: dict[str, Any],
+    record,
+    candidate_name_set: set[str],
+    candidate_party_map: dict[str, str | None],
+    service_cache: dict[tuple[str, str | None, str | None, str], DataGoCandidateService | None],
+) -> str | None:
+    option_type = option_payload.get("option_type")
+    if option_type not in {"candidate", "candidate_matchup"}:
+        option_payload["candidate_verified"] = True
+        option_payload["candidate_verify_source"] = "manual"
+        option_payload["candidate_verify_confidence"] = 1.0
+        return None
+
+    option_name = str(option_payload.get("option_name") or "").strip()
+    normalized_name = _normalize_candidate_token(option_name)
+    party_name = candidate_party_map.get(normalized_name)
+
+    if _looks_like_noise_candidate(option_name):
+        option_payload["candidate_verified"] = False
+        option_payload["candidate_verify_source"] = "manual"
+        option_payload["candidate_verify_confidence"] = 0.0
+        option_payload["needs_manual_review"] = True
+        return "CANDIDATE_TOKEN_NOISE"
+
+    sd_name, sgg_name = _resolve_region_names(record)
+    for sg_typecode in _office_type_sg_types(record.observation.office_type):
+        cache_key = (
+            _infer_election_id(record.observation.matchup_id),
+            sd_name,
+            sgg_name,
+            sg_typecode,
+        )
+        service = service_cache.get(cache_key)
+        if cache_key not in service_cache:
+            service = _build_candidate_service(record=record, sg_typecode=sg_typecode)
+            service_cache[cache_key] = service
+        if service is None:
+            continue
+        verified, confidence = service.verify_candidate(candidate_name=option_name, party_name=party_name)
+        if verified:
+            option_payload["candidate_verified"] = True
+            option_payload["candidate_verify_source"] = "data_go"
+            option_payload["candidate_verify_confidence"] = round(float(confidence), 3)
+            return None
+
+    if normalized_name in candidate_name_set:
+        option_payload["candidate_verified"] = True
+        option_payload["candidate_verify_source"] = "article_context"
+        option_payload["candidate_verify_confidence"] = 0.68
+        return None
+
+    option_payload["candidate_verified"] = False
+    option_payload["candidate_verify_source"] = "manual"
+    option_payload["candidate_verify_confidence"] = 0.2
+    option_payload["needs_manual_review"] = True
+    return "CANDIDATE_NOT_VERIFIED"
 
 
 def _normalize_option(option: PollOptionInput) -> tuple[dict, str | None]:
@@ -66,6 +215,7 @@ def ingest_payload(payload: IngestPayload, repo) -> IngestResult:
     error_count = 0
     date_inference_failed_count = 0
     date_inference_estimated_count = 0
+    candidate_service_cache: dict[tuple[str, str | None, str | None, str], DataGoCandidateService | None] = {}
 
     for record in payload.records:
         try:
@@ -134,14 +284,37 @@ def ingest_payload(payload: IngestPayload, repo) -> IngestResult:
                 ingestion_run_id=run_id,
             )
 
+            candidate_name_set = {
+                _normalize_candidate_token(candidate.name_ko)
+                for candidate in record.candidates
+                if _normalize_candidate_token(candidate.name_ko)
+            }
+            candidate_party_map = {
+                _normalize_candidate_token(candidate.name_ko): candidate.party_name
+                for candidate in record.candidates
+                if _normalize_candidate_token(candidate.name_ko)
+            }
+
             party_inference_low_confidence: list[tuple[str, float]] = []
             option_type_manual_review: list[tuple[str, str]] = []
+            candidate_verify_manual_review: list[tuple[str, str]] = []
             for option in record.options:
                 normalized_option, classification_reason = _normalize_option(option)
+                candidate_verify_reason = _apply_candidate_verification(
+                    option_payload=normalized_option,
+                    record=record,
+                    candidate_name_set=candidate_name_set,
+                    candidate_party_map=candidate_party_map,
+                    service_cache=candidate_service_cache,
+                )
                 repo.upsert_poll_option(observation_id, normalized_option)
                 if classification_reason:
                     option_type_manual_review.append(
                         (normalized_option.get("option_name", "unknown"), classification_reason)
+                    )
+                if candidate_verify_reason:
+                    candidate_verify_manual_review.append(
+                        (normalized_option.get("option_name", "unknown"), candidate_verify_reason)
                     )
 
                 confidence = normalized_option.get("party_inference_confidence")
@@ -188,6 +361,17 @@ def ingest_payload(payload: IngestPayload, repo) -> IngestResult:
                         entity_id=record.observation.observation_key,
                         issue_type="mapping_error",
                         review_note=f"option_type manual review required: {detail}",
+                    )
+                except Exception:  # noqa: BLE001
+                    pass
+            if candidate_verify_manual_review:
+                detail = ", ".join(f"{name}:{reason}" for name, reason in candidate_verify_manual_review)
+                try:
+                    repo.insert_review_queue(
+                        entity_type="poll_observation",
+                        entity_id=record.observation.observation_key,
+                        issue_type="mapping_error",
+                        review_note=f"candidate verification manual review required: {detail}",
                     )
                 except Exception:  # noqa: BLE001
                     pass

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -253,6 +253,9 @@ CREATE TABLE IF NOT EXISTS poll_options (
     party_inferred BOOLEAN NOT NULL DEFAULT FALSE,
     party_inference_source TEXT NULL,
     party_inference_confidence FLOAT NULL,
+    candidate_verified BOOLEAN NOT NULL DEFAULT TRUE,
+    candidate_verify_source TEXT NULL,
+    candidate_verify_confidence FLOAT NULL,
     needs_manual_review BOOLEAN NOT NULL DEFAULT FALSE,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
@@ -263,6 +266,9 @@ ALTER TABLE poll_options
     ADD COLUMN IF NOT EXISTS party_inferred BOOLEAN NOT NULL DEFAULT FALSE,
     ADD COLUMN IF NOT EXISTS party_inference_source TEXT NULL,
     ADD COLUMN IF NOT EXISTS party_inference_confidence FLOAT NULL,
+    ADD COLUMN IF NOT EXISTS candidate_verified BOOLEAN NOT NULL DEFAULT TRUE,
+    ADD COLUMN IF NOT EXISTS candidate_verify_source TEXT NULL,
+    ADD COLUMN IF NOT EXISTS candidate_verify_confidence FLOAT NULL,
     ADD COLUMN IF NOT EXISTS needs_manual_review BOOLEAN NOT NULL DEFAULT FALSE;
 
 DO $$
@@ -277,6 +283,23 @@ BEGIN
             CHECK (
                 party_inference_source IS NULL
                 OR party_inference_source IN ('name_rule', 'article_context', 'manual')
+            );
+    END IF;
+END;
+$$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'poll_options_candidate_verify_source_check'
+    ) THEN
+        ALTER TABLE poll_options
+            ADD CONSTRAINT poll_options_candidate_verify_source_check
+            CHECK (
+                candidate_verify_source IS NULL
+                OR candidate_verify_source IN ('data_go', 'article_context', 'manual')
             );
     END IF;
 END;

--- a/src/pipeline/collector.py
+++ b/src/pipeline/collector.py
@@ -72,12 +72,15 @@ class PollCollector:
     _NON_CANDIDATE_TOKENS = {
         "여론조사",
         "응답률",
+        "응답률은",
         "표본",
         "조사기관",
         "조사결과",
         "오차범위",
         "표본오차",
+        "오차는",
         "지지율",
+        "지지율은",
     }
     _CANDIDATE_STOPWORDS = {
         "대통령",
@@ -92,6 +95,9 @@ class PollCollector:
         "비호감",
         "여당",
         "야당",
+        "응답률은",
+        "오차는",
+        "지지율은",
     }
     _BODY_NOISE_MARKERS = (
         "무단전재",

--- a/tests/test_bootstrap_ingest.py
+++ b/tests/test_bootstrap_ingest.py
@@ -81,8 +81,8 @@ def _write_payload(path: Path, *, region_code: str, observation_key: str) -> Non
                 },
                 "options": [
                     {
-                        "option_type": "candidate_matchup",
-                        "option_name": "A",
+                        "option_type": "election_frame",
+                        "option_name": "지지정당없음",
                         "value_raw": "40%",
                     }
                 ],

--- a/tests/test_collector_extract.py
+++ b/tests/test_collector_extract.py
@@ -30,6 +30,15 @@ class CollectorExtractTest(unittest.TestCase):
         self.assertEqual(pairs[1]["name"], "오세훈")
         self.assertEqual(pairs[1]["value_raw"], "37%")
 
+    def test_extract_candidate_pairs_v2_filters_noise_tokens(self) -> None:
+        collector = PollCollector()
+        body = "서울시장 여론조사에서 응답률은 12.3%였고 정원오 41% vs 오세훈 37%였다."
+        pairs = collector.extract_candidate_pairs(body, title="서울시장 조사", mode="v2")
+        names = [row["name"] for row in pairs]
+        self.assertIn("정원오", names)
+        self.assertIn("오세훈", names)
+        self.assertNotIn("응답률은", names)
+
     def test_fetch_success_path(self) -> None:
         collector = PollCollector()
         collector._robots_allowed = lambda _url: True  # type: ignore[method-assign]

--- a/tests/test_normalize_ingest_payload_for_schedule.py
+++ b/tests/test_normalize_ingest_payload_for_schedule.py
@@ -180,3 +180,28 @@ def test_normalize_payload_marks_ambiguous_presidential_option_type_for_manual_r
     option = out["records"][0]["options"][0]
     assert option["option_type"] == "presidential_approval"
     assert option["needs_manual_review"] is True
+
+
+def test_normalize_payload_candidate_verify_fields() -> None:
+    payload = {
+        "records": [
+            {
+                "options": [
+                    {
+                        "option_type": "candidate_matchup",
+                        "option_name": "홍길동",
+                        "value_raw": "47%",
+                        "candidate_verified": "true",
+                        "candidate_verify_source": "external-service",
+                        "candidate_verify_confidence": "0.83",
+                    }
+                ]
+            }
+        ]
+    }
+
+    out = normalize_payload(payload)
+    option = out["records"][0]["options"][0]
+    assert option["candidate_verified"] is True
+    assert option["candidate_verify_source"] == "article_context"
+    assert option["candidate_verify_confidence"] == 0.83

--- a/tests/test_schema_party_inference.py
+++ b/tests/test_schema_party_inference.py
@@ -6,6 +6,9 @@ def test_schema_contains_party_inference_columns() -> None:
     assert "party_inferred BOOLEAN NOT NULL DEFAULT FALSE" in sql
     assert "party_inference_source TEXT NULL" in sql
     assert "party_inference_confidence FLOAT NULL" in sql
+    assert "candidate_verified BOOLEAN NOT NULL DEFAULT TRUE" in sql
+    assert "candidate_verify_source TEXT NULL" in sql
+    assert "candidate_verify_confidence FLOAT NULL" in sql
     assert "needs_manual_review BOOLEAN NOT NULL DEFAULT FALSE" in sql
     assert "ALTER TABLE candidates" in sql
     assert "ADD COLUMN IF NOT EXISTS source_channel TEXT NULL" in sql
@@ -14,3 +17,4 @@ def test_schema_contains_party_inference_columns() -> None:
     assert "ALTER TABLE poll_options" in sql
     assert "ADD COLUMN IF NOT EXISTS party_inferred BOOLEAN NOT NULL DEFAULT FALSE" in sql
     assert "poll_options_party_inference_source_check" in sql
+    assert "poll_options_candidate_verify_source_check" in sql


### PR DESCRIPTION
## Summary
- 후보 옵션 검증 게이트 추가(Data.go 후보자 매칭 + article_context fallback)
- 비후보/노이즈 토큰(오차는/응답률은/지지율은) 필터 강화 및 미검증 review_queue(mapping_error) 라우팅
- `candidate_verified` 계열 필드(DB/스키마/API/정규화) 반영 및 후보 랭킹 기본 조회에서 미검증 옵션 제외
- 관련 테스트 및 Collector 보고서 추가

## Linked Issue
- Closes #293

## Report-Path
Report-Path: Collector_reports/2026-02-26_issue293_candidate_verify_gate_report.md

## Checklist
- [x] docs 계약(필드/API/용어)과 일치
- [x] 테스트 또는 검증 로그 첨부
- [x] 보안 정보(key/secret) 미포함 확인
- [x] Report-Path 파일이 이번 PR에 포함됨

## Validation
- `../election2026_codex/.venv/bin/pytest -q tests/test_ingest_service.py tests/test_collector_extract.py tests/test_schema_party_inference.py tests/test_normalize_ingest_payload_for_schedule.py`
- `../election2026_codex/.venv/bin/pytest -q`
- 결과: 173 passed
