### PR TITLE
[DEVELOP][P1] region code alias normalization v1

### DIFF
--- a/app/services/region_code_normalizer.py
+++ b/app/services/region_code_normalizer.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+LEGACY_REGION_PREFIX_MAP = {
+    # 강원도(legacy 32) -> 강원특별자치도(42)
+    "32": "42",
+}
+
+_SIMPLE_REGION_CODE_RE = re.compile(r"^\d{2}(?:-\d{3})?$")
+_COMPACT_REGION_CODE_RE = re.compile(r"^\d{5}$")
+_SCENARIO_REGION_CODE_RE = re.compile(r"^\d{2}-\d{2}-\d{3}$")
+
+
+@dataclass(frozen=True)
+class RegionCodeNormalization:
+    raw: str
+    canonical: str | None
+    is_code_like: bool
+    was_aliased: bool
+
+
+def _strip_country_prefix(value: str) -> str:
+    if value.startswith("KR-"):
+        return value[3:]
+    if value.startswith("KR"):
+        return value[2:]
+    return value
+
+
+def _apply_legacy_prefix_alias(code: str) -> str:
+    prefix = code[:2]
+    mapped_prefix = LEGACY_REGION_PREFIX_MAP.get(prefix, prefix)
+    return f"{mapped_prefix}{code[2:]}"
+
+
+def _canonicalize_normalized_token(normalized_token: str) -> str | None:
+    stripped = _strip_country_prefix(normalized_token)
+    if _SCENARIO_REGION_CODE_RE.fullmatch(stripped):
+        return _apply_legacy_prefix_alias(stripped)
+    if _SIMPLE_REGION_CODE_RE.fullmatch(stripped):
+        digits = "".join(ch for ch in stripped if ch.isdigit())
+        if len(digits) == 2:
+            return _apply_legacy_prefix_alias(f"{digits}-000")
+        if len(digits) == 5:
+            return _apply_legacy_prefix_alias(f"{digits[:2]}-{digits[2:]}")
+    if _COMPACT_REGION_CODE_RE.fullmatch(stripped):
+        return _apply_legacy_prefix_alias(f"{stripped[:2]}-{stripped[2:]}")
+    return None
+
+
+def normalize_region_code_input(raw_value: str | None) -> RegionCodeNormalization:
+    raw = (raw_value or "").strip()
+    if not raw:
+        return RegionCodeNormalization(raw=raw, canonical=None, is_code_like=False, was_aliased=False)
+
+    normalized_token = raw.replace(" ", "").replace("_", "-").upper()
+    canonical = _canonicalize_normalized_token(normalized_token)
+    if canonical is None:
+        return RegionCodeNormalization(raw=raw, canonical=None, is_code_like=False, was_aliased=False)
+
+    was_aliased = normalized_token != canonical
+    return RegionCodeNormalization(raw=raw, canonical=canonical, is_code_like=True, was_aliased=was_aliased)

--- a/develop_report/2026-02-26_issue313_region_code_alias_normalization_report.md
+++ b/develop_report/2026-02-26_issue313_region_code_alias_normalization_report.md
@@ -1,0 +1,59 @@
+# 2026-02-26 Issue #313 지역코드 Alias 정규화 v1 보고서
+
+## 1) 작업 개요
+- 이슈: [#313](https://github.com/iAmSomething/2026-/issues/313)
+- 목표: `KR-xx/legacy` 형태 입력을 API 경계에서 canonical 지역코드로 정규화하고, 조회 결과를 일관되게 반환.
+
+## 2) 구현 내용
+1. 지역코드 정규화 모듈 추가
+- 파일: `/Users/gimtaehun/election2026_codex/app/services/region_code_normalizer.py`
+- 추가 함수: `normalize_region_code_input(raw_value)`
+- 지원 입력 예시:
+  - `KR-32`, `KR-42`, `32-000`, `32_000`, `42000`, `42-000`, `29-46-000`
+- canonical 규칙:
+  - legacy prefix 매핑 v1: `32 -> 42` (강원)
+  - 그 외는 canonical 형식(`xx-xxx`, `xx-xx-xxx`)으로 정규화
+
+2. API 경계 적용
+- 파일: `/Users/gimtaehun/election2026_codex/app/api/routes.py`
+- 반영 엔드포인트:
+  - `GET /api/v1/regions/search`
+    - 코드형 질의는 `search_regions_by_code`로 분기
+  - `GET /api/v1/regions/{region_code}/elections`
+    - path `region_code`를 canonical로 정규화 후 조회
+  - `GET /api/v1/matchups/{matchup_id}`
+    - `matchup_id`의 region segment를 canonical로 정규화
+
+3. 관측성(로그)
+- alias 입력이 canonical로 변환될 때 아래 이벤트 로그 추가:
+  - `region_code_alias_normalized endpoint=regions.search ...`
+  - `region_code_alias_normalized endpoint=regions.elections ...`
+  - `region_code_alias_normalized endpoint=matchups.get ...`
+
+4. Repository 확장
+- 파일: `/Users/gimtaehun/election2026_codex/app/services/repository.py`
+- 추가 메서드: `search_regions_by_code(region_code, limit)`
+- 동작: `regions.region_code = %s` exact match 검색 + 기존 응답필드(`has_data`, `matchup_count`) 유지
+
+## 3) 테스트
+1. 신규 테스트
+- `/Users/gimtaehun/election2026_codex/tests/test_region_code_normalizer.py`
+- `/Users/gimtaehun/election2026_codex/tests/test_api_routes.py`
+  - alias/canonical 결과 동일성
+  - `/regions/{region_code}/elections` alias path 정규화
+  - matchup id 내 alias region 정규화
+- `/Users/gimtaehun/election2026_codex/tests/test_repository_region_search_hardening.py`
+  - `search_regions_by_code` exact match SQL 및 빈 입력 가드
+
+2. 실행 결과
+- `pytest -q tests/test_api_routes.py tests/test_region_code_normalizer.py tests/test_repository_region_search_hardening.py`
+- 결과: `33 passed in 1.37s`
+
+## 4) 수용 기준 대비
+- alias 입력 200 응답 + canonical 일관 반환: 충족
+- canonical direct 입력과 결과 동일: 충족 (`/regions/search`)
+- 강원 샘플 회귀(legacy `32 -> 42`): 충족
+
+## 5) 리스크/후속 제안
+- v1은 legacy prefix 매핑을 `32 -> 42`로 제한.
+- 후속 의사결정 필요: legacy 코드 매핑 범위를 전국 단위로 확장할지 여부.

--- a/tests/test_region_code_normalizer.py
+++ b/tests/test_region_code_normalizer.py
@@ -1,0 +1,24 @@
+import pytest
+
+from app.services.region_code_normalizer import normalize_region_code_input
+
+
+@pytest.mark.parametrize(
+    ("raw", "canonical", "is_code_like", "was_aliased"),
+    [
+        ("KR-32", "42-000", True, True),
+        ("KR-42", "42-000", True, True),
+        ("32-000", "42-000", True, True),
+        ("32_000", "42-000", True, True),
+        ("42000", "42-000", True, True),
+        ("42-000", "42-000", True, False),
+        ("29-46-000", "29-46-000", True, False),
+        ("서울특별시", None, False, False),
+        ("", None, False, False),
+    ],
+)
+def test_normalize_region_code_input(raw, canonical, is_code_like, was_aliased):
+    normalized = normalize_region_code_input(raw)
+    assert normalized.canonical == canonical
+    assert normalized.is_code_like is is_code_like
+    assert normalized.was_aliased is was_aliased

--- a/tests/test_repository_region_search_hardening.py
+++ b/tests/test_repository_region_search_hardening.py
@@ -54,3 +54,24 @@ def test_region_search_returns_empty_without_query_text():
     out = repo.search_regions("   ", limit=20)
     assert out == []
     assert conn._cursor.executed == []
+
+
+def test_region_search_by_code_uses_exact_match():
+    conn = _RecordingConn(rows=[])
+    repo = PostgresRepository(conn)
+
+    repo.search_regions_by_code("42-000", limit=10)
+
+    assert len(conn._cursor.executed) == 1
+    query, params = conn._cursor.executed[0]
+    assert "WHERE r.region_code = %s" in query
+    assert params == ("42-000", 10)
+
+
+def test_region_search_by_code_returns_empty_without_region_code():
+    conn = _RecordingConn(rows=[{"region_code": "42-000"}])
+    repo = PostgresRepository(conn)
+
+    out = repo.search_regions_by_code("   ", limit=20)
+    assert out == []
+    assert conn._cursor.executed == []


### PR DESCRIPTION
## Summary
- add `region_code_normalizer` service for KR/legacy/canonical inputs (`KR-32`, `32-000`, `42000` -> `42-000`)
- apply canonical normalization at API boundaries for `/regions/search`, `/regions/{region_code}/elections`, and matchup region segment parsing
- add repository code search path `search_regions_by_code` for exact canonical region lookup
- add alias-normalization observability logs (`region_code_alias_normalized`)
- add regression/unit tests for normalizer, API aliases, and repository query contract

## Test
- `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q tests/test_api_routes.py tests/test_region_code_normalizer.py tests/test_repository_region_search_hardening.py`
- `33 passed in 1.37s`

Closes #313

Report-Path: develop_report/2026-02-26_issue313_region_code_alias_normalization_report.md
