### PR TITLE
[DEVELOP][P0] API 500 hotfix: db health + runtime schema guard

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -7,10 +7,30 @@ from psycopg.rows import dict_row
 from app.config import get_settings
 
 
+class DatabaseConfigurationError(RuntimeError):
+    """Raised when DB settings are missing or invalid."""
+
+
+class DatabaseConnectionError(RuntimeError):
+    """Raised when a DB connection cannot be established."""
+
+
 @contextmanager
 def get_connection():
-    settings = get_settings()
-    conn = psycopg.connect(settings.database_url, row_factory=dict_row)
+    try:
+        settings = get_settings()
+    except Exception as exc:  # noqa: BLE001
+        raise DatabaseConfigurationError("database settings are not configured") from exc
+
+    database_url = str(settings.database_url or "").strip()
+    if not database_url:
+        raise DatabaseConfigurationError("DATABASE_URL is empty")
+
+    try:
+        conn = psycopg.connect(database_url, row_factory=dict_row)
+    except psycopg.Error as exc:
+        raise DatabaseConnectionError("database connection failed") from exc
+
     try:
         yield conn
     finally:

--- a/app/main.py
+++ b/app/main.py
@@ -1,9 +1,14 @@
 import os
+import logging
 
 from fastapi import FastAPI
+from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
+import psycopg
 
 from app.api.routes import router as api_router
+from app.db import DatabaseConfigurationError, DatabaseConnectionError, get_connection
+from app.runtime_db_guard import DB_BOOTSTRAP_STATE, apply_schema_bootstrap, heal_schema_once, is_schema_mismatch_sqlstate
 
 DEFAULT_CORS_ALLOW_ORIGINS = (
     "https://2026-deploy.vercel.app,"
@@ -12,6 +17,8 @@ DEFAULT_CORS_ALLOW_ORIGINS = (
     "http://127.0.0.1:3300,"
     "http://localhost:3300"
 )
+
+logger = logging.getLogger(__name__)
 
 
 def _resolve_cors_allow_origins() -> list[str]:
@@ -30,6 +37,88 @@ app.add_middleware(
 app.include_router(api_router)
 
 
+@app.on_event("startup")
+def startup_schema_bootstrap():
+    state = apply_schema_bootstrap()
+    logger.info(
+        "startup_schema_bootstrap enabled=%s attempted=%s ok=%s detail=%s",
+        state.get("enabled"),
+        state.get("attempted"),
+        state.get("ok"),
+        state.get("detail"),
+    )
+
+
+@app.exception_handler(psycopg.Error)
+def handle_psycopg_error(_, exc: psycopg.Error):  # noqa: ANN001
+    detail = "database query failed"
+    sqlstate = getattr(exc, "sqlstate", None)
+
+    if is_schema_mismatch_sqlstate(sqlstate):
+        try:
+            healed = heal_schema_once()
+        except Exception as heal_exc:  # noqa: BLE001
+            logger.exception("schema_auto_heal_failed: %s", heal_exc)
+            healed = False
+        if healed:
+            detail = "database schema auto-healed; retry request"
+        else:
+            detail = "database schema mismatch detected"
+    elif sqlstate:
+        detail = f"database query failed ({sqlstate})"
+
+    return JSONResponse(status_code=503, content={"detail": detail})
+
+
 @app.get("/health")
 def health_check():
     return {"status": "ok"}
+
+
+@app.get("/health/db")
+def health_db_check():
+    try:
+        with get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute("SELECT 1 AS ok")
+                row = cur.fetchone() or {}
+    except DatabaseConfigurationError as exc:
+        return JSONResponse(
+            status_code=503,
+            content={
+                "status": "degraded",
+                "db": "error",
+                "reason": "database_not_configured",
+                "detail": str(exc),
+                "bootstrap": DB_BOOTSTRAP_STATE,
+            },
+        )
+    except DatabaseConnectionError as exc:
+        return JSONResponse(
+            status_code=503,
+            content={
+                "status": "degraded",
+                "db": "error",
+                "reason": "database_connection_failed",
+                "detail": str(exc),
+                "bootstrap": DB_BOOTSTRAP_STATE,
+            },
+        )
+    except psycopg.Error as exc:
+        return JSONResponse(
+            status_code=503,
+            content={
+                "status": "degraded",
+                "db": "error",
+                "reason": "database_query_failed",
+                "sqlstate": exc.sqlstate,
+                "bootstrap": DB_BOOTSTRAP_STATE,
+            },
+        )
+
+    return {
+        "status": "ok",
+        "db": "ok",
+        "ping": row.get("ok") == 1,
+        "bootstrap": DB_BOOTSTRAP_STATE,
+    }

--- a/app/runtime_db_guard.py
+++ b/app/runtime_db_guard.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from threading import Lock
+
+from app.db import run_schema
+
+_TRUTHY = {"1", "true", "yes", "y", "on"}
+_FALSY = {"0", "false", "no", "n", "off"}
+_SCHEMA_MISMATCH_SQLSTATE = {"42P01", "42703"}  # undefined_table, undefined_column
+
+_schema_heal_lock = Lock()
+_schema_healed_once = False
+
+DB_BOOTSTRAP_STATE: dict[str, object] = {
+    "enabled": False,
+    "attempted": False,
+    "ok": None,
+    "detail": None,
+}
+
+
+def _parse_bool_env(value: str | None) -> bool | None:
+    if value is None:
+        return None
+    token = value.strip().lower()
+    if token in _TRUTHY:
+        return True
+    if token in _FALSY:
+        return False
+    return None
+
+
+def should_auto_apply_schema_on_startup() -> bool:
+    explicit = _parse_bool_env(os.getenv("AUTO_APPLY_SCHEMA_ON_STARTUP"))
+    if explicit is not None:
+        return explicit
+    return bool(os.getenv("RAILWAY_PROJECT_ID") or os.getenv("RAILWAY_SERVICE_ID"))
+
+
+def apply_schema_bootstrap() -> dict[str, object]:
+    enabled = should_auto_apply_schema_on_startup()
+    DB_BOOTSTRAP_STATE["enabled"] = enabled
+    if not enabled:
+        DB_BOOTSTRAP_STATE["attempted"] = False
+        DB_BOOTSTRAP_STATE["ok"] = None
+        DB_BOOTSTRAP_STATE["detail"] = "disabled"
+        return DB_BOOTSTRAP_STATE
+
+    DB_BOOTSTRAP_STATE["attempted"] = True
+    schema_path = Path(__file__).resolve().parents[1] / "db" / "schema.sql"
+    try:
+        run_schema(schema_path)
+    except Exception as exc:  # noqa: BLE001
+        DB_BOOTSTRAP_STATE["ok"] = False
+        DB_BOOTSTRAP_STATE["detail"] = f"{type(exc).__name__}: {exc}"
+        return DB_BOOTSTRAP_STATE
+
+    DB_BOOTSTRAP_STATE["ok"] = True
+    DB_BOOTSTRAP_STATE["detail"] = "schema applied"
+    return DB_BOOTSTRAP_STATE
+
+
+def is_schema_mismatch_sqlstate(sqlstate: str | None) -> bool:
+    return sqlstate in _SCHEMA_MISMATCH_SQLSTATE
+
+
+def heal_schema_once() -> bool:
+    global _schema_healed_once  # noqa: PLW0603
+
+    with _schema_heal_lock:
+        if _schema_healed_once:
+            return False
+        schema_path = Path(__file__).resolve().parents[1] / "db" / "schema.sql"
+        run_schema(schema_path)
+        _schema_healed_once = True
+        return True

--- a/develop_report/2026-02-26_issue319_api500_db_schema_hotfix_report.md
+++ b/develop_report/2026-02-26_issue319_api500_db_schema_hotfix_report.md
@@ -1,0 +1,57 @@
+# 2026-02-26 Issue #319 운영 API 500 핫픽스 보고서
+
+## 1) 이슈
+- 대상: https://2026-api-production.up.railway.app
+- 재현(수집 시각: 2026-02-26)
+  - `GET /health` -> `200`
+  - `GET /api/v1/dashboard/summary` -> `500`
+  - `GET /api/v1/dashboard/map-latest` -> `500`
+  - `GET /api/v1/dashboard/big-matches` -> `500`
+  - `GET /api/v1/regions/search?q=강원` -> `500`
+  - `GET /api/v1/regions/42-000/elections` -> `500`
+  - `GET /health/db` -> `404` (기존 미구현)
+
+## 2) 원인 가설 정리
+- 프로세스는 살아있으나 DB 의존 경로에서 실패하는 패턴.
+- 가능성 2축:
+  1. `DATABASE_URL` 미설정/오설정
+  2. 런타임 DB 스키마가 코드 쿼리와 불일치(컬럼/테이블 누락)
+
+## 3) 적용한 핫픽스
+1. DB 의존성 에러를 500 대신 503으로 명확화
+- 파일: `/Users/gimtaehun/election2026_codex/app/db.py`
+- `DatabaseConfigurationError`, `DatabaseConnectionError` 추가
+- 설정 누락/연결 실패를 명시적으로 분리
+
+2. API 의존성 레이어에서 DB 에러 매핑 강화
+- 파일: `/Users/gimtaehun/election2026_codex/app/api/dependencies.py`
+- repository dependency에서 DB 설정/연결/쿼리 실패를 `503`으로 반환
+
+3. 런타임 스키마 가드 추가
+- 파일: `/Users/gimtaehun/election2026_codex/app/runtime_db_guard.py`
+- Railway 환경(또는 `AUTO_APPLY_SCHEMA_ON_STARTUP=true`)에서 startup 시 `db/schema.sql` 자동 적용
+- SQLSTATE `42P01`/`42703`(undefined table/column) 감지 시 1회 schema heal 시도
+
+4. 운영 진단 엔드포인트 추가
+- 파일: `/Users/gimtaehun/election2026_codex/app/main.py`
+- `GET /health/db` 추가 (DB ping + bootstrap 상태)
+- psycopg 예외 핸들러 추가 (스키마 mismatch 진단 메시지 제공)
+
+## 4) 테스트
+- 실행:
+  - `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q tests/test_api_routes.py tests/test_runtime_db_guard.py`
+- 결과:
+  - `25 passed`
+
+## 5) 운영 반영 후 검증 항목
+- 아래 6개 endpoint가 모두 `200`인지 재확인 필요:
+  1. `/api/v1/dashboard/summary`
+  2. `/api/v1/dashboard/map-latest`
+  3. `/api/v1/dashboard/big-matches`
+  4. `/api/v1/regions/search?q=강원`
+  5. `/api/v1/regions/42-000/elections`
+  6. `/health/db`
+
+## 6) 남은 확인/결정
+- Railway 재배포 후에도 `DATABASE_URL` 오설정이면 `/health/db`가 `503(database_not_configured|database_connection_failed)`를 반환함.
+- 이 경우 오너가 Railway 변수의 `DATABASE_URL` 실제값(특수문자 URL-encoding 포함)을 재확인해야 함.

--- a/tests/test_runtime_db_guard.py
+++ b/tests/test_runtime_db_guard.py
@@ -1,0 +1,25 @@
+from app.runtime_db_guard import should_auto_apply_schema_on_startup
+
+
+def test_should_auto_apply_schema_on_startup_defaults_to_false_without_railway(monkeypatch):
+    monkeypatch.delenv("AUTO_APPLY_SCHEMA_ON_STARTUP", raising=False)
+    monkeypatch.delenv("RAILWAY_PROJECT_ID", raising=False)
+    monkeypatch.delenv("RAILWAY_SERVICE_ID", raising=False)
+    assert should_auto_apply_schema_on_startup() is False
+
+
+def test_should_auto_apply_schema_on_startup_uses_explicit_env(monkeypatch):
+    monkeypatch.setenv("AUTO_APPLY_SCHEMA_ON_STARTUP", "true")
+    monkeypatch.delenv("RAILWAY_PROJECT_ID", raising=False)
+    monkeypatch.delenv("RAILWAY_SERVICE_ID", raising=False)
+    assert should_auto_apply_schema_on_startup() is True
+
+    monkeypatch.setenv("AUTO_APPLY_SCHEMA_ON_STARTUP", "false")
+    monkeypatch.setenv("RAILWAY_PROJECT_ID", "dummy")
+    assert should_auto_apply_schema_on_startup() is False
+
+
+def test_should_auto_apply_schema_on_startup_enables_on_railway(monkeypatch):
+    monkeypatch.delenv("AUTO_APPLY_SCHEMA_ON_STARTUP", raising=False)
+    monkeypatch.setenv("RAILWAY_SERVICE_ID", "svc-123")
+    assert should_auto_apply_schema_on_startup() is True


### PR DESCRIPTION
## Summary
- add explicit DB dependency error handling so DB misconfig/connection/query failures no longer surface as opaque 500s
- add runtime schema guard:
  - startup schema bootstrap on Railway (or `AUTO_APPLY_SCHEMA_ON_STARTUP=true`)
  - one-time schema heal attempt when SQLSTATE indicates undefined table/column (`42P01`, `42703`)
- add `GET /health/db` for DB ping + bootstrap state visibility
- add tests for `/health/db` and runtime guard env behavior

## Baseline (before deploy)
- production URL: `https://2026-api-production.up.railway.app`
- observed on 2026-02-26:
  - `/health` -> 200
  - `/api/v1/dashboard/summary` -> 500
  - `/api/v1/dashboard/map-latest` -> 500
  - `/api/v1/dashboard/big-matches` -> 500
  - `/api/v1/regions/search?q=강원` -> 500
  - `/api/v1/regions/42-000/elections` -> 500

## Test
- `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q tests/test_api_routes.py tests/test_runtime_db_guard.py`
- `25 passed`

## Deploy-time verification checklist
1. `/health/db` returns 200
2. five public endpoints recover to 200
3. if `/health/db` is 503, fix Railway `DATABASE_URL` and redeploy

Closes #319

Report-Path: develop_report/2026-02-26_issue319_api500_db_schema_hotfix_report.md
