### PR TITLE
[DEVELOP] #366 ingest 실패 진단코드 표준화

### DIFF
--- a/.github/workflows/collector-live-news-schedule.yml
+++ b/.github/workflows/collector-live-news-schedule.yml
@@ -121,6 +121,7 @@ jobs:
                   "elapsed_seconds": report.get("elapsed_seconds"),
                   "failure_class": report.get("failure_class") or "workflow_step_interrupted",
                   "failure_type": report.get("failure_type") or "workflow_interrupted",
+                  "cause_code": report.get("cause_code") or "unknown",
                   "failure_reason": report.get("failure_reason")
                   or "collector ingest step interrupted before runner classification persisted",
                   "timeout_attempts": sum(

--- a/.github/workflows/ingest-schedule.yml
+++ b/.github/workflows/ingest-schedule.yml
@@ -68,6 +68,8 @@ jobs:
             --timeout-scale-on-timeout 1.5 \
             --timeout-max 360 \
             --allow-partial-success \
+            --classification-artifact data/ingest_schedule_failure_classification.json \
+            --comment-template-path data/ingest_schedule_failure_comment_template.md \
             --dead-letter-dir data/dead_letter \
             --report data/ingest_schedule_report.json
 
@@ -77,6 +79,87 @@ jobs:
           echo "===== /tmp/ingest-schedule-api.log ====="
           cat /tmp/ingest-schedule-api.log || true
 
+      - name: Ensure ingest diagnostics artifacts exist
+        if: always()
+        run: |
+          .venv/bin/python - <<'PY'
+          import json
+          import os
+          from datetime import datetime, timezone
+          from pathlib import Path
+
+          report_path = Path("data/ingest_schedule_report.json")
+          payload_path = Path(os.environ.get("INGEST_SCHEDULE_PAYLOAD", "data/collector_live_payload.json"))
+          classification_path = Path("data/ingest_schedule_failure_classification.json")
+          comment_template_path = Path("data/ingest_schedule_failure_comment_template.md")
+
+          report = {}
+          if report_path.exists():
+              report = json.loads(report_path.read_text(encoding="utf-8"))
+
+          payload = {}
+          if payload_path.exists():
+              payload = json.loads(payload_path.read_text(encoding="utf-8"))
+
+          if not classification_path.exists():
+              attempts = report.get("attempts") or []
+              failure_counts = {}
+              for item in attempts:
+                  key = item.get("failure_class") or "none"
+                  failure_counts[key] = failure_counts.get(key, 0) + 1
+              artifact = {
+                  "schema_version": "collector_ingest_failure_classification.v1",
+                  "generated_at": datetime.now(timezone.utc).isoformat(),
+                  "source_input_path": str(payload_path),
+                  "payload_run_type": payload.get("run_type"),
+                  "payload_record_count": len(payload.get("records") or []),
+                  "runner": {
+                      "success": bool(report.get("success")),
+                      "raw_success": bool(report.get("raw_success", report.get("success"))),
+                      "attempt_count": len(attempts),
+                      "run_ids": report.get("run_ids") or [],
+                      "started_at": report.get("started_at"),
+                      "finished_at": report.get("finished_at"),
+                      "elapsed_seconds": report.get("elapsed_seconds"),
+                      "failure_class": report.get("failure_class") or "workflow_step_interrupted",
+                      "failure_type": report.get("failure_type") or "workflow_interrupted",
+                      "cause_code": report.get("cause_code") or "unknown",
+                      "failure_reason": report.get("failure_reason") or "ingest step interrupted",
+                      "timeout_attempts": sum(
+                          1 for item in attempts
+                          if (item.get("failure_class") == "timeout" or item.get("cause_code") == "timeout_request")
+                      ),
+                      "failure_class_counts": failure_counts,
+                  },
+                  "dead_letter_path": report.get("dead_letter_path"),
+                  "attempt_timeline": attempts,
+              }
+              classification_path.parent.mkdir(parents=True, exist_ok=True)
+              classification_path.write_text(json.dumps(artifact, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+          if not comment_template_path.exists() and report.get("success") is False:
+              repo = os.environ.get("GITHUB_REPOSITORY", "")
+              run_id = os.environ.get("GITHUB_RUN_ID", "")
+              server = os.environ.get("GITHUB_SERVER_URL", "https://github.com")
+              run_url = f"{server}/{repo}/actions/runs/{run_id}" if repo and run_id else ""
+              lines = [
+                  "[DEVELOP][INGEST FAILURE TEMPLATE]",
+                  "report_path: develop_report/YYYY-MM-DD_issueNNN_ingest_failure_report.md",
+                  "evidence:",
+                  f"- workflow_run: {run_url}",
+                  f"- ingest_report: `{report_path}`",
+                  f"- classification_artifact: `{classification_path}`",
+                  f"- dead_letter: `{report.get('dead_letter_path')}`",
+                  f"- failure_class: `{report.get('failure_class')}`",
+                  f"- failure_type: `{report.get('failure_type')}`",
+                  f"- cause_code: `{report.get('cause_code')}`",
+                  f"- failure_reason: `{report.get('failure_reason')}`",
+                  "next_status: status/in-progress",
+              ]
+              comment_template_path.parent.mkdir(parents=True, exist_ok=True)
+              comment_template_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+          PY
+
       - name: Upload ingest report artifact
         if: always()
         uses: actions/upload-artifact@v4
@@ -85,6 +168,8 @@ jobs:
           path: |
             data/ingest_schedule_report.json
             data/ingest_schedule_payload_route_report.json
+            data/ingest_schedule_failure_classification.json
+            data/ingest_schedule_failure_comment_template.md
           if-no-files-found: error
 
       - name: Upload dead-letter artifact (optional)

--- a/develop_report/2026-02-26_issue352_close_execution_report.md
+++ b/develop_report/2026-02-26_issue352_close_execution_report.md
@@ -1,0 +1,18 @@
+# 2026-02-26 Issue352 Close Execution Report
+
+## 1) 배경
+- #352는 운영 런타임 제목 정책 동기화 이슈였고, QA corrected pass 코멘트가 추가된 상태에서 issue만 open으로 남아 있었습니다.
+
+## 2) 확인 사항
+- QA corrected pass 코멘트 존재:
+  - `report_path`, `evidence`, `next_status` 키 포함
+- issue 라벨 상태:
+  - `status/done`
+
+## 3) 수행
+- issue close 실행:
+  - `gh issue close 352 --repo iAmSomething/2026- --comment "..."`
+
+## 4) 결과
+- issue 상태: `CLOSED`
+- URL: `https://github.com/iAmSomething/2026-/issues/352`

--- a/develop_report/2026-02-26_issue366_ingest_failure_diagnostic_standardization_report.md
+++ b/develop_report/2026-02-26_issue366_ingest_failure_diagnostic_standardization_report.md
@@ -1,0 +1,80 @@
+# 2026-02-26 Issue366 Ingest Failure Diagnostic Standardization Report
+
+## 1) 배경
+- ingest 실패 시 `http_5xx`/`http_4xx` 수준의 거친 분류만 남아 DB/Auth/Schema/Timeout 조치 경로가 즉시 분리되지 않는 문제가 있었습니다.
+- 목표는 run 단위 원인코드 표준화 + 아티팩트 일관화 + 실패 코멘트 템플릿 표준화입니다.
+
+## 2) 구현 내용
+
+### A. ingest runner 원인코드(cause_code) 표준화
+- 파일: `app/jobs/ingest_runner.py`
+- 변경:
+  - `AttemptLog`, `IngestRunnerResult`에 `cause_code` 필드 추가
+  - `_derive_cause_code()` 신규 구현
+  - 분류 규칙(핵심):
+    - DB/Auth: `db_auth_failed`
+    - DB/Schema: `db_schema_mismatch`, `schema_payload_contract_422`
+    - DB/Config/연결: `db_config_missing`, `db_connection_error`, `db_connection_unknown`, `db_network_error`, `db_uri_invalid`, `db_ssl_required`
+    - Timeout: `timeout_request`, `db_timeout`
+    - HTTP fallback: `http_5xx`, `http_4xx`, `http_408`, `http_429`, `http_<status>`
+
+### B. ingest retry 스크립트 진단/코멘트 템플릿 확장
+- 파일: `scripts/qa/run_ingest_with_retry.py`
+- 변경:
+  - `--comment-template-path` 인자 추가
+  - classification artifact에 `runner.cause_code`, `attempt_timeline[].cause_code` 저장
+  - 실패 시 `write_failure_comment_template()`로 표준 코멘트 초안 파일 생성
+  - 표준 코멘트 초안은 계약키(`report_path`, `evidence`, `next_status`) 포함
+
+### C. Ingest Schedule workflow 아티팩트 표준화
+- 파일: `.github/workflows/ingest-schedule.yml`
+- 변경:
+  - `run_ingest_with_retry.py` 실행 시
+    - `--classification-artifact data/ingest_schedule_failure_classification.json`
+    - `--comment-template-path data/ingest_schedule_failure_comment_template.md`
+  - `if: always()` 단계에서 진단 아티팩트 fallback 생성 보강
+  - 업로드 대상에 아래 파일 추가:
+    - `data/ingest_schedule_failure_classification.json`
+    - `data/ingest_schedule_failure_comment_template.md`
+
+### D. Collector workflow fallback 동기화
+- 파일: `.github/workflows/collector-live-news-schedule.yml`
+- 변경:
+  - fallback classification artifact 생성 시 `runner.cause_code` 포함
+
+### E. 운영 문서 반영
+- 파일: `docs/05_RUNBOOK_AND_OPERATIONS.md`
+- 변경:
+  - ingest schedule 진단 아티팩트 경로 추가
+  - `cause_code` 표준 분류표/운영 목적 문서화
+
+## 3) 테스트 및 검증
+
+### 단위 테스트
+- 명령:
+  - `/Users/gimtaehun/election2026_codex/.venv/bin/python -m pytest -q tests/test_ingest_runner.py tests/test_run_ingest_with_retry_script.py`
+- 결과:
+  - `12 passed`
+
+### workflow YAML 검증
+- 명령:
+  - `bash scripts/qa/validate_workflow_yaml.sh`
+- 결과:
+  - `.github/workflows/*.yml` 파싱 성공
+
+## 4) 수용기준 대응
+1. 실패 run 1건에서 원인코드 확인 가능
+- `ingest_schedule_failure_classification.json`의 `runner.cause_code` / `attempt_timeline[].cause_code`로 확인 가능
+2. 동일 유형 실패 재현 시 코드 일치
+- `db_auth_failed`, `db_schema_mismatch`, `timeout_request` 케이스를 단위테스트로 고정
+3. 보고서 제출
+- 본 문서 제출
+
+## 5) 반영 파일
+- `app/jobs/ingest_runner.py`
+- `scripts/qa/run_ingest_with_retry.py`
+- `.github/workflows/ingest-schedule.yml`
+- `.github/workflows/collector-live-news-schedule.yml`
+- `tests/test_ingest_runner.py`
+- `tests/test_run_ingest_with_retry_script.py`
+- `docs/05_RUNBOOK_AND_OPERATIONS.md`

--- a/tests/test_run_ingest_with_retry_script.py
+++ b/tests/test_run_ingest_with_retry_script.py
@@ -4,7 +4,11 @@ import json
 from pathlib import Path
 
 from app.jobs.ingest_runner import AttemptLog, IngestRunnerResult
-from scripts.qa.run_ingest_with_retry import is_effective_success, write_failure_classification_artifact
+from scripts.qa.run_ingest_with_retry import (
+    is_effective_success,
+    write_failure_classification_artifact,
+    write_failure_comment_template,
+)
 
 
 def _result(*, success: bool, failure_class: str | None) -> IngestRunnerResult:
@@ -17,6 +21,7 @@ def _result(*, success: bool, failure_class: str | None) -> IngestRunnerResult:
                 job_status="partial_success" if failure_class else "success",
                 failure_class=failure_class,
                 failure_type=failure_class,
+                cause_code=failure_class,
                 retryable=False,
                 request_timeout_seconds=30.0,
             )
@@ -25,6 +30,7 @@ def _result(*, success: bool, failure_class: str | None) -> IngestRunnerResult:
         finished_at="2026-02-24T00:00:00+00:00",
         failure_class=failure_class,
         failure_type=failure_class,
+        cause_code=failure_class,
         failure_reason=None,
     )
 
@@ -59,6 +65,23 @@ def test_write_failure_classification_artifact(tmp_path: Path) -> None:
     saved = json.loads(out.read_text(encoding="utf-8"))
     assert saved["schema_version"] == "collector_ingest_failure_classification.v1"
     assert saved["runner"]["failure_class"] == "timeout"
+    assert saved["runner"]["cause_code"] == "timeout"
     assert saved["runner"]["attempt_count"] == 1
     assert saved["payload_record_count"] == 3
     assert saved["dead_letter_path"] == "data/dead_letter/file.json"
+    assert saved["attempt_timeline"][0]["cause_code"] == "timeout"
+
+
+def test_write_failure_comment_template(tmp_path: Path) -> None:
+    result = _result(success=False, failure_class="db_auth_failed")
+    out = write_failure_comment_template(
+        path=tmp_path / "comment.md",
+        report_path="data/ingest_schedule_report.json",
+        classification_artifact_path="data/ingest_schedule_failure_classification.json",
+        dead_letter_path="data/dead_letter/dead.json",
+        result=result,
+    )
+    text = out.read_text(encoding="utf-8")
+    assert "[DEVELOP][INGEST FAILURE TEMPLATE]" in text
+    assert "classification_artifact" in text
+    assert "next_status: status/in-progress" in text


### PR DESCRIPTION
## 변경 요약
- ingest runner에 `cause_code` 분류를 추가해 DB/Auth/Schema/Timeout 원인 식별을 표준화했습니다.
- ingest-schedule 워크플로에 진단 아티팩트 2종을 기본 생성/업로드하도록 확장했습니다.
  - `data/ingest_schedule_failure_classification.json`
  - `data/ingest_schedule_failure_comment_template.md`
- 실패 코멘트 템플릿 자동 생성 로직을 추가해 계약키(`report_path/evidence/next_status`) 누락을 줄였습니다.
- collector-live fallback classification에도 `cause_code`를 포함해 포맷을 동기화했습니다.
- 런북에 진단코드 표준과 운영 절차를 문서화했습니다.

## 테스트
- `/Users/gimtaehun/election2026_codex/.venv/bin/python -m pytest -q tests/test_ingest_runner.py tests/test_run_ingest_with_retry_script.py`
- `bash scripts/qa/validate_workflow_yaml.sh`

## 보고서
- Report-Path: `develop_report/2026-02-26_issue366_ingest_failure_diagnostic_standardization_report.md`

close #366
