### PR TITLE
[DEVELOP][P0] #347 Railway 운영 동기화 strict 스모크 및 런북 반영

### DIFF
--- a/develop_report/2026-02-26_issue347_railway_operational_sync_recovery_report.md
+++ b/develop_report/2026-02-26_issue347_railway_operational_sync_recovery_report.md
@@ -1,0 +1,67 @@
+# [DEVELOP] Issue #347 Railway 운영 API 동기화 복구 보고서
+
+- 작성일: 2026-02-26
+- 이슈: https://github.com/iAmSomething/2026-/issues/347
+- 담당: role/develop
+- 우선순위: P0
+
+## 1) 목적
+`main` 머지 후 Railway 운영 API가 최신 커밋과 동기화되지 않아 발생한 회귀 상태를 복구하고,
+재발 시 즉시 판정 가능한 strict 스모크 절차를 정립한다.
+
+## 2) 변경 사항
+
+### A. 운영 스모크 strict-contract 모드 추가
+- 파일: `scripts/qa/smoke_public_api.sh`
+- 신규 옵션: `--strict-contract`
+- strict 검증 항목:
+  1. `GET /api/v1/dashboard/map-latest?limit=200` 노이즈 옵션(`재정자립도/지지/국정안정론/국정견제론`) 0건
+  2. `GET /api/v1/regions/29-000/elections` title 전부 `세종` 포함
+
+### B. 런북 업데이트
+- 파일: `docs/05_RUNBOOK_AND_OPERATIONS.md`
+- 공개 API 원격 스모크 섹션에 strict-contract 설명/실행 예시 추가
+
+## 3) 운영 실측 증빙 (UTC)
+실측 시각: 2026-02-26 10:34:40 UTC
+
+1. 기본 스모크
+```bash
+bash scripts/qa/smoke_public_api.sh \
+  --api-base "https://2026-api-production.up.railway.app" \
+  --web-origin "https://2026-deploy.vercel.app" \
+  --out-dir /tmp/public_api_smoke_issue347
+```
+- 결과: PASS
+- health/summary/regions/candidate/cors 모두 200
+
+2. strict 스모크
+```bash
+bash scripts/qa/smoke_public_api.sh \
+  --api-base "https://2026-api-production.up.railway.app" \
+  --web-origin "https://2026-deploy.vercel.app" \
+  --out-dir /tmp/public_api_smoke_issue347_strict \
+  --strict-contract
+```
+- 결과: PASS
+- `map_noise_count=0`
+- `sejong_bad_title_count=0`
+
+3. 직접 API 확인
+- `GET /api/v1/regions/29-000/elections`
+  - `세종시장`, `세종시의회`, `세종교육감` 확인
+- `GET /api/v1/dashboard/map-latest?limit=200`
+  - 문제 옵션 미노출 확인
+
+## 4) 결론
+- 운영 API 동기화 상태 정상으로 판단.
+- #347 수용기준(운영 실측 + 재검증 가능 절차) 충족.
+
+## 5) 의사결정 필요 사항
+1. strict 스모크 CI 편입 여부
+- 현재는 수동 실행 스크립트.
+- `staging/prod smoke` 워크플로에 `--strict-contract`을 기본값으로 넣을지 결정 필요.
+
+2. matchups 후보 옵션 empty 정책
+- 현재 일부 매치업에서 노이즈 필터 적용 후 `options=[]` 가능.
+- UI 문구/상태 정책(예: "후보정보 정제중") 고정 여부를 UIUX/QA와 합의 필요.

--- a/docs/05_RUNBOOK_AND_OPERATIONS.md
+++ b/docs/05_RUNBOOK_AND_OPERATIONS.md
@@ -386,12 +386,23 @@ curl -sS -o /tmp/web_rc_candidate.json -w "%{http_code}\n" "$API_BASE/api/v1/can
 - `GET /api/v1/regions/search?q=서울` (200, `query` alias도 허용)
 - `GET /api/v1/candidates/cand-jwo` (200 또는 계약된 404)
 - CORS preflight(`OPTIONS /api/v1/dashboard/summary`) 응답 및 `access-control-allow-origin` 일치
+4. strict-contract 모드(회귀 핫스팟 확인):
+- `GET /api/v1/dashboard/map-latest?limit=200`에서 노이즈 옵션(`재정자립도/지지/국정안정론/국정견제론`) 0건
+- `GET /api/v1/regions/29-000/elections`의 title이 모두 `세종` 포함
 4. 실행 예시:
 ```bash
 scripts/qa/smoke_public_api.sh \
   --api-base "https://2026-api-production.up.railway.app" \
   --web-origin "https://2026-deploy.vercel.app" \
   --out-dir /tmp/public_api_smoke
+```
+5. strict 실행 예시:
+```bash
+scripts/qa/smoke_public_api.sh \
+  --api-base "https://2026-api-production.up.railway.app" \
+  --web-origin "https://2026-deploy.vercel.app" \
+  --out-dir /tmp/public_api_smoke_strict \
+  --strict-contract
 ```
 
 ## 16. 공개 웹 라우트 RC 스모크

--- a/scripts/qa/smoke_public_api.sh
+++ b/scripts/qa/smoke_public_api.sh
@@ -4,10 +4,12 @@ set -euo pipefail
 API_BASE="${API_BASE:-https://2026-api-production.up.railway.app}"
 WEB_ORIGIN="${WEB_ORIGIN:-https://2026-deploy.vercel.app}"
 OUT_DIR="${OUT_DIR:-/tmp/public_api_smoke}"
+STRICT_CONTRACT="${STRICT_CONTRACT:-0}"
 
 usage() {
   cat <<USAGE
 Usage: $0 [--api-base URL] [--web-origin URL] [--out-dir PATH]
+          [--strict-contract]
 USAGE
 }
 
@@ -24,6 +26,10 @@ while [[ $# -gt 0 ]]; do
     --out-dir)
       OUT_DIR="${2:-}"
       shift 2
+      ;;
+    --strict-contract)
+      STRICT_CONTRACT=1
+      shift 1
       ;;
     -h|--help)
       usage
@@ -50,11 +56,19 @@ request() {
 
 echo "[INFO] API_BASE=${API_BASE}"
 echo "[INFO] WEB_ORIGIN=${WEB_ORIGIN}"
+echo "[INFO] STRICT_CONTRACT=${STRICT_CONTRACT}"
 
 health_status="$(request "health" "/health" | awk '{print $2}')"
 summary_status="$(request "summary" "/api/v1/dashboard/summary" | awk '{print $2}')"
 regions_status="$(request "regions" "/api/v1/regions/search?q=%EC%84%9C%EC%9A%B8" | awk '{print $2}')"
 candidate_status="$(request "candidate" "/api/v1/candidates/cand-jwo" | awk '{print $2}')"
+
+map_latest_status=""
+sejong_status=""
+if [[ "$STRICT_CONTRACT" == "1" ]]; then
+  map_latest_status="$(request "map_latest" "/api/v1/dashboard/map-latest?limit=200" | awk '{print $2}')"
+  sejong_status="$(request "sejong_elections" "/api/v1/regions/29-000/elections" | awk '{print $2}')"
+fi
 
 curl -sS -D "$OUT_DIR/cors_headers.txt" -o "$OUT_DIR/cors_body.txt" \
   -X OPTIONS "${API_BASE}/api/v1/dashboard/summary" \
@@ -67,6 +81,9 @@ cors_allow_origin="$(awk -F': ' 'tolower($1)=="access-control-allow-origin" {pri
 
 echo "[RESULT] health=${health_status} summary=${summary_status} regions=${regions_status} candidate=${candidate_status} cors=${cors_status}"
 echo "[RESULT] cors_allow_origin=${cors_allow_origin:-<empty>}"
+if [[ "$STRICT_CONTRACT" == "1" ]]; then
+  echo "[RESULT] strict map_latest=${map_latest_status} sejong_elections=${sejong_status}"
+fi
 
 failed=0
 [[ "$health_status" == "200" ]] || failed=1
@@ -75,6 +92,37 @@ failed=0
 [[ "$candidate_status" == "200" || "$candidate_status" == "404" ]] || failed=1
 [[ "$cors_status" == "200" || "$cors_status" == "204" ]] || failed=1
 [[ "${cors_allow_origin:-}" == "$WEB_ORIGIN" ]] || failed=1
+
+if [[ "$STRICT_CONTRACT" == "1" ]]; then
+  [[ "$map_latest_status" == "200" ]] || failed=1
+  [[ "$sejong_status" == "200" ]] || failed=1
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "[FAIL] strict-contract requires jq"
+    failed=1
+  else
+    map_noise_count="$(
+      jq '[.items[]?.option_name | select(.=="재정자립도" or .=="지지" or .=="국정안정론" or .=="국정견제론")] | length' \
+        "$OUT_DIR/map_latest.json" 2>/dev/null || echo "-1"
+    )"
+    sejong_bad_title_count="$(
+      jq '[.[]? | select(.region_code=="29-000" and ((.title | tostring) | contains("세종") | not))] | length' \
+        "$OUT_DIR/sejong_elections.json" 2>/dev/null || echo "-1"
+    )"
+
+    echo "[RESULT] strict map_noise_count=${map_noise_count} sejong_bad_title_count=${sejong_bad_title_count}"
+
+    [[ "$map_noise_count" =~ ^[0-9]+$ ]] || failed=1
+    [[ "$sejong_bad_title_count" =~ ^[0-9]+$ ]] || failed=1
+
+    if [[ "$map_noise_count" =~ ^[0-9]+$ ]] && [[ "$map_noise_count" -gt 0 ]]; then
+      failed=1
+    fi
+    if [[ "$sejong_bad_title_count" =~ ^[0-9]+$ ]] && [[ "$sejong_bad_title_count" -gt 0 ]]; then
+      failed=1
+    fi
+  fi
+fi
 
 if [[ "$failed" -eq 1 ]]; then
   echo "[FAIL] public API smoke check failed"


### PR DESCRIPTION
## Summary
- 운영 API 동기화 판정을 위한 `smoke_public_api.sh --strict-contract` 모드를 추가했습니다.
- strict 모드에서 `map-latest` 노이즈 옵션과 `29-000` 세종 라벨을 함께 검증합니다.
- 런북에 strict 실행 절차를 반영했습니다.
- 운영 실측 결과(strict 포함 PASS)를 보고서에 기록했습니다.

## Changes
- `scripts/qa/smoke_public_api.sh`
- `docs/05_RUNBOOK_AND_OPERATIONS.md`
- `develop_report/2026-02-26_issue347_railway_operational_sync_recovery_report.md`

## Validation
- `bash -n scripts/qa/smoke_public_api.sh`
- `bash scripts/qa/smoke_public_api.sh --api-base "https://2026-api-production.up.railway.app" --web-origin "https://2026-deploy.vercel.app" --out-dir /tmp/public_api_smoke_issue347`
- `bash scripts/qa/smoke_public_api.sh --api-base "https://2026-api-production.up.railway.app" --web-origin "https://2026-deploy.vercel.app" --out-dir /tmp/public_api_smoke_issue347_strict --strict-contract`

Report-Path: develop_report/2026-02-26_issue347_railway_operational_sync_recovery_report.md

Closes #347
