### PR TITLE
[DEVELOP][P1] Complete matchup -> candidate routing (#295)

### DIFF
--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -165,7 +165,7 @@ class RegionElectionOut(BaseModel):
 
 class MatchupOptionOut(BaseModel):
     option_name: str
-    candidate_id: str | None = None
+    candidate_id: str | None
     party_name: str | None = None
     scenario_key: str | None = None
     scenario_type: Literal["head_to_head", "multi_candidate"] | None = None

--- a/apps/web/app/candidates/[candidate_id]/page.js
+++ b/apps/web/app/candidates/[candidate_id]/page.js
@@ -12,6 +12,8 @@ export default async function CandidatePage({ params, searchParams }) {
   const resolvedParams = await params;
   const resolvedSearch = await searchParams;
   const requestedCandidateId = resolvedParams.candidate_id;
+  const fromSource = (resolvedSearch?.from || "").trim().toLowerCase();
+  const fromMatchupId = (resolvedSearch?.matchup_id || "").trim();
 
   const partyDemo = (resolvedSearch?.party_demo || "").trim().toLowerCase();
   const confirmDemo = (resolvedSearch?.confirm_demo || "").trim().toLowerCase();
@@ -52,6 +54,10 @@ export default async function CandidatePage({ params, searchParams }) {
     RELATED_MATCHUP_ALIAS_BY_CANDIDATE[effectiveCandidateId] ||
     RELATED_MATCHUP_ALIAS_BY_CANDIDATE[requestedCandidateId] ||
     "m_2026_seoul_mayor";
+  const returnMatchupHref =
+    fromSource === "matchup" && fromMatchupId
+      ? `/matchups/${encodeURIComponent(fromMatchupId)}`
+      : null;
 
   const relatedMatchup = await fetchApi(`/api/v1/matchups/${encodeURIComponent(relatedAlias)}`);
 
@@ -96,6 +102,11 @@ export default async function CandidatePage({ params, searchParams }) {
           </p>
         </div>
         <div className="hero-actions">
+          {returnMatchupHref ? (
+            <Link href={returnMatchupHref} className="text-link">
+              매치업으로 복귀
+            </Link>
+          ) : null}
           <Link href="/search" className="text-link">
             지역 검색
           </Link>

--- a/develop_report/2026-02-26_issue295_matchup_candidate_routing_report.md
+++ b/develop_report/2026-02-26_issue295_matchup_candidate_routing_report.md
@@ -1,0 +1,41 @@
+# 2026-02-26 DEVELOP P1 후보 클릭 라우팅 완성 보고서 (#295)
+
+## 1) 작업 범위
+1. 매치업 옵션의 `candidate_id` 응답 키 필수화
+2. 매치업 화면 후보명 클릭/`프로필` 버튼 라우팅 추가
+3. 후보 상세 진입 시 `from=matchup&matchup_id=...` 복귀 링크 유지
+
+## 2) 핵심 변경
+1. API 계약
+   - `MatchupOptionOut.candidate_id`를 필수 키(값 `null` 허용)로 조정
+   - `candidate_id` 누락 시에도 응답에서 키가 빠지지 않도록 테스트 보강
+2. 매치업 UI (`/matchups/[matchup_id]`)
+   - 후보명 자체를 후보 상세 링크로 제공
+   - `프로필` 버튼 추가
+   - `candidate_id` 누락 후보는 `프로필` 버튼 disabled 처리 + `candidate_id 누락` 사유 배지 표시
+   - 후보 상세 링크에 `?from=matchup&matchup_id=<canonical_id>` 전달
+3. 후보 상세 UI (`/candidates/[candidate_id]`)
+   - `from=matchup&matchup_id=...` 파라미터가 있으면 `매치업으로 복귀` 링크 노출
+
+## 3) 변경 파일
+1. `/Users/gimtaehun/election2026_codex/app/models/schemas.py`
+2. `/Users/gimtaehun/election2026_codex/apps/web/app/matchups/[matchup_id]/page.js`
+3. `/Users/gimtaehun/election2026_codex/apps/web/app/candidates/[candidate_id]/page.js`
+4. `/Users/gimtaehun/election2026_codex/tests/test_api_routes.py`
+
+## 4) 검증
+1. 실행:
+```bash
+/Users/gimtaehun/election2026_codex/.venv/bin/python -m pytest -q
+```
+2. 결과: `175 passed in 3.19s`
+
+## 5) 완료 기준 대비
+1. 매치업 후보 행마다 후보 상세 이동 가능: 완료
+2. `candidate_id` 누락 후보 버튼 비활성 + 사유 뱃지: 완료
+3. e2e 스모크: 코드/계약 변경 반영 완료, CI 단계 검증 대상
+
+## 6) 의사결정 필요
+1. disabled 상태 문구 표준 확정 필요
+   - 현재: `candidate_id 누락`
+   - 대안: `후보식별자 미매핑(검수대기)`


### PR DESCRIPTION
## Summary
- make `candidate_id` a required key in matchup option response contract (nullable value allowed)
- add candidate-name click routing and explicit `프로필` action on matchup detail rows
- append `from=matchup&matchup_id=<canonical>` on candidate links
- add disabled `프로필` button + reason badge when candidate_id is missing
- add candidate detail return link when entered from matchup
- add API regression test for required candidate_id key behavior

## Report-Path
Report-Path: develop_report/2026-02-26_issue295_matchup_candidate_routing_report.md

## Validation
- `/Users/gimtaehun/election2026_codex/.venv/bin/python -m pytest -q`
- `175 passed in 3.19s`

## Linked Issue
- Closes #295
