### PR TITLE
[COLLECTOR][P1] 후보자 프로필 확장 수집 v1

### DIFF
--- a/Collector_reports/2026-02-26_issue298_candidate_profile_enrichment_report.md
+++ b/Collector_reports/2026-02-26_issue298_candidate_profile_enrichment_report.md
@@ -1,0 +1,72 @@
+# 2026-02-26 Issue #298 Candidate Profile Enrichment v1 Report
+
+## 1. 대상 이슈
+- Issue: #298 `[COLLECTOR][P1] 후보자 프로필 확장 수집 v1(약력/이력/정당/기본속성 충전율 개선)`
+- URL: https://github.com/iAmSomething/2026-/issues/298
+
+## 2. 구현 요약
+- ingest 단계 후보 프로필 enrichment 추가:
+  - 선거/지역 컨텍스트(`election_id`, `office_type`, `sido/sigungu`) 기반 Data.go 후보 API 재사용.
+  - 후보별 `party_name/gender/birth_date/job/career_summary/election_history` 충전 점수가 높은 결과를 채택.
+- 동명이인 최소화 매칭 보강:
+  - `name` 일치 후보들 중 `party/gender/birth/job` 점수 기반으로 최적 후보 선택.
+- profile 필드 추출 규칙 보강:
+  - career 필드 다중 키(`career1..5`, `career`, `majorCareer`) 병합.
+  - election history 필드 다중 키(`electionHistory`, `history`, `his1..3` 등) 우선 추출.
+  - history 키 미존재 시 career 텍스트에서 선거/당선 힌트 기반 보조 추출.
+- 미확정 필드 처리:
+  - `party_name/career_summary/election_history` 미충전 후보는 `null` 유지 +
+    `review_queue(entity_type=candidate, issue_type=mapping_error)`로 라우팅하여 `needs_manual_review`가 노출되도록 반영.
+- 충전율 리포트 자동화:
+  - `scripts/generate_collector_candidate_profile_coverage_v1.py` 추가.
+  - candidates + candidate_profiles 조인 기반 충전율 집계 JSON 생성.
+
+## 3. 변경 파일
+- 코드
+  - `app/services/data_go_candidate.py`
+  - `app/services/ingest_service.py`
+  - `scripts/generate_collector_candidate_profile_coverage_v1.py`
+- 테스트
+  - `tests/test_data_go_candidate_service.py`
+  - `tests/test_ingest_service.py`
+  - `tests/test_collector_candidate_profile_coverage_v1_script.py`
+
+## 4. 검증 결과
+- 실행:
+  - `../election2026_codex/.venv/bin/pytest -q tests/test_data_go_candidate_service.py tests/test_ingest_service.py tests/test_collector_candidate_profile_coverage_v1_script.py`
+  - `../election2026_codex/.venv/bin/pytest -q`
+- 결과:
+  - `21 passed`
+  - `179 passed`
+
+## 5. 수용 기준 대비
+1. Data.go 후보 API 기반 기본속성 충전율 개선
+- 충족: ingest에서 후보 upsert 전 enrichment 수행, `party/gender/birth/job` 자동 충전 경로 반영.
+
+2. 선거/지역 컨텍스트 매칭 정확도 강화
+- 충족: 기존 context fetch(선거/지역) + 동명이인 점수 매칭(`party/gender/birth/job`) 반영.
+
+3. profile 필드(career_summary/election_history) 추출 규칙 보강
+- 충족: 다중 키 추출 + 힌트 기반 보조 추출 + 단위 테스트 추가.
+
+4. 충전율 리포트 자동 생성
+- 충족(코드 기준): 전용 스크립트 추가 및 단위 테스트로 계산/검증 규칙 고정.
+- 운영 실행은 DB/시크릿 환경변수 주입 후 `data/collector_candidate_profile_coverage_v1_report.json` 생성 가능.
+
+5. 미확정 필드 null + needs_manual_review
+- 충족: 미확정 핵심필드 시 review_queue 라우팅으로 candidate API의 `needs_manual_review`가 true 노출되도록 구현.
+
+## 6. 실행 시 참고
+- 충전율 리포트 스크립트 실행:
+  - `PYTHONPATH=. ../election2026_codex/.venv/bin/python scripts/generate_collector_candidate_profile_coverage_v1.py`
+- 필요 환경변수:
+  - `supabase_url`, `supabase_service_role_key`, `data_go_kr_key`, `database_url`
+
+## 7. 의사결정 필요사항
+1. 후보 프로필 미확정 라우팅 임계 기준 확정 필요
+- 현재는 `party_name/career_summary/election_history` 중 하나라도 미확정이면 review_queue 라우팅합니다.
+- 운영 노이즈를 줄이려면 `2개 이상 미확정` 또는 `party_name 미확정일 때만`으로 조정 가능.
+
+2. candidate_profiles `source_type` 표준값 확정 필요
+- 현재 `upsert_candidate`는 `source_type='manual'` 고정입니다.
+- Data.go 기반 입력을 `data_go`로 분리 기록할지 정책 확정이 필요합니다.

--- a/scripts/generate_collector_candidate_profile_coverage_v1.py
+++ b/scripts/generate_collector_candidate_profile_coverage_v1.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+from typing import Any
+
+from app.db import get_connection
+
+
+def _filled(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    return True
+
+
+def compute_candidate_profile_coverage(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    total = len(rows)
+    metrics = {
+        "candidates_total": total,
+        "with_party": 0,
+        "with_gender": 0,
+        "with_birth": 0,
+        "with_job": 0,
+        "with_career_summary": 0,
+        "with_election_history": 0,
+    }
+
+    for row in rows:
+        if _filled(row.get("party_name")):
+            metrics["with_party"] += 1
+        if _filled(row.get("gender")):
+            metrics["with_gender"] += 1
+        if _filled(row.get("birth_date")):
+            metrics["with_birth"] += 1
+        if _filled(row.get("job")):
+            metrics["with_job"] += 1
+        if _filled(row.get("career_summary")):
+            metrics["with_career_summary"] += 1
+        if _filled(row.get("election_history")):
+            metrics["with_election_history"] += 1
+
+    ratios: dict[str, float] = {}
+    if total <= 0:
+        for key in ("party", "gender", "birth", "job", "career_summary", "election_history"):
+            ratios[f"{key}_fill_rate"] = 0.0
+    else:
+        ratios["party_fill_rate"] = round(metrics["with_party"] / total, 4)
+        ratios["gender_fill_rate"] = round(metrics["with_gender"] / total, 4)
+        ratios["birth_fill_rate"] = round(metrics["with_birth"] / total, 4)
+        ratios["job_fill_rate"] = round(metrics["with_job"] / total, 4)
+        ratios["career_summary_fill_rate"] = round(metrics["with_career_summary"] / total, 4)
+        ratios["election_history_fill_rate"] = round(metrics["with_election_history"] / total, 4)
+
+    return {**metrics, **ratios}
+
+
+def fetch_candidate_rows() -> list[dict[str, Any]]:
+    with get_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT
+                    c.candidate_id,
+                    c.party_name,
+                    c.gender,
+                    c.birth_date,
+                    c.job,
+                    cp.career_summary,
+                    cp.election_history
+                FROM candidates c
+                LEFT JOIN candidate_profiles cp ON cp.candidate_id = c.candidate_id
+                ORDER BY c.candidate_id
+                """
+            )
+            return list(cur.fetchall() or [])
+
+
+def build_candidate_profile_coverage_report(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    coverage = compute_candidate_profile_coverage(rows)
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "coverage": coverage,
+        "acceptance_checks": {
+            "counts_non_negative": all(
+                int(coverage[key]) >= 0
+                for key in (
+                    "candidates_total",
+                    "with_party",
+                    "with_gender",
+                    "with_birth",
+                    "with_job",
+                    "with_career_summary",
+                    "with_election_history",
+                )
+            ),
+            "fill_rates_in_range": all(
+                0.0 <= float(coverage[key]) <= 1.0
+                for key in (
+                    "party_fill_rate",
+                    "gender_fill_rate",
+                    "birth_fill_rate",
+                    "job_fill_rate",
+                    "career_summary_fill_rate",
+                    "election_history_fill_rate",
+                )
+            ),
+        },
+    }
+
+
+def main() -> None:
+    rows = fetch_candidate_rows()
+    report = build_candidate_profile_coverage_report(rows)
+    out_path = Path("data/collector_candidate_profile_coverage_v1_report.json")
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(report, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    print(f"written: {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_collector_candidate_profile_coverage_v1_script.py
+++ b/tests/test_collector_candidate_profile_coverage_v1_script.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from scripts.generate_collector_candidate_profile_coverage_v1 import (
+    build_candidate_profile_coverage_report,
+    compute_candidate_profile_coverage,
+)
+
+
+def test_compute_candidate_profile_coverage_counts() -> None:
+    rows = [
+        {
+            "candidate_id": "cand-1",
+            "party_name": "더불어민주당",
+            "gender": "M",
+            "birth_date": "1968-08-12",
+            "job": "정치인",
+            "career_summary": "성동구청장",
+            "election_history": "2018 지방선거 당선",
+        },
+        {
+            "candidate_id": "cand-2",
+            "party_name": None,
+            "gender": None,
+            "birth_date": None,
+            "job": "",
+            "career_summary": " ",
+            "election_history": None,
+        },
+    ]
+
+    out = compute_candidate_profile_coverage(rows)
+
+    assert out["candidates_total"] == 2
+    assert out["with_party"] == 1
+    assert out["with_gender"] == 1
+    assert out["with_birth"] == 1
+    assert out["with_job"] == 1
+    assert out["with_career_summary"] == 1
+    assert out["with_election_history"] == 1
+    assert out["party_fill_rate"] == 0.5
+    assert out["election_history_fill_rate"] == 0.5
+
+
+def test_build_candidate_profile_coverage_report_acceptance_checks() -> None:
+    report = build_candidate_profile_coverage_report([])
+
+    assert report["coverage"]["candidates_total"] == 0
+    assert report["coverage"]["party_fill_rate"] == 0.0
+    assert report["acceptance_checks"]["counts_non_negative"] is True
+    assert report["acceptance_checks"]["fill_rates_in_range"] is True

--- a/tests/test_ingest_service.py
+++ b/tests/test_ingest_service.py
@@ -13,6 +13,7 @@ class FakeRepo:
         self.observations = {}
         self.options = set()
         self.option_rows = []
+        self.candidate_rows = []
         self.review = []
         self.policy_counters = []
 
@@ -30,7 +31,7 @@ class FakeRepo:
         pass
 
     def upsert_candidate(self, candidate):
-        pass
+        self.candidate_rows.append(candidate)
 
     def upsert_article(self, article):
         self.articles[article["url"]] = article
@@ -255,6 +256,9 @@ def test_candidate_noise_token_routes_manual_review_mapping_error():
 
 def test_candidate_data_go_verified_sets_data_go_source(monkeypatch):
     class _FakeVerifier:
+        def enrich_candidate(self, candidate):  # noqa: ANN001
+            return candidate
+
         def verify_candidate(self, *, candidate_name, party_name=None):  # noqa: ARG002
             return (candidate_name == "정원오", 0.97)
 
@@ -283,3 +287,91 @@ def test_candidate_data_go_verified_sets_data_go_source(monkeypatch):
     assert repo.option_rows[0]["candidate_verified"] is True
     assert repo.option_rows[0]["candidate_verify_source"] == "data_go"
     assert float(repo.option_rows[0]["candidate_verify_confidence"]) >= 0.9
+
+
+def test_candidate_profile_enrichment_fills_candidate_fields(monkeypatch):
+    class _FakeService:
+        def enrich_candidate(self, candidate):  # noqa: ANN001
+            out = dict(candidate)
+            out["party_name"] = "더불어민주당"
+            out["gender"] = "M"
+            out["birth_date"] = "1968-08-12"
+            out["job"] = "정치인"
+            out["career_summary"] = "성동구청장"
+            out["election_history"] = "2018 지방선거 당선"
+            return out
+
+        def verify_candidate(self, *, candidate_name, party_name=None):  # noqa: ARG002
+            return (candidate_name == "정원오", 0.98)
+
+    def fake_build_service(*, record, sg_typecode):  # noqa: ARG001
+        return _FakeService()
+
+    monkeypatch.setattr(ingest_service_module, "_build_candidate_service", fake_build_service)
+
+    repo = FakeRepo()
+    payload_data = deepcopy(PAYLOAD)
+    payload_data["records"][0]["candidates"] = [
+        {
+            "candidate_id": "cand-jwo",
+            "name_ko": "정원오",
+            "party_name": None,
+            "gender": None,
+            "birth_date": None,
+            "job": None,
+            "career_summary": None,
+            "election_history": None,
+        }
+    ]
+    payload = IngestPayload.model_validate(payload_data)
+
+    result = ingest_payload(payload, repo)
+
+    assert result.status == "success"
+    assert len(repo.candidate_rows) == 1
+    row = repo.candidate_rows[0]
+    assert row["party_name"] == "더불어민주당"
+    assert row["career_summary"] == "성동구청장"
+    assert row["election_history"] == "2018 지방선거 당선"
+
+
+def test_candidate_profile_incomplete_routes_mapping_error(monkeypatch):
+    class _FakeService:
+        def enrich_candidate(self, candidate):  # noqa: ANN001
+            out = dict(candidate)
+            out["party_name"] = None
+            out["career_summary"] = None
+            out["election_history"] = None
+            return out
+
+        def verify_candidate(self, *, candidate_name, party_name=None):  # noqa: ARG002
+            return (False, 0.0)
+
+    def fake_build_service(*, record, sg_typecode):  # noqa: ARG001
+        return _FakeService()
+
+    monkeypatch.setattr(ingest_service_module, "_build_candidate_service", fake_build_service)
+
+    repo = FakeRepo()
+    payload_data = deepcopy(PAYLOAD)
+    payload_data["records"][0]["candidates"] = [
+        {
+            "candidate_id": "cand-jwo",
+            "name_ko": "정원오",
+            "party_name": None,
+            "gender": None,
+            "birth_date": None,
+            "job": None,
+            "career_summary": None,
+            "election_history": None,
+        }
+    ]
+    payload = IngestPayload.model_validate(payload_data)
+
+    result = ingest_payload(payload, repo)
+
+    assert result.status == "success"
+    assert any(
+        row[0] == "candidate" and row[1] == "cand-jwo" and row[2] == "mapping_error" and "CANDIDATE_PROFILE_INCOMPLETE" in row[3]
+        for row in repo.review
+    )


### PR DESCRIPTION
## Summary
- ingest 단계에서 후보 프로필 Data.go 컨텍스트 enrichment를 추가해 `party_name/gender/birth_date/job/career_summary/election_history` 충전 경로를 강화
- 동명이인 후보 매칭 정확도 개선(이름 일치 후보 중 정당/성별/생년/직업 점수 기반 선택)
- profile 추출 규칙 강화(career/election_history 다중 키 + 힌트 기반 보강)
- profile 핵심필드 미확정 후보를 `review_queue(mapping_error)`로 라우팅해 candidate API `needs_manual_review` 노출 보장
- 후보 프로필 충전율 자동 리포트 스크립트 및 테스트 추가
- Collector 보고서 추가

## Linked Issue
- Closes #298

## Report-Path
Report-Path: Collector_reports/2026-02-26_issue298_candidate_profile_enrichment_report.md

## Checklist
- [x] docs 계약(필드/API/용어)과 일치
- [x] 테스트 또는 검증 로그 첨부
- [x] 보안 정보(key/secret) 미포함 확인
- [x] Report-Path 파일이 이번 PR에 포함됨

## Validation
- `../election2026_codex/.venv/bin/pytest -q tests/test_data_go_candidate_service.py tests/test_ingest_service.py tests/test_collector_candidate_profile_coverage_v1_script.py`
- `../election2026_codex/.venv/bin/pytest -q`
- 결과: 179 passed
