### PR TITLE
[DEVELOP][P1] Add topology scenario mode for region elections (#305)

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -1,6 +1,7 @@
 import re
 import unicodedata
 from datetime import date, datetime, timezone
+from typing import Literal
 from urllib.parse import unquote_plus
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
@@ -403,8 +404,13 @@ def search_regions(
 
 
 @router.get("/regions/{region_code}/elections", response_model=list[RegionElectionOut])
-def get_region_elections(region_code: str, repo=Depends(get_repository)):
-    rows = repo.fetch_region_elections(region_code=region_code)
+def get_region_elections(
+    region_code: str,
+    topology: Literal["official", "scenario"] = Query(default="official"),
+    version_id: str | None = Query(default=None),
+    repo=Depends(get_repository),
+):
+    rows = repo.fetch_region_elections(region_code=region_code, topology=topology, version_id=version_id)
     return [RegionElectionOut(**row) for row in rows]
 
 

--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -161,6 +161,8 @@ class RegionElectionOut(BaseModel):
     office_type: str
     title: str
     is_active: bool
+    topology: Literal["official", "scenario"] = "official"
+    topology_version_id: str | None = None
     is_placeholder: bool = False
     has_poll_data: bool = False
     has_candidate_data: bool = False

--- a/develop_report/2026-02-26_issue305_topology_scenario_mode_report.md
+++ b/develop_report/2026-02-26_issue305_topology_scenario_mode_report.md
@@ -1,0 +1,61 @@
+# 2026-02-26 DEVELOP P1 선거체계 시나리오 모드(official/scenario) 지원 보고서 (#305)
+
+## 1) 작업 범위
+1. topology 버전 관리 스키마 추가
+2. 지역 선거 슬롯 조회 API에 topology/version 파라미터 추가
+3. scenario 모드에서 광주·전남 통합 슬롯 시뮬레이션 지원
+4. 운영 안전장치 유지(기본 official)
+
+## 2) 핵심 변경
+1. DB 스키마 확장
+   - `region_topology_versions(version_id, mode, effective_from, effective_to, status, note)`
+   - `region_topology_edges(parent_region_code, child_region_code, version_id)`
+   - mode/status 체크 제약 및 인덱스 추가
+   - 기본 seed 추가:
+     - `official-v1`
+     - `scenario-gj-jn-merge-v1`
+     - edges: `29-46-000 <- 29-000, 46-000`
+2. API 계약 확장
+   - `GET /api/v1/regions/{region_code}/elections?topology=official|scenario&version_id=...`
+   - 기본값은 `topology=official`
+3. repository 로직 확장 (`fetch_region_elections`)
+   - topology/version 해석
+   - scenario에서 child->parent edge 적용
+   - parent region 미존재 시 child regions 기반 synthetic region 생성
+   - 슬롯 응답에 topology 메타 포함:
+     - `topology`, `topology_version_id`
+4. UI 검색 페이지 연동
+   - topology/version query 전달 유지
+   - scenario/placeholder 상태에서도 슬롯 리스트 렌더 유지
+
+## 3) 변경 파일
+1. `/Users/gimtaehun/election2026_codex/db/schema.sql`
+2. `/Users/gimtaehun/election2026_codex/app/services/repository.py`
+3. `/Users/gimtaehun/election2026_codex/app/models/schemas.py`
+4. `/Users/gimtaehun/election2026_codex/app/api/routes.py`
+5. `/Users/gimtaehun/election2026_codex/apps/web/app/search/page.js`
+6. `/Users/gimtaehun/election2026_codex/tests/test_api_routes.py`
+7. `/Users/gimtaehun/election2026_codex/tests/test_repository_region_elections_master.py`
+8. `/Users/gimtaehun/election2026_codex/tests/test_schema_region_topology.py` (신규)
+
+## 4) 검증
+1. 부분 검증:
+```bash
+/Users/gimtaehun/election2026_codex/.venv/bin/python -m pytest -q tests/test_repository_region_elections_master.py tests/test_api_routes.py tests/test_schema_region_topology.py
+```
+2. 전체 회귀:
+```bash
+/Users/gimtaehun/election2026_codex/.venv/bin/python -m pytest -q
+```
+3. 결과: `180 passed in 2.70s`
+
+## 5) 수용 기준 대비
+1. topology 파라미터에 따라 슬롯 구성 변화: 완료
+2. official 기본동작 회귀 0: 완료(전체 테스트 통과)
+3. scenario 모드 광주·전남 통합 슬롯 시뮬레이션: 완료
+
+## 6) 의사결정 필요
+1. scenario synthetic region 표시명 확정 필요
+   - 현재: `광주·전남 통합특별시` 기반 자동 생성
+2. scenario 전용 버전 라이프사이클 운영정책 확정 필요
+   - `draft/announced/effective` 전환 책임자 및 전환 절차(runbook) 명시 필요

--- a/tests/test_repository_region_elections_master.py
+++ b/tests/test_repository_region_elections_master.py
@@ -4,12 +4,24 @@ from app.services.repository import PostgresRepository
 
 
 class _Cursor:
-    def __init__(self, *, region_row, election_rows, matchup_rows, poll_meta_rows):
-        self._region_row = region_row
-        self._election_rows = election_rows
-        self._matchup_rows = matchup_rows
-        self._poll_meta_rows = poll_meta_rows
-        self._step = 0
+    def __init__(
+        self,
+        *,
+        topology_rows,
+        parent_by_child,
+        region_rows,
+        matchup_rows,
+        poll_meta_rows,
+        scenario_children,
+    ):
+        self.topology_rows = topology_rows
+        self.parent_by_child = parent_by_child
+        self.region_rows = region_rows
+        self.matchup_rows = matchup_rows
+        self.poll_meta_rows = poll_meta_rows
+        self.scenario_children = scenario_children
+        self._query = ""
+        self._params = ()
 
     def __enter__(self):
         return self
@@ -17,52 +29,102 @@ class _Cursor:
     def __exit__(self, exc_type, exc, tb):  # noqa: ANN001
         return False
 
-    def execute(self, query, params=None):  # noqa: ARG002
-        return None
+    def execute(self, query, params=None):
+        self._query = query
+        self._params = params or ()
 
     def fetchone(self):
-        if self._step == 0:
-            self._step += 1
-            return self._region_row
+        if "FROM region_topology_versions" in self._query:
+            if len(self._params) == 2:
+                version_id, mode = self._params
+                row = self.topology_rows.get(mode)
+                if row and row.get("version_id") == version_id:
+                    return row
+                return None
+            mode = self._params[0]
+            return self.topology_rows.get(mode)
+
+        if "FROM region_topology_edges" in self._query and "child_region_code" in self._query:
+            version_id, child_region_code = self._params
+            parent_region_code = self.parent_by_child.get((version_id, child_region_code))
+            return {"parent_region_code": parent_region_code} if parent_region_code else None
+
+        if "FROM regions" in self._query and "WHERE region_code" in self._query:
+            region_code = self._params[0]
+            return self.region_rows.get(region_code)
+
         return None
 
     def fetchall(self):
-        if self._step == 1:
-            self._step += 1
-            return self._election_rows
-        if self._step == 2:
-            self._step += 1
-            return self._matchup_rows
-        if self._step == 3:
-            self._step += 1
-            return self._poll_meta_rows
+        if "FROM matchups" in self._query:
+            region_code = self._params[0]
+            return self.matchup_rows.get(region_code, [])
+
+        if "FROM ranked r" in self._query:
+            region_code = self._params[0]
+            return self.poll_meta_rows.get(region_code, [])
+
+        if "JOIN regions r ON r.region_code = e.child_region_code" in self._query:
+            version_id, parent_region_code = self._params
+            return self.scenario_children.get((version_id, parent_region_code), [])
+
         return []
 
 
 class _Conn:
-    def __init__(self, *, region_row, election_rows, matchup_rows, poll_meta_rows):
+    def __init__(
+        self,
+        *,
+        topology_rows,
+        parent_by_child,
+        region_rows,
+        matchup_rows,
+        poll_meta_rows,
+        scenario_children,
+    ):
         self._cursor = _Cursor(
-            region_row=region_row,
-            election_rows=election_rows,
+            topology_rows=topology_rows,
+            parent_by_child=parent_by_child,
+            region_rows=region_rows,
             matchup_rows=matchup_rows,
             poll_meta_rows=poll_meta_rows,
+            scenario_children=scenario_children,
         )
 
     def cursor(self):
         return self._cursor
 
 
-def test_region_elections_returns_master_slots_for_sido_even_without_poll_data():
-    conn = _Conn(
-        region_row={
-            "region_code": "32-000",
-            "sido_name": "강원특별자치도",
-            "sigungu_name": "전체",
-            "admin_level": "sido",
+def _base_conn(*, region_rows, matchup_rows, poll_meta_rows, parent_by_child=None, scenario_children=None):
+    return _Conn(
+        topology_rows={
+            "official": {"version_id": "official-v1", "mode": "official", "status": "effective"},
+            "scenario": {
+                "version_id": "scenario-gj-jn-merge-v1",
+                "mode": "scenario",
+                "status": "draft",
+            },
         },
-        election_rows=[],
-        matchup_rows=[],
-        poll_meta_rows=[],
+        parent_by_child=parent_by_child or {},
+        region_rows=region_rows,
+        matchup_rows=matchup_rows,
+        poll_meta_rows=poll_meta_rows,
+        scenario_children=scenario_children or {},
+    )
+
+
+def test_region_elections_returns_master_slots_for_sido_even_without_poll_data():
+    conn = _base_conn(
+        region_rows={
+            "32-000": {
+                "region_code": "32-000",
+                "sido_name": "강원특별자치도",
+                "sigungu_name": "전체",
+                "admin_level": "sido",
+            }
+        },
+        matchup_rows={"32-000": []},
+        poll_meta_rows={"32-000": []},
     )
 
     repo = PostgresRepository(conn)
@@ -72,27 +134,31 @@ def test_region_elections_returns_master_slots_for_sido_even_without_poll_data()
     assert [row["title"] for row in rows] == ["강원도지사", "강원도의회", "강원교육감"]
     assert all(row["has_poll_data"] is False for row in rows)
     assert all(row["status"] == "조사 데이터 없음" for row in rows)
+    assert all(row["topology"] == "official" for row in rows)
 
 
 def test_region_elections_adds_sigungu_slots_and_status_metadata():
-    conn = _Conn(
-        region_row={
-            "region_code": "26-710",
-            "sido_name": "부산광역시",
-            "sigungu_name": "중구",
-            "admin_level": "sigungu",
-        },
-        election_rows=[],
-        matchup_rows=[],
-        poll_meta_rows=[
-            {
-                "office_type": "기초자치단체장",
-                "has_poll_data": True,
-                "latest_survey_end_date": date(2026, 2, 19),
-                "latest_matchup_id": "20260603|기초자치단체장|26-710",
-                "has_candidate_data": False,
+    conn = _base_conn(
+        region_rows={
+            "26-710": {
+                "region_code": "26-710",
+                "sido_name": "부산광역시",
+                "sigungu_name": "중구",
+                "admin_level": "sigungu",
             }
-        ],
+        },
+        matchup_rows={"26-710": []},
+        poll_meta_rows={
+            "26-710": [
+                {
+                    "office_type": "기초자치단체장",
+                    "has_poll_data": True,
+                    "latest_survey_end_date": date(2026, 2, 19),
+                    "latest_matchup_id": "20260603|기초자치단체장|26-710",
+                    "has_candidate_data": False,
+                }
+            ]
+        },
     )
 
     repo = PostgresRepository(conn)
@@ -107,3 +173,46 @@ def test_region_elections_adds_sigungu_slots_and_status_metadata():
     assert mayor["latest_survey_end_date"] == date(2026, 2, 19)
     assert mayor["latest_matchup_id"] == "20260603|기초자치단체장|26-710"
     assert mayor["status"] == "후보 정보 준비중"
+
+
+def test_region_elections_supports_scenario_topology_merge_slots():
+    conn = _base_conn(
+        region_rows={
+            "29-000": {
+                "region_code": "29-000",
+                "sido_name": "광주광역시",
+                "sigungu_name": "전체",
+                "admin_level": "sido",
+            },
+            "46-000": {
+                "region_code": "46-000",
+                "sido_name": "전라남도",
+                "sigungu_name": "전체",
+                "admin_level": "sido",
+            },
+        },
+        matchup_rows={"29-46-000": []},
+        poll_meta_rows={"29-46-000": []},
+        parent_by_child={
+            ("scenario-gj-jn-merge-v1", "29-000"): "29-46-000",
+            ("scenario-gj-jn-merge-v1", "46-000"): "29-46-000",
+        },
+        scenario_children={
+            (
+                "scenario-gj-jn-merge-v1",
+                "29-46-000",
+            ): [
+                {"sido_name": "광주광역시", "sigungu_name": "전체"},
+                {"sido_name": "전라남도", "sigungu_name": "전체"},
+            ]
+        },
+    )
+
+    repo = PostgresRepository(conn)
+    rows = repo.fetch_region_elections("29-000", topology="scenario", version_id="scenario-gj-jn-merge-v1")
+
+    assert [row["office_type"] for row in rows] == ["광역자치단체장", "광역의회", "교육감"]
+    assert [row["title"] for row in rows] == ["광주·전남 통합시장", "광주·전남 통합시의회", "광주·전남 통합교육감"]
+    assert all(row["region_code"] == "29-46-000" for row in rows)
+    assert all(row["topology"] == "scenario" for row in rows)
+    assert all(row["topology_version_id"] == "scenario-gj-jn-merge-v1" for row in rows)

--- a/tests/test_schema_region_topology.py
+++ b/tests/test_schema_region_topology.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+
+def test_schema_contains_region_topology_tables_and_seed() -> None:
+    sql = Path("db/schema.sql").read_text(encoding="utf-8")
+    assert "CREATE TABLE IF NOT EXISTS region_topology_versions" in sql
+    assert "region_topology_versions_mode_check" in sql
+    assert "region_topology_versions_status_check" in sql
+    assert "CREATE TABLE IF NOT EXISTS region_topology_edges" in sql
+    assert "idx_region_topology_edges_child" in sql
+    assert "idx_region_topology_edges_parent" in sql
+    assert "scenario-gj-jn-merge-v1" in sql


### PR DESCRIPTION
## Summary
- add topology versioning tables: `region_topology_versions`, `region_topology_edges`
- seed `official-v1` and `scenario-gj-jn-merge-v1` with 광주/전남 merge edges
- extend region elections API contract with `topology` and `version_id` query support
- keep default behavior official-only and route-level scenario isolation
- update region election slot resolver to apply scenario parent-child topology mapping
- support synthetic merged region labels when parent code does not exist in `regions`
- propagate topology query params through search page
- add regression tests for API/repository/schema

## Report-Path
Report-Path: develop_report/2026-02-26_issue305_topology_scenario_mode_report.md

## Validation
- `/Users/gimtaehun/election2026_codex/.venv/bin/python -m pytest -q`
- `180 passed in 2.70s`

## Linked Issue
- Closes #305
