### PR TITLE
[DEVELOP][P0] Region election master slots always-on with poll metadata (#301)

### DIFF
--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -161,6 +161,12 @@ class RegionElectionOut(BaseModel):
     office_type: str
     title: str
     is_active: bool
+    is_placeholder: bool = False
+    has_poll_data: bool = False
+    has_candidate_data: bool = False
+    latest_survey_end_date: date | None = None
+    latest_matchup_id: str | None = None
+    status: Literal["조사 데이터 없음", "후보 정보 준비중", "데이터 준비 완료"] = "조사 데이터 없음"
 
 
 class MatchupOptionOut(BaseModel):

--- a/apps/web/app/search/page.js
+++ b/apps/web/app/search/page.js
@@ -160,15 +160,34 @@ export default async function SearchPage({ searchParams }) {
 
               {electionsRes.ok && filteredElections.length > 0 ? (
                 <ul className="election-list full">
-                  {filteredElections.map((election) => (
-                    <li key={election.matchup_id}>
-                      <Link href={`/matchups/${encodeURIComponent(election.matchup_id)}`}>
-                        <span>{election.office_type}</span>
-                        <strong>{election.title}</strong>
-                        <span>{election.is_active ? "활성" : "비활성"}</span>
-                      </Link>
-                    </li>
-                  ))}
+                  {filteredElections.map((election) => {
+                    const navigationMatchupId =
+                      election.latest_matchup_id || (election.is_placeholder ? "" : election.matchup_id);
+                    const canNavigate = Boolean(navigationMatchupId);
+                    const statusText =
+                      election.status ||
+                      (election.has_poll_data ? "데이터 준비 완료" : "조사 데이터 없음");
+
+                    return (
+                      <li key={election.matchup_id}>
+                        {canNavigate ? (
+                          <Link href={`/matchups/${encodeURIComponent(navigationMatchupId)}`}>
+                            <span>{election.office_type}</span>
+                            <strong>{election.title}</strong>
+                            <span>{statusText}</span>
+                            <span>{election.latest_survey_end_date || "-"}</span>
+                          </Link>
+                        ) : (
+                          <div>
+                            <span>{election.office_type}</span>
+                            <strong>{election.title}</strong>
+                            <span>{statusText}</span>
+                            <span>매치업 준비중</span>
+                          </div>
+                        )}
+                      </li>
+                    );
+                  })}
                 </ul>
               ) : null}
             </section>

--- a/develop_report/2026-02-26_issue301_region_election_master_slots_report.md
+++ b/develop_report/2026-02-26_issue301_region_election_master_slots_report.md
@@ -1,0 +1,56 @@
+# 2026-02-26 DEVELOP P0 지역 인터랙션 마스터 슬롯 상시 노출 보고서 (#301)
+
+## 1) 작업 범위
+1. `/api/v1/regions/{region_code}/elections`를 관측치 의존에서 region master 기반으로 전환
+2. 선거 항목별 optional poll 메타 결합
+3. 검색 UI에서 상태/준비중 표시 반영
+
+## 2) 핵심 변경
+1. Region Elections API 계약 확장
+   - `has_poll_data`
+   - `has_candidate_data`
+   - `latest_survey_end_date`
+   - `latest_matchup_id`
+   - `status` (`조사 데이터 없음` | `후보 정보 준비중` | `데이터 준비 완료`)
+   - `is_placeholder`
+2. repository `fetch_region_elections` 재구현
+   - `regions` 테이블 기준으로 admin_level별 기본 슬롯 구성
+   - `sido`: `광역자치단체장`, `광역의회`, `교육감`
+   - `sigungu/local`: 기본 슬롯 + `기초자치단체장`, `기초의회`
+   - `재보궐`은 실제 데이터 존재 시 추가
+   - `poll_observations` 최신값과 `poll_options(candidate_matchup)` 존재 여부로 상태 산출
+3. placeholder title 규칙 추가
+   - 예: `강원특별자치도` 기준 `강원도지사 / 강원도의회 / 강원교육감`
+4. 검색 페이지 렌더 보강
+   - 상태 문자열 및 최신 조사일 노출
+   - `latest_matchup_id`가 없는 placeholder는 `매치업 준비중`으로 비활성 렌더
+
+## 3) 변경 파일
+1. `/Users/gimtaehun/election2026_codex/app/models/schemas.py`
+2. `/Users/gimtaehun/election2026_codex/app/services/repository.py`
+3. `/Users/gimtaehun/election2026_codex/apps/web/app/search/page.js`
+4. `/Users/gimtaehun/election2026_codex/tests/test_api_routes.py`
+5. `/Users/gimtaehun/election2026_codex/tests/test_repository_region_elections_master.py` (신규)
+
+## 4) 검증
+1. 부분 검증:
+```bash
+/Users/gimtaehun/election2026_codex/.venv/bin/python -m pytest -q tests/test_repository_region_elections_master.py tests/test_api_routes.py
+```
+2. 전체 회귀:
+```bash
+/Users/gimtaehun/election2026_codex/.venv/bin/python -m pytest -q
+```
+3. 결과: `177 passed in 7.72s`
+
+## 5) 수용 기준 대비
+1. 강원도 선택 시 최소 3개 슬롯 노출: 완료(테스트로 `광역자치단체장/광역의회/교육감` 고정 검증)
+2. `poll_observations=0`이어도 elections 비어있지 않음: 완료(master 슬롯 반환)
+3. 기존 빈 상태 정책 유지: 완료(`status`/placeholder로 분리)
+
+## 6) 의사결정 필요
+1. placeholder 제목 규칙 표준화 필요
+   - 현재는 규칙 기반 자동 생성(예: `강원도지사`, `중구청장`)
+   - UIUX에서 최종 카피/표기 사전 고정 여부 결정 필요
+2. placeholder 항목 클릭 허용 정책 확정 필요
+   - 현재는 `latest_matchup_id` 없으면 비활성 처리(`매치업 준비중`)

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -610,7 +610,12 @@ def test_api_contract_fields():
 
     region_elections = client.get("/api/v1/regions/11-000/elections")
     assert region_elections.status_code == 200
-    assert region_elections.json()[0]["is_active"] is True
+    region_election_row = region_elections.json()[0]
+    assert region_election_row["is_active"] is True
+    assert "has_poll_data" in region_election_row
+    assert "latest_survey_end_date" in region_election_row
+    assert "latest_matchup_id" in region_election_row
+    assert "status" in region_election_row
 
     matchup = client.get("/api/v1/matchups/20260603|광역자치단체장|11-000")
     assert matchup.status_code == 200

--- a/tests/test_repository_region_elections_master.py
+++ b/tests/test_repository_region_elections_master.py
@@ -1,0 +1,98 @@
+from datetime import date
+
+from app.services.repository import PostgresRepository
+
+
+class _Cursor:
+    def __init__(self, *, region_row, matchup_rows, poll_meta_rows):
+        self._region_row = region_row
+        self._matchup_rows = matchup_rows
+        self._poll_meta_rows = poll_meta_rows
+        self._step = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):  # noqa: ANN001
+        return False
+
+    def execute(self, query, params=None):  # noqa: ARG002
+        return None
+
+    def fetchone(self):
+        if self._step == 0:
+            self._step += 1
+            return self._region_row
+        return None
+
+    def fetchall(self):
+        if self._step == 1:
+            self._step += 1
+            return self._matchup_rows
+        if self._step == 2:
+            self._step += 1
+            return self._poll_meta_rows
+        return []
+
+
+class _Conn:
+    def __init__(self, *, region_row, matchup_rows, poll_meta_rows):
+        self._cursor = _Cursor(region_row=region_row, matchup_rows=matchup_rows, poll_meta_rows=poll_meta_rows)
+
+    def cursor(self):
+        return self._cursor
+
+
+def test_region_elections_returns_master_slots_for_sido_even_without_poll_data():
+    conn = _Conn(
+        region_row={
+            "region_code": "32-000",
+            "sido_name": "강원특별자치도",
+            "sigungu_name": "전체",
+            "admin_level": "sido",
+        },
+        matchup_rows=[],
+        poll_meta_rows=[],
+    )
+
+    repo = PostgresRepository(conn)
+    rows = repo.fetch_region_elections("32-000")
+
+    assert [row["office_type"] for row in rows] == ["광역자치단체장", "광역의회", "교육감"]
+    assert [row["title"] for row in rows] == ["강원도지사", "강원도의회", "강원교육감"]
+    assert all(row["has_poll_data"] is False for row in rows)
+    assert all(row["status"] == "조사 데이터 없음" for row in rows)
+
+
+def test_region_elections_adds_sigungu_slots_and_status_metadata():
+    conn = _Conn(
+        region_row={
+            "region_code": "26-710",
+            "sido_name": "부산광역시",
+            "sigungu_name": "중구",
+            "admin_level": "sigungu",
+        },
+        matchup_rows=[],
+        poll_meta_rows=[
+            {
+                "office_type": "기초자치단체장",
+                "has_poll_data": True,
+                "latest_survey_end_date": date(2026, 2, 19),
+                "latest_matchup_id": "20260603|기초자치단체장|26-710",
+                "has_candidate_data": False,
+            }
+        ],
+    )
+
+    repo = PostgresRepository(conn)
+    rows = repo.fetch_region_elections("26-710")
+
+    office_types = [row["office_type"] for row in rows]
+    assert office_types[:5] == ["광역자치단체장", "광역의회", "교육감", "기초자치단체장", "기초의회"]
+
+    mayor = next(row for row in rows if row["office_type"] == "기초자치단체장")
+    assert mayor["has_poll_data"] is True
+    assert mayor["has_candidate_data"] is False
+    assert mayor["latest_survey_end_date"] == date(2026, 2, 19)
+    assert mayor["latest_matchup_id"] == "20260603|기초자치단체장|26-710"
+    assert mayor["status"] == "후보 정보 준비중"


### PR DESCRIPTION
## Summary
- switch `/api/v1/regions/{region_code}/elections` to region-master-driven slot generation
- always return legal election slots by admin level (`sido` minimum 3 slots, `sigungu/local` adds 2 local slots)
- enrich each slot with optional poll metadata: `has_poll_data`, `latest_survey_end_date`, `latest_matchup_id`
- add slot state contract: `조사 데이터 없음` / `후보 정보 준비중` / `데이터 준비 완료`
- add placeholder handling (`is_placeholder`) and update search UI to show state + disable unresolved navigation
- add repository/API regression tests for 강원/기초 시나리오

## Report-Path
Report-Path: develop_report/2026-02-26_issue301_region_election_master_slots_report.md

## Validation
- `/Users/gimtaehun/election2026_codex/.venv/bin/python -m pytest -q`
- `177 passed in 7.72s`

## Linked Issue
- Closes #301
