### PR TITLE
[COLLECTOR][P0] #339 runtime blocked update2 보고서

### DIFF
--- a/Collector_reports/2026-02-26_issue339_runtime_blocked_update2_report.md
+++ b/Collector_reports/2026-02-26_issue339_runtime_blocked_update2_report.md
@@ -1,0 +1,27 @@
+# 2026-02-26 Issue339 Runtime Blocked Update 2 Report
+
+## 요약
+- #339 3블록 분리 코드(PR #378)는 main 반영 완료
+- 운영 재적재를 수동으로 재시도했으나 ingest schedule이 동일하게 DB 503으로 실패
+- 따라서 운영 `26-710` after 검증(`scenario_count>=3`)은 아직 수행 불가
+
+## 최신 재시도 증빙
+- workflow run: https://github.com/iAmSomething/2026-/actions/runs/22440075570
+- conclusion: `failure`
+- 실패 단계: `Run scheduled ingest with retry`
+- 실패 상세: 3회 재시도 모두 `http_status=503`, `detail=database connection failed`
+
+## collector 준비 상태
+- 반영 PR: https://github.com/iAmSomething/2026-/pull/378
+- merge commit: `15856c9edc805f4a9e827bd62e6da882dd6172fd`
+- 재적재 payload: `data/issue339_scenario_mix_reingest_payload.json`
+- 3블록 분리 기준 보고서:
+  - `Collector_reports/2026-02-26_issue339_three_scenario_split_preingest_report.md`
+
+## 현재 blocker
+- #357 (Ingest Schedule DB 연결 503 복구)
+
+## 완료 조건(변경 없음)
+1. #357 복구 후 ingest schedule green 1회
+2. 운영 `/api/v1/matchups/2026_local|기초자치단체장|26-710` after 캡처
+3. scenario_count>=3 + 3블록(h2h/h2h/multi) 정합 확인


### PR DESCRIPTION
## Summary
- #339 운영 재적재 재시도(run 22440075570) 실패 증빙을 보고서로 고정
- 3블록 분리 코드(main 반영)는 완료 상태이나, 운영 적용은 DB 503 blocker로 차단 중

## Changes
- `Collector_reports/2026-02-26_issue339_runtime_blocked_update2_report.md`

## Runtime evidence
- run: https://github.com/iAmSomething/2026-/actions/runs/22440075570
- step: `Run scheduled ingest with retry`
- failure: `http_status=503`, `database connection failed` (attempt 1~3)

## Note
- #339는 #357 복구 전까지 in-progress 유지

Report-Path: Collector_reports/2026-02-26_issue339_runtime_blocked_update2_report.md
Refs: #339 #357
