### PR TITLE
[DEVELOP][P0] #352 매치업 제목 정책 운영 반영(런타임 동기화)

### DIFF
--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -213,6 +213,8 @@ class MatchupOut(BaseModel):
     region_code: str
     office_type: str
     title: str
+    canonical_title: str | None = None
+    article_title: str | None = None
     has_data: bool = True
     pollster: str | None = None
     survey_start_date: date | None = None

--- a/app/services/repository.py
+++ b/app/services/repository.py
@@ -1722,13 +1722,16 @@ class PostgresRepository:
             return None
 
         canonical_matchup_id = matchup_meta["matchup_id"]
+        canonical_title = str(matchup_meta.get("title") or "").strip() or canonical_matchup_id
         observation = self._fetch_latest_matchup_observation(canonical_matchup_id)
         if not observation:
             return {
                 "matchup_id": canonical_matchup_id,
                 "region_code": matchup_meta["region_code"],
                 "office_type": matchup_meta["office_type"],
-                "title": matchup_meta["title"] or canonical_matchup_id,
+                "title": canonical_title,
+                "canonical_title": canonical_title,
+                "article_title": None,
                 "has_data": False,
                 "pollster": None,
                 "survey_start_date": None,
@@ -1762,11 +1765,19 @@ class PostgresRepository:
 
         options = self._normalize_options(observation.get("options"))
         scenarios, primary_options = self._build_matchup_scenarios(options)
+        observation_title = str(observation.get("title") or "").strip()
+        if not canonical_title:
+            canonical_title = observation_title or canonical_matchup_id
+        article_title = observation_title or None
+        if article_title and article_title == canonical_title:
+            article_title = None
         return {
             "matchup_id": observation["matchup_id"],
             "region_code": observation["region_code"],
             "office_type": observation["office_type"],
-            "title": observation["title"],
+            "title": canonical_title,
+            "canonical_title": canonical_title,
+            "article_title": article_title,
             "has_data": True,
             "pollster": observation["pollster"],
             "survey_start_date": observation["survey_start_date"],

--- a/apps/web/app/matchups/[matchup_id]/page.js
+++ b/apps/web/app/matchups/[matchup_id]/page.js
@@ -110,6 +110,9 @@ export default async function MatchupPage({ params, searchParams }) {
   }
 
   const matchup = payload.body;
+  const canonicalTitle = matchup.canonical_title || matchup.title || matchup.matchup_id;
+  const articleSubtitle =
+    matchup.article_title && matchup.article_title !== canonicalTitle ? matchup.article_title : null;
   let scenarios = Array.isArray(matchup.scenarios) && matchup.scenarios.length > 0
     ? matchup.scenarios.map((scenario) => ({
         ...scenario,
@@ -200,7 +203,8 @@ export default async function MatchupPage({ params, searchParams }) {
       <section className="panel detail-hero">
         <div>
           <p className="kicker">MATCHUP DETAIL</p>
-          <h1>{matchup.title || matchup.matchup_id}</h1>
+          <h1>{canonicalTitle}</h1>
+          {articleSubtitle ? <p className="muted-text">기사 제목: {articleSubtitle}</p> : null}
           <p>
             {matchup.pollster || "조사기관 미상"} · {formatDate(matchup.survey_start_date)} ~ {formatDate(matchup.survey_end_date)}
           </p>

--- a/develop_report/2026-02-26_issue352_matchup_title_runtime_sync_report.md
+++ b/develop_report/2026-02-26_issue352_matchup_title_runtime_sync_report.md
@@ -1,0 +1,60 @@
+# 2026-02-26 issue352 matchup title runtime sync report
+
+## 1. 이슈
+- Issue: #352
+- 제목: [DEVELOP][P0] #340 매치업 제목 정책 운영 반영(런타임 동기화)
+- 목표: 매치업 상세에서 `h1`은 canonical 제목으로 고정하고, 기사형 제목은 부제로 분리 노출.
+
+## 2. 변경 파일
+1. `app/services/repository.py`
+2. `app/models/schemas.py`
+3. `apps/web/app/matchups/[matchup_id]/page.js`
+4. `tests/test_repository_matchup_legal_metadata.py`
+5. `tests/test_api_routes.py`
+
+## 3. 구현 내용
+1. API/Repository 제목 정책 반영
+- `get_matchup()`에서 `matchups.title`을 canonical 제목으로 우선 사용.
+- 응답 필드 추가:
+  - `canonical_title`
+  - `article_title`
+- `title`은 canonical 제목으로 고정.
+- 기사 제목이 canonical과 동일하면 `article_title`은 `null`로 정규화.
+
+2. 웹 런타임 렌더링 정책 반영 (`apps/web`)
+- 매치업 상세 상단:
+  - `h1`: `canonical_title` 우선, 없으면 `title`, 최후 `matchup_id`
+  - 부제: `article_title`이 있고 canonical과 다를 때만 `기사 제목: ...`로 노출
+
+3. 계약 테스트 보강
+- repository 테스트에서 canonical/meta 제목과 observation 제목이 다를 때 분리 저장/응답을 검증.
+- API 계약 테스트에서 `canonical_title`, `article_title` 키 존재 검증.
+
+## 4. 검증 로그
+1. Python/pytest (3.13)
+- 명령:
+```bash
+source .venv313/bin/activate && pytest tests/test_repository_matchup_legal_metadata.py tests/test_repository_matchup_scenarios.py tests/test_api_routes.py
+```
+- 결과: `28 passed`
+
+2. Web build (`apps/web`)
+- 명령:
+```bash
+npm --prefix apps/web run build
+```
+- 결과: 성공 (`/matchups/[matchup_id]` 포함)
+
+3. 런타임/환경 메모
+- Python 3.14에서는 `pydantic-core` 빌드 이슈로 실패 확인.
+- 동일 설치를 Python 3.13 가상환경(`.venv313`)에서 성공 확인.
+
+## 5. 배포 경로 일치 근거
+- CI 배포 워크플로: `.github/workflows/vercel-preview.yml`
+- `root_dir` 허용값/기본값: `apps/web` 단일
+- deploy 단계는 repo root에서 `vercel deploy` 수행(프로젝트 rootDirectory 중복 방지 주석 포함)
+
+## 6. 남은 운영 확인 항목
+- main 반영 후 운영 URL 실증(요구사항):
+  1. before/after 캡처 2건 이상
+  2. `h1=canonical` + `부제=기사 제목` 동시 확인

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -651,6 +651,8 @@ def test_api_contract_fields():
     matchup = client.get("/api/v1/matchups/20260603|광역자치단체장|11-000")
     assert matchup.status_code == 200
     assert matchup.json()["has_data"] is True
+    assert "canonical_title" in matchup.json()
+    assert "article_title" in matchup.json()
     assert matchup.json()["options"][0]["option_name"] == "정원오"
     assert matchup.json()["survey_start_date"] == "2026-02-15"
     assert matchup.json()["audience_scope"] == "regional"

--- a/tests/test_repository_matchup_legal_metadata.py
+++ b/tests/test_repository_matchup_legal_metadata.py
@@ -24,7 +24,7 @@ class _Cursor:
                 "matchup_id": "m1",
                 "region_code": "11-000",
                 "office_type": "광역자치단체장",
-                "title": "서울시장 가상대결",
+                "title": "서울특별시장 선거",
                 "is_active": True,
             }
         if self._step == 1:
@@ -33,7 +33,7 @@ class _Cursor:
                 "matchup_id": "m1",
                 "region_code": "11-000",
                 "office_type": "광역자치단체장",
-                "title": "서울시장 가상대결",
+                "title": "[여론조사] 서울시장 양자대결 정원오-오세훈",
                 "pollster": "KBS",
                 "survey_start_date": date(2026, 2, 15),
                 "survey_end_date": date(2026, 2, 18),
@@ -98,6 +98,9 @@ def test_get_matchup_returns_legal_metadata_fields():
     out = repo.get_matchup("m1")
 
     assert out is not None
+    assert out["title"] == "서울특별시장 선거"
+    assert out["canonical_title"] == "서울특별시장 선거"
+    assert out["article_title"] == "[여론조사] 서울시장 양자대결 정원오-오세훈"
     assert out["survey_start_date"] == date(2026, 2, 15)
     assert out["confidence_level"] == 95.0
     assert out["sample_size"] == 1000


### PR DESCRIPTION
## Summary
- matchup API title policy synced to runtime contract
- `title` now resolves to canonical title from matchup metadata
- added `canonical_title` and `article_title` in matchup response
- matchup detail page renders `h1=canonical` and article title as subtitle
- added regression tests and develop report

## Linked Issue
- Closes #352

## Report-Path
Report-Path: develop_report/2026-02-26_issue352_matchup_title_runtime_sync_report.md

## Verification
- `source .venv313/bin/activate && pytest tests/test_repository_matchup_legal_metadata.py tests/test_repository_matchup_scenarios.py tests/test_api_routes.py`
- `npm --prefix apps/web run build`
