### PR TITLE
[DEVELOP][P0] Matchup candidate-party mapping and scenario split (#291 #292)

### DIFF
--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -165,6 +165,11 @@ class RegionElectionOut(BaseModel):
 
 class MatchupOptionOut(BaseModel):
     option_name: str
+    candidate_id: str | None = None
+    party_name: str | None = None
+    scenario_key: str | None = None
+    scenario_type: Literal["head_to_head", "multi_candidate"] | None = None
+    scenario_title: str | None = None
     value_mid: float | None = None
     value_raw: str | None = None
     party_inferred: bool = False
@@ -174,6 +179,13 @@ class MatchupOptionOut(BaseModel):
     candidate_verify_source: Literal["data_go", "article_context", "manual"] | None = None
     candidate_verify_confidence: float | None = None
     needs_manual_review: bool = False
+
+
+class MatchupScenarioOut(BaseModel):
+    scenario_key: str
+    scenario_type: Literal["head_to_head", "multi_candidate"]
+    scenario_title: str
+    options: list[MatchupOptionOut]
 
 
 class MatchupOut(BaseModel):
@@ -210,6 +222,7 @@ class MatchupOut(BaseModel):
     source_channel: Literal["article", "nesdc"] | None = None
     source_channels: list[Literal["article", "nesdc"]] | None = None
     verified: bool = False
+    scenarios: list[MatchupScenarioOut] = Field(default_factory=list)
     options: list[MatchupOptionOut]
 
 
@@ -397,6 +410,11 @@ class PollObservationInput(BaseModel):
 class PollOptionInput(BaseModel):
     option_type: str
     option_name: str
+    candidate_id: str | None = None
+    party_name: str | None = None
+    scenario_key: str | None = None
+    scenario_type: Literal["head_to_head", "multi_candidate"] | None = None
+    scenario_title: str | None = None
     value_raw: str | None = None
     value_min: float | None = None
     value_max: float | None = None

--- a/app/services/ingest_service.py
+++ b/app/services/ingest_service.py
@@ -182,6 +182,26 @@ def _apply_candidate_verification(
 
 def _normalize_option(option: PollOptionInput) -> tuple[dict, str | None]:
     payload = option.model_dump()
+    scenario_key = payload.get("scenario_key")
+    if isinstance(scenario_key, str):
+        scenario_key = scenario_key.strip()
+    payload["scenario_key"] = scenario_key or "default"
+
+    candidate_id = payload.get("candidate_id")
+    if isinstance(candidate_id, str):
+        candidate_id = candidate_id.strip() or None
+    payload["candidate_id"] = candidate_id
+
+    party_name = payload.get("party_name")
+    if isinstance(party_name, str):
+        party_name = party_name.strip() or None
+    payload["party_name"] = party_name
+
+    scenario_title = payload.get("scenario_title")
+    if isinstance(scenario_title, str):
+        scenario_title = scenario_title.strip() or None
+    payload["scenario_title"] = scenario_title
+
     normalized_option_type, classification_needs_review, classification_reason = normalize_option_type(
         payload.get("option_type"),
         payload.get("option_name"),

--- a/develop_report/2026-02-26_issue291_292_matchup_scenarios_party_mapping_report.md
+++ b/develop_report/2026-02-26_issue291_292_matchup_scenarios_party_mapping_report.md
@@ -1,0 +1,56 @@
+# 2026-02-26 DEVELOP P0 매치업 후보 정당/시나리오 분리 보고서 (#291, #292)
+
+## 1) 작업 범위
+1. #291 `[DEVELOP][P0] 매치업 후보 정당 표시 정확화(후보ID 매핑 + 정당 조인)`
+2. #292 `[DEVELOP][P0] 매치업 상세 시나리오 분리(양자/다자) 데이터모델·API 확장`
+
+## 2) 핵심 변경
+1. `poll_options` 스키마 확장:
+   - `candidate_id`, `party_name`, `scenario_key`, `scenario_type`, `scenario_title` 추가
+   - 유니크 키를 `(observation_id, option_type, option_name, scenario_key)`로 교체
+2. 적재 파이프라인 확장:
+   - `PollOptionInput`/적재 어댑터에 후보/시나리오 필드 전달
+   - 시나리오 키 미입력 시 `scenario_key="default"` 기본값 적용
+3. 매치업 조회 로직 확장 (`GET /api/v1/matchups/{matchup_id}`):
+   - 후보 정당 우선순위 정책 반영: `official(candidates.party_name) > inferred(poll_options.party_name) > unknown(미확정(검수대기))`
+   - `options[]` 외에 `scenarios[]` 응답 구조 추가
+   - 동일 후보의 다중 시나리오 값이 덮어써지지 않도록 시나리오별 분리 반환
+4. 매치업 상세 화면 확장:
+   - 시나리오 섹션(`양자대결/다자대결`) 단위 렌더
+   - 옵션 행에서 `candidate_id` 기반 후보 상세 링크 사용
+   - 정당명(`party_name`) 표시
+
+## 3) 변경 파일
+1. `/Users/gimtaehun/election2026_codex/db/schema.sql`
+2. `/Users/gimtaehun/election2026_codex/app/models/schemas.py`
+3. `/Users/gimtaehun/election2026_codex/app/services/ingest_service.py`
+4. `/Users/gimtaehun/election2026_codex/app/services/repository.py`
+5. `/Users/gimtaehun/election2026_codex/src/pipeline/ingest_adapter.py`
+6. `/Users/gimtaehun/election2026_codex/apps/web/app/matchups/[matchup_id]/page.js`
+7. `/Users/gimtaehun/election2026_codex/tests/test_api_routes.py`
+8. `/Users/gimtaehun/election2026_codex/tests/test_ingest_adapter.py`
+9. `/Users/gimtaehun/election2026_codex/tests/test_ingest_service.py`
+10. `/Users/gimtaehun/election2026_codex/tests/test_repository_matchup_legal_metadata.py`
+11. `/Users/gimtaehun/election2026_codex/tests/test_repository_matchup_scenarios.py` (신규)
+12. `/Users/gimtaehun/election2026_codex/tests/test_schema_party_inference.py`
+
+## 4) 검증
+1. 실행:
+```bash
+/Users/gimtaehun/election2026_codex/.venv/bin/python -m pytest -q
+```
+2. 결과: `170 passed in 2.05s`
+
+## 5) 완료 기준 대비
+1. 후보 식별자 보존 및 API 노출: 완료 (`candidate_id`)
+2. 정당 표시 안정화 및 미확정 표준화: 완료 (`미확정(검수대기)`)
+3. 양자/다자 시나리오 분리 저장·응답: 완료 (`scenarios[]`)
+4. 동일 후보 다중 시나리오 값 비덮어쓰기: 완료 (시나리오 키 기반 유니크/그룹화)
+
+## 6) 의사결정 필요
+1. `options[]` 하위호환 필드 제거 시점 확정 필요
+   - 현재는 기존 클라이언트 호환을 위해 `scenarios[]`와 병행 제공 중.
+2. `scenario_title` 생성 규칙의 단일 표준(collector 단계 선생성 vs API 단계 동적 생성) 확정 필요
+   - 현재는 입력 우선, 미입력 시 API에서 동적 생성.
+3. 후보명 동명이인 대응 정책 확정 필요
+   - 현재는 `candidate_id` 우선 조인, 미지정 시 `option_name` 기반 보조 조인을 수행.

--- a/src/pipeline/ingest_adapter.py
+++ b/src/pipeline/ingest_adapter.py
@@ -109,6 +109,11 @@ def collector_output_to_ingest_payload(
                     {
                         "option_type": _option_type_for_ingest(option["option_type"]),
                         "option_name": option["option_name"],
+                        "candidate_id": option.get("candidate_id"),
+                        "party_name": option.get("party_name"),
+                        "scenario_key": option.get("scenario_key"),
+                        "scenario_type": option.get("scenario_type"),
+                        "scenario_title": option.get("scenario_title"),
                         "value_raw": option["value_raw"],
                         "value_min": option["value_min"],
                         "value_max": option["value_max"],

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -205,6 +205,7 @@ class FakeApiRepo:
                 "source_channel": None,
                 "source_channels": [],
                 "verified": False,
+                "scenarios": [],
                 "options": [],
             }
         return {
@@ -238,9 +239,51 @@ class FakeApiRepo:
             "source_channel": "article",
             "source_channels": ["article", "nesdc"],
             "verified": True,
+            "scenarios": [
+                {
+                    "scenario_key": "h2h-jwo-oh",
+                    "scenario_type": "head_to_head",
+                    "scenario_title": "정원오 vs 오세훈",
+                    "options": [
+                        {
+                            "option_name": "정원오",
+                            "candidate_id": "cand-jwo",
+                            "party_name": "더불어민주당",
+                            "scenario_key": "h2h-jwo-oh",
+                            "scenario_type": "head_to_head",
+                            "scenario_title": "정원오 vs 오세훈",
+                            "value_mid": 44.0,
+                            "value_raw": "44%",
+                            "party_inferred": True,
+                            "party_inference_source": "name_rule",
+                            "party_inference_confidence": 0.86,
+                            "needs_manual_review": False,
+                        },
+                        {
+                            "option_name": "오세훈",
+                            "candidate_id": "cand-oh",
+                            "party_name": "국민의힘",
+                            "scenario_key": "h2h-jwo-oh",
+                            "scenario_type": "head_to_head",
+                            "scenario_title": "정원오 vs 오세훈",
+                            "value_mid": 42.0,
+                            "value_raw": "42%",
+                            "party_inferred": False,
+                            "party_inference_source": None,
+                            "party_inference_confidence": None,
+                            "needs_manual_review": True,
+                        },
+                    ],
+                }
+            ],
             "options": [
                 {
                     "option_name": "정원오",
+                    "candidate_id": "cand-jwo",
+                    "party_name": "더불어민주당",
+                    "scenario_key": "h2h-jwo-oh",
+                    "scenario_type": "head_to_head",
+                    "scenario_title": "정원오 vs 오세훈",
                     "value_mid": 44.0,
                     "value_raw": "44%",
                     "party_inferred": True,
@@ -250,6 +293,11 @@ class FakeApiRepo:
                 },
                 {
                     "option_name": "오세훈",
+                    "candidate_id": "cand-oh",
+                    "party_name": "국민의힘",
+                    "scenario_key": "h2h-jwo-oh",
+                    "scenario_type": "head_to_head",
+                    "scenario_title": "정원오 vs 오세훈",
                     "value_mid": 42.0,
                     "value_raw": "42%",
                     "party_inferred": False,
@@ -585,11 +633,16 @@ def test_api_contract_fields():
     assert matchup.json()["official_release_at"] is not None
     assert matchup.json()["source_channel"] == "article"
     assert matchup.json()["source_channels"] == ["article", "nesdc"]
+    assert matchup.json()["scenarios"][0]["scenario_type"] == "head_to_head"
+    assert matchup.json()["scenarios"][0]["scenario_title"] == "정원오 vs 오세훈"
     assert matchup.json()["options"][0]["party_inferred"] is True
     assert matchup.json()["options"][0]["party_inference_source"] == "name_rule"
     assert matchup.json()["options"][0]["party_inference_confidence"] == 0.86
+    assert matchup.json()["options"][0]["candidate_id"] == "cand-jwo"
+    assert matchup.json()["options"][0]["party_name"] == "더불어민주당"
     assert matchup.json()["options"][0]["needs_manual_review"] is False
     assert matchup.json()["options"][1]["needs_manual_review"] is True
+    assert matchup.json()["options"][1]["candidate_id"] == "cand-oh"
     matchup_alias = client.get("/api/v1/matchups/m_2026_seoul_mayor")
     assert matchup_alias.status_code == 200
     assert matchup_alias.json()["matchup_id"] == "20260603|광역자치단체장|11-000"
@@ -597,6 +650,7 @@ def test_api_contract_fields():
     assert matchup_meta_only.status_code == 200
     assert matchup_meta_only.json()["matchup_id"] == "20260603|기초자치단체장|26-710"
     assert matchup_meta_only.json()["has_data"] is False
+    assert matchup_meta_only.json()["scenarios"] == []
     assert matchup_meta_only.json()["options"] == []
 
     candidate = client.get("/api/v1/candidates/cand-jwo")

--- a/tests/test_ingest_adapter.py
+++ b/tests/test_ingest_adapter.py
@@ -48,3 +48,4 @@ def test_collector_output_converts_to_ingest_payload():
     assert parsed.records[0].observation.source_channel == "article"
     assert parsed.records[0].observation.source_channels == ["article"]
     assert parsed.records[0].observation.date_inference_mode == "relative_published_at"
+    assert parsed.records[0].options[0].candidate_id is not None

--- a/tests/test_ingest_service.py
+++ b/tests/test_ingest_service.py
@@ -126,6 +126,7 @@ def test_idempotent_ingest_no_duplicate_records():
     assert len(repo.options) == 1
     assert repo.option_rows[0]["option_type"] == "election_frame"
     assert repo.option_rows[0]["candidate_verified"] is True
+    assert repo.option_rows[0]["scenario_key"] == "default"
     assert repo.observations["obs-1"]["audience_scope"] == "national"
     assert repo.observations["obs-1"]["legal_filled_count"] == 6
     assert len(repo.observations["obs-1"]["poll_fingerprint"]) == 64

--- a/tests/test_repository_matchup_legal_metadata.py
+++ b/tests/test_repository_matchup_legal_metadata.py
@@ -64,6 +64,11 @@ class _Cursor:
                 "options": [
                     {
                         "option_name": "정원오",
+                        "candidate_id": "cand-jwo",
+                        "party_name": "더불어민주당",
+                        "scenario_key": "default",
+                        "scenario_type": "head_to_head",
+                        "scenario_title": "정원오 vs 오세훈",
                         "value_mid": 44.0,
                         "value_raw": "44%",
                         "party_inferred": True,
@@ -108,5 +113,9 @@ def test_get_matchup_returns_legal_metadata_fields():
     assert out["options"][0]["party_inferred"] is True
     assert out["options"][0]["party_inference_source"] == "name_rule"
     assert out["options"][0]["party_inference_confidence"] == 0.84
+    assert out["options"][0]["candidate_id"] == "cand-jwo"
+    assert out["options"][0]["party_name"] == "더불어민주당"
     assert out["options"][0]["needs_manual_review"] is False
+    assert out["scenarios"][0]["scenario_type"] == "head_to_head"
+    assert out["scenarios"][0]["scenario_title"] == "정원오 vs 오세훈"
     assert len(conn.cur.execs) == 2

--- a/tests/test_repository_matchup_scenarios.py
+++ b/tests/test_repository_matchup_scenarios.py
@@ -1,0 +1,172 @@
+from datetime import date
+
+from app.services.repository import PostgresRepository
+
+
+class _Cursor:
+    def __init__(self):
+        self.execs: list[str] = []
+        self._step = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):  # noqa: ANN001
+        return False
+
+    def execute(self, query, params=None):  # noqa: ARG002
+        self.execs.append(query)
+
+    def fetchone(self):
+        if self._step == 0:
+            self._step += 1
+            return {
+                "matchup_id": "m1",
+                "region_code": "26-000",
+                "office_type": "광역자치단체장",
+                "title": "부산시장 가상대결",
+                "is_active": True,
+            }
+        if self._step == 1:
+            self._step += 1
+            return {
+                "matchup_id": "m1",
+                "region_code": "26-000",
+                "office_type": "광역자치단체장",
+                "title": "부산시장 가상대결",
+                "pollster": "테스트리서치",
+                "survey_start_date": date(2026, 2, 15),
+                "survey_end_date": date(2026, 2, 18),
+                "confidence_level": 95.0,
+                "sample_size": 1000,
+                "response_rate": 12.3,
+                "margin_of_error": 3.1,
+                "source_grade": "B",
+                "audience_scope": "regional",
+                "audience_region_code": "26-000",
+                "sampling_population_text": "부산 거주 만 18세 이상",
+                "legal_completeness_score": 0.86,
+                "legal_filled_count": 6,
+                "legal_required_count": 7,
+                "date_resolution": "exact",
+                "date_inference_mode": "relative_published_at",
+                "date_inference_confidence": 0.92,
+                "observation_updated_at": "2026-02-18T03:00:00+00:00",
+                "official_release_at": None,
+                "article_published_at": "2026-02-18T01:00:00+00:00",
+                "nesdc_enriched": True,
+                "needs_manual_review": False,
+                "poll_fingerprint": "f" * 64,
+                "source_channel": "article",
+                "source_channels": ["article", "nesdc"],
+                "verified": True,
+                "observation_id": 777,
+                "options": [
+                    {
+                        "option_name": "전재수",
+                        "candidate_id": "cand-jjs",
+                        "party_name": None,
+                        "scenario_key": "h2h-a",
+                        "scenario_type": "head_to_head",
+                        "scenario_title": "전재수 vs 박형준",
+                        "value_mid": 43.4,
+                        "value_raw": "43.4%",
+                        "party_inferred": True,
+                        "party_inference_source": "name_rule",
+                        "party_inference_confidence": 0.81,
+                        "needs_manual_review": False,
+                    },
+                    {
+                        "option_name": "박형준",
+                        "candidate_id": "cand-phj",
+                        "party_name": "국민의힘",
+                        "scenario_key": "h2h-a",
+                        "scenario_type": "head_to_head",
+                        "scenario_title": "전재수 vs 박형준",
+                        "value_mid": 32.3,
+                        "value_raw": "32.3%",
+                        "party_inferred": False,
+                        "party_inference_source": None,
+                        "party_inference_confidence": None,
+                        "needs_manual_review": False,
+                    },
+                    {
+                        "option_name": "전재수",
+                        "candidate_id": "cand-jjs",
+                        "party_name": "더불어민주당",
+                        "scenario_key": "h2h-b",
+                        "scenario_type": "head_to_head",
+                        "scenario_title": "전재수 vs 김도읍",
+                        "value_mid": 43.8,
+                        "value_raw": "43.8%",
+                        "party_inferred": False,
+                        "party_inference_source": None,
+                        "party_inference_confidence": None,
+                        "needs_manual_review": False,
+                    },
+                    {
+                        "option_name": "김도읍",
+                        "candidate_id": "cand-kdu",
+                        "party_name": "국민의힘",
+                        "scenario_key": "h2h-b",
+                        "scenario_type": "head_to_head",
+                        "scenario_title": "전재수 vs 김도읍",
+                        "value_mid": 33.2,
+                        "value_raw": "33.2%",
+                        "party_inferred": False,
+                        "party_inference_source": None,
+                        "party_inference_confidence": None,
+                        "needs_manual_review": False,
+                    },
+                    {
+                        "option_name": "전재수",
+                        "candidate_id": "cand-jjs",
+                        "party_name": "더불어민주당",
+                        "scenario_key": "multi-a",
+                        "scenario_type": "multi_candidate",
+                        "scenario_title": "전재수·박형준·김도읍",
+                        "value_mid": 26.8,
+                        "value_raw": "26.8%",
+                        "party_inferred": False,
+                        "party_inference_source": None,
+                        "party_inference_confidence": None,
+                        "needs_manual_review": False,
+                    },
+                ],
+            }
+        return None
+
+
+class _Conn:
+    def __init__(self):
+        self.cur = _Cursor()
+
+    def cursor(self):
+        return self.cur
+
+
+def test_get_matchup_groups_options_by_scenario_without_overwrite():
+    repo = PostgresRepository(_Conn())
+
+    out = repo.get_matchup("m1")
+
+    assert out is not None
+    assert len(out["scenarios"]) == 3
+
+    jeon_values = [
+        option["value_mid"]
+        for scenario in out["scenarios"]
+        for option in scenario["options"]
+        if option["candidate_id"] == "cand-jjs"
+    ]
+    assert sorted(jeon_values) == [26.8, 43.4, 43.8]
+
+    unknown_party_count = sum(
+        1
+        for scenario in out["scenarios"]
+        for option in scenario["options"]
+        if option["party_name"] == "미확정(검수대기)"
+    )
+    assert unknown_party_count == 1
+    assert all(scenario["scenario_type"] in {"head_to_head", "multi_candidate"} for scenario in out["scenarios"])
+    assert len(out["options"]) == 2

--- a/tests/test_schema_party_inference.py
+++ b/tests/test_schema_party_inference.py
@@ -18,3 +18,8 @@ def test_schema_contains_party_inference_columns() -> None:
     assert "ADD COLUMN IF NOT EXISTS party_inferred BOOLEAN NOT NULL DEFAULT FALSE" in sql
     assert "poll_options_party_inference_source_check" in sql
     assert "poll_options_candidate_verify_source_check" in sql
+    assert "ADD COLUMN IF NOT EXISTS candidate_id TEXT NULL" in sql
+    assert "ADD COLUMN IF NOT EXISTS party_name TEXT NULL" in sql
+    assert "ADD COLUMN IF NOT EXISTS scenario_key TEXT NOT NULL DEFAULT 'default'" in sql
+    assert "poll_options_observation_option_scenario_unique" in sql
+    assert "poll_options_scenario_type_check" in sql


### PR DESCRIPTION
## Summary
- add `candidate_id`, `party_name`, `scenario_key`, `scenario_type`, `scenario_title` to matchup option storage and ingest path
- change poll option upsert uniqueness to `(observation_id, option_type, option_name, scenario_key)` to prevent cross-scenario overwrite
- extend matchup API payload with `scenarios[]` while keeping `options[]` compatibility
- apply party resolution priority `official > inferred > unknown(미확정(검수대기))`
- update matchup detail UI to render scenario sections and candidate-id links
- add regression tests for scenario separation and party/candidate fields

## Report-Path
Report-Path: develop_report/2026-02-26_issue291_292_matchup_scenarios_party_mapping_report.md

## Validation
- `/Users/gimtaehun/election2026_codex/.venv/bin/python -m pytest -q`
- `170 passed in 2.05s`

## Linked Issues
- Closes #291
- Closes #292
