### PR TITLE
[DEVELOP][P0] fix schema-heal bypass in repository dependency

### DIFF
--- a/develop_report/2026-02-26_issue319_schema_heal_dependency_path_hotfix_report.md
+++ b/develop_report/2026-02-26_issue319_schema_heal_dependency_path_hotfix_report.md
@@ -1,0 +1,29 @@
+# 2026-02-26 Issue #319 Schema Heal Dependency Path Hotfix Report
+
+## 1) 배경
+- 운영 재검증에서 `/health/db`는 `ok`로 복구됐지만, `/api/v1/regions/42-000/elections`는 계속 `503` + `42P01`.
+- 원인 분석 결과, `get_repository()`가 `psycopg.Error`를 즉시 `HTTPException`으로 변환하여 schema auto-heal 경로가 실행되지 않음.
+
+## 2) 수정 내용
+1. dependency 경로에서 schema mismatch 처리 추가
+- 파일: `/Users/gimtaehun/election2026_codex/app/api/dependencies.py`
+- SQLSTATE `42P01`/`42703` 감지 시 `heal_schema_once()` 시도
+- heal 성공 시: `503` + `database schema auto-healed; retry request`
+- heal 미적용 시: `503` + `database schema mismatch detected`
+
+2. 단위 테스트 추가
+- 파일: `/Users/gimtaehun/election2026_codex/tests/test_api_dependencies.py`
+- 검증 항목:
+  - schema mismatch + heal success
+  - schema mismatch + heal not applied
+  - non-schema DB error 기본 동작 유지
+
+## 3) 테스트
+- 실행:
+  - `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q tests/test_api_dependencies.py tests/test_api_routes.py tests/test_runtime_db_guard.py`
+- 결과:
+  - `28 passed`
+
+## 4) 기대 효과
+- 스키마 미스매치 상황에서 첫 실패 요청 이후 heal 트리거가 실제로 실행됨.
+- 재시도 시 `/api/v1/regions/{region_code}/elections` 경로의 42P01 잔존 가능성 감소.

--- a/tests/test_api_dependencies.py
+++ b/tests/test_api_dependencies.py
@@ -1,0 +1,59 @@
+from contextlib import contextmanager
+
+import psycopg
+import pytest
+from fastapi import HTTPException
+
+import app.api.dependencies as deps
+
+
+@contextmanager
+def _fake_connection():
+    yield object()
+
+
+def _make_psycopg_error(sqlstate: str) -> psycopg.Error:
+    err = psycopg.ProgrammingError("boom")
+    err.sqlstate = sqlstate
+    return err
+
+
+def test_get_repository_schema_mismatch_triggers_heal(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(deps, "get_connection", _fake_connection)
+    monkeypatch.setattr(deps, "heal_schema_once", lambda: True)
+
+    gen = deps.get_repository()
+    _ = next(gen)
+
+    with pytest.raises(HTTPException) as exc_info:
+        gen.throw(_make_psycopg_error("42P01"))
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == "database schema auto-healed; retry request"
+
+
+def test_get_repository_schema_mismatch_reports_detected_when_heal_not_applied(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(deps, "get_connection", _fake_connection)
+    monkeypatch.setattr(deps, "heal_schema_once", lambda: False)
+
+    gen = deps.get_repository()
+    _ = next(gen)
+
+    with pytest.raises(HTTPException) as exc_info:
+        gen.throw(_make_psycopg_error("42703"))
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == "database schema mismatch detected"
+
+
+def test_get_repository_non_schema_db_error_keeps_sqlstate_detail(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(deps, "get_connection", _fake_connection)
+
+    gen = deps.get_repository()
+    _ = next(gen)
+
+    with pytest.raises(HTTPException) as exc_info:
+        gen.throw(_make_psycopg_error("40001"))
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == "database query failed (40001)"


### PR DESCRIPTION
## Summary
- fix a regression in DB error handling path where `get_repository()` converted `psycopg.Error` to `HTTPException` too early and bypassed schema auto-heal
- when SQLSTATE is schema-mismatch (`42P01`, `42703`), dependency layer now triggers `heal_schema_once()`
- response detail now distinguishes:
  - `database schema auto-healed; retry request`
  - `database schema mismatch detected`
- add focused unit tests for dependency behavior

## Test
- `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q tests/test_api_dependencies.py tests/test_api_routes.py tests/test_runtime_db_guard.py`
- `28 passed`

Refs #319

Report-Path: develop_report/2026-02-26_issue319_schema_heal_dependency_path_hotfix_report.md
