### PR TITLE
[DEVELOP][P0] #352 reopen canonical title source hardening

### DIFF
--- a/develop_report/2026-02-26_issue352_runtime_sync_reopen_fix_report.md
+++ b/develop_report/2026-02-26_issue352_runtime_sync_reopen_fix_report.md
@@ -1,0 +1,49 @@
+# 2026-02-26 issue352 runtime sync reopen fix report
+
+## 1. 배경
+- 이슈: #352 (reopen)
+- 재오픈 원인: 운영 URL에서 매치업 상세 `h1`이 기사형 제목으로 노출됨.
+- 기존 반영(PR #356): `canonical_title/article_title` 필드 추가 및 page.js 렌더링 반영.
+- 잔존 문제: `canonical_title` 생성이 `matchups.title` 오염 데이터에 종속되어 canonical이 기사형 문자열로 남음.
+
+## 2. 재현 증거 (reopen 시점)
+1. 운영 웹 `h1` 확인
+- `/matchups/m_2026_seoul_mayor` -> `<h1>전국지표조사(NBS) 2026-02-26`
+- `/matchups/2026_local|기초자치단체장|28-450` -> `<h1>[여론조사] 인천시장 양자대결 ...`
+
+2. 운영 API 확인
+- `GET /api/v1/matchups/m_2026_seoul_mayor`
+  - `title`: `전국지표조사(NBS) 2026-02-26`
+  - `canonical_title`: `전국지표조사(NBS) 2026-02-26`
+  - `article_title`: `null`
+
+## 3. 이번 수정
+1. `app/services/repository.py`
+- `get_matchup()` canonical 제목 산출 로직 교체:
+  - 기존: `matchups.title` 우선(오염 시 그대로 전파)
+  - 변경: `regions(region_code)` + `office_type` 기반 canonical 생성
+- 추가 메서드:
+  - `_strip_region_suffix`
+  - `_derive_matchup_title_from_region`
+  - `_fetch_region_for_matchup_title`
+- 결과: `matchups.title`가 기사형이어도 canonical 제목이 지역+선거유형 규칙으로 복원됨.
+
+2. 테스트 보강
+- `tests/test_repository_matchup_legal_metadata.py`
+  - 오염된 meta/observation title 입력에서도 canonical이 `서울시장`으로 복원되는지 검증.
+- `tests/test_repository_matchup_scenarios.py`
+  - 신규 region 조회 쿼리 순서를 반영하도록 fixture cursor step 보정.
+
+## 4. 검증
+1. 명령
+```bash
+source .venv313/bin/activate && pytest tests/test_repository_matchup_legal_metadata.py tests/test_repository_matchup_scenarios.py tests/test_api_routes.py
+```
+
+2. 결과
+- `28 passed`
+
+## 5. 남은 운영 확인
+- main 반영 후 아래 2개 URL에서 증빙 채취 필요:
+  1. `h1`이 canonical 제목인지
+  2. `기사 제목: ...` 부제 라인이 함께 노출되는지

--- a/tests/test_repository_matchup_legal_metadata.py
+++ b/tests/test_repository_matchup_legal_metadata.py
@@ -24,10 +24,18 @@ class _Cursor:
                 "matchup_id": "m1",
                 "region_code": "11-000",
                 "office_type": "광역자치단체장",
-                "title": "서울특별시장 선거",
+                "title": "[여론조사] 서울시장 양자대결 정원오-오세훈",
                 "is_active": True,
             }
         if self._step == 1:
+            self._step += 1
+            return {
+                "region_code": "11-000",
+                "sido_name": "서울특별시",
+                "sigungu_name": "전체",
+                "admin_level": "sido",
+            }
+        if self._step == 2:
             self._step += 1
             return {
                 "matchup_id": "m1",
@@ -98,8 +106,8 @@ def test_get_matchup_returns_legal_metadata_fields():
     out = repo.get_matchup("m1")
 
     assert out is not None
-    assert out["title"] == "서울특별시장 선거"
-    assert out["canonical_title"] == "서울특별시장 선거"
+    assert out["title"] == "서울시장"
+    assert out["canonical_title"] == "서울시장"
     assert out["article_title"] == "[여론조사] 서울시장 양자대결 정원오-오세훈"
     assert out["survey_start_date"] == date(2026, 2, 15)
     assert out["confidence_level"] == 95.0
@@ -121,4 +129,4 @@ def test_get_matchup_returns_legal_metadata_fields():
     assert out["options"][0]["needs_manual_review"] is False
     assert out["scenarios"][0]["scenario_type"] == "head_to_head"
     assert out["scenarios"][0]["scenario_title"] == "정원오 vs 오세훈"
-    assert len(conn.cur.execs) == 2
+    assert len(conn.cur.execs) == 3

--- a/tests/test_repository_matchup_scenarios.py
+++ b/tests/test_repository_matchup_scenarios.py
@@ -30,6 +30,14 @@ class _Cursor:
         if self._step == 1:
             self._step += 1
             return {
+                "region_code": "26-000",
+                "sido_name": "부산광역시",
+                "sigungu_name": "전체",
+                "admin_level": "sido",
+            }
+        if self._step == 2:
+            self._step += 1
+            return {
                 "matchup_id": "m1",
                 "region_code": "26-000",
                 "office_type": "광역자치단체장",


### PR DESCRIPTION
## Summary
- fix canonical matchup title generation to avoid polluted `matchups.title` values
- derive canonical title from `regions(region_code)` + `office_type` rule
- keep article headline in `article_title` when different from canonical
- update repository tests for added region lookup query and canonical restoration path

## Linked Issue
- Closes #352

## Report-Path
Report-Path: develop_report/2026-02-26_issue352_runtime_sync_reopen_fix_report.md

## Verification
- `source .venv313/bin/activate && pytest tests/test_repository_matchup_legal_metadata.py tests/test_repository_matchup_scenarios.py tests/test_api_routes.py`
