### PR TITLE
[DEVELOP] queue hygiene follow-up report

### DIFF
--- a/develop_report/2026-02-26_develop_queue_hygiene_followup_report.md
+++ b/develop_report/2026-02-26_develop_queue_hygiene_followup_report.md
@@ -1,0 +1,33 @@
+# [DEVELOP] Queue Hygiene Follow-up Report
+
+- 작성일: 2026-02-26
+- 담당: role/develop
+
+## 1) 작업 목적
+- develop 큐 상태를 재점검하고, 최근 종료 이슈의 라벨 계약(`status/*`) 정합을 보완해 재오픈/오탐 리스크를 낮춘다.
+
+## 2) 수행 내용
+1. 오픈 develop 이슈 재점검
+- 조회 결과: `role/develop` 오픈 이슈 0건
+
+2. 최근 종료 develop 이슈 라벨 정리
+- 대상 이슈:
+  - #347 `[DEVELOP][P0] main 머지 후 Railway 운영 API 미동기화 배포 복구`
+  - #345 `[DEVELOP][P0] 운영 API 데이터 품질 회귀 핫픽스(후보명/정당/검색 응답 정합)`
+  - #338 `[DEVELOP][P0] regions/elections 시도명 매핑 회귀 복구(세종→광주 오표기 수정)`
+- 조치:
+  - #347: `status/done` 추가
+  - #345: `status/done` 추가
+  - #338: `status/in-progress` 제거, `status/done` 추가
+
+3. 정리 후 확인
+- 최근 종료 develop 이슈 top 10 기준 `status/done` 일관성 확인 완료
+
+## 3) 현재 상태
+- `role/develop` 오픈 이슈: 0건
+- develop 관련 오픈 PR: 0건
+
+## 4) 의사결정 필요 사항
+1. `closed + status/done` 외에 `QA PASS` 코멘트 강제 여부
+- 일부 자동검증 규칙이 닫힌 이슈에서 QA PASS를 요구할 수 있음.
+- PM/QA 규칙을 확정해 개발 종료 시점의 라벨/코멘트 템플릿을 고정할지 결정 필요.


### PR DESCRIPTION
## Summary
- develop 큐 follow-up 점검 결과를 보고서로 추가했습니다.
- 최근 종료 develop 이슈(#347/#345/#338)의 `status` 라벨 정합화 작업을 기록했습니다.
- 현재 `role/develop` 오픈 이슈/PR 0건 상태를 기록했습니다.

## Changes
- `develop_report/2026-02-26_develop_queue_hygiene_followup_report.md`

Report-Path: develop_report/2026-02-26_develop_queue_hygiene_followup_report.md
