### PR TITLE
[W2][DEVELOP][P1] Add single matchup reprocess CLI with idempotency artifacts

### DIFF
--- a/develop_report/2026-02-26_issue367_single_matchup_reprocess_cli_report.md
+++ b/develop_report/2026-02-26_issue367_single_matchup_reprocess_cli_report.md
@@ -1,0 +1,67 @@
+# 2026-02-26 Issue #367 단건 매치업 재처리 CLI 구현 보고서
+
+## 1) 작업 개요
+- 이슈: #367 `[W2][DEVELOP][P1] 매치업 단건 재처리 CLI(matchup_id/fingerprint) 추가`
+- 목표: 전체 ingest 없이 `matchup_id`/`poll_fingerprint` 대상만 재처리하고, before/after artifact 및 idempotent 판정 근거를 남기는 경로 제공.
+
+## 2) 구현 내용
+1. CLI 추가
+- 파일: `scripts/qa/reprocess_single_matchup.py`
+- 입력: `--matchup-id`, `--poll-fingerprint`
+- 모드: `--mode dry-run|apply`
+- 옵션: `--idempotency-check`, `--output-dir`, `--tag`, `--report`
+
+2. artifact 생성
+- `payload.json`
+- `before_snapshot.json`
+- `after_first_apply_snapshot.json` (`apply`)
+- `after_snapshot.json`
+- `diff.json`
+- `report.json`
+
+3. idempotent 근거 강화
+- `build_idempotency_evidence(...)` 추가
+  - `new_observation_ids`
+  - `removed_observation_ids`
+  - `count_delta`
+- `idempotent_ok` 판정은 아래를 모두 만족해야 true
+  - 집계 delta 0
+  - 신규 observation id 없음
+  - 제거 observation id 없음
+
+4. 런북 반영
+- 파일: `docs/05_RUNBOOK_AND_OPERATIONS.md`
+- 섹션 추가: `7.2 매치업 단건 재처리 CLI (Issue #367)`
+- dry-run/apply 실행 예시, 산출물 목록, PASS 기준 문서화
+
+## 3) 테스트
+- 신규 테스트 파일: `tests/test_reprocess_single_matchup_script.py`
+  - 필터 입력 검증
+  - where clause 조합 검증
+  - idempotency evidence 검증
+  - apply 모드에서 artifact 생성 + idempotent PASS 경로 검증(모킹)
+
+- 회귀 포함 실행:
+```bash
+/Users/gimtaehun/election2026_codex/.venv/bin/python -m pytest -q \
+  tests/test_reprocess_single_matchup_script.py \
+  tests/test_ingest_dead_letter_reprocess.py \
+  tests/test_run_ingest_with_retry_script.py
+```
+- 결과: `12 passed`
+
+## 4) 변경 파일
+- `scripts/qa/reprocess_single_matchup.py`
+- `tests/test_reprocess_single_matchup_script.py`
+- `docs/05_RUNBOOK_AND_OPERATIONS.md`
+- `develop_report/2026-02-26_issue367_single_matchup_reprocess_cli_report.md`
+
+## 5) 수용기준 대응
+1. 동일 입력 2회 실행 시 중복 0
+- `--idempotency-check` 시 2회 apply 수행 및 `idempotent_ok`/`idempotency_evidence`로 판정.
+
+2. before/after 비교 artifact 생성
+- before/after/after_first/diff/report 파일 생성.
+
+3. QA 샘플 회귀 PASS
+- 스크립트 단위테스트 및 관련 회귀 테스트 PASS(`12 passed`).

--- a/docs/05_RUNBOOK_AND_OPERATIONS.md
+++ b/docs/05_RUNBOOK_AND_OPERATIONS.md
@@ -191,6 +191,41 @@
 4. 응답:
 - 최신 `review_queue` row를 반환하며 `status`가 `approved|rejected`로 갱신된다.
 
+## 7.2 매치업 단건 재처리 CLI (Issue #367)
+1. 목적:
+- 전체 ingest 없이 특정 `matchup_id`/`poll_fingerprint` 대상만 재처리
+- before/after 스냅샷과 diff artifact를 남겨 중복/회귀를 즉시 확인
+2. 엔트리포인트:
+- `scripts/qa/reprocess_single_matchup.py`
+3. dry-run 예시:
+```bash
+python scripts/qa/reprocess_single_matchup.py \
+  --matchup-id "20260603|광역자치단체장|11-000" \
+  --poll-fingerprint "<fingerprint>" \
+  --mode dry-run \
+  --output-dir data/single_matchup_reprocess
+```
+4. apply 예시(idempotency 2회 검증 포함):
+```bash
+python scripts/qa/reprocess_single_matchup.py \
+  --matchup-id "20260603|광역자치단체장|11-000" \
+  --poll-fingerprint "<fingerprint>" \
+  --mode apply \
+  --idempotency-check \
+  --output-dir data/single_matchup_reprocess
+```
+5. 기본 산출물:
+- `payload.json`
+- `before_snapshot.json`
+- `after_first_apply_snapshot.json` (`apply` 모드)
+- `after_snapshot.json`
+- `diff.json`
+- `report.json`
+6. idempotent PASS 기준:
+- `report.idempotent_ok == true`
+- `report.idempotency_evidence.new_observation_ids`가 빈 배열
+- `report.delta_after_first_to_after_second`의 집계 delta가 모두 0
+
 ## 8. 모니터링 체크리스트
 1. 배치 성공률
 2. 기사 수집량 대비 추출 성공률

--- a/scripts/qa/reprocess_single_matchup.py
+++ b/scripts/qa/reprocess_single_matchup.py
@@ -1,0 +1,495 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict, is_dataclass
+import json
+import re
+import sys
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app.db import get_connection
+from app.models.schemas import IngestPayload
+from app.services.ingest_service import ingest_payload
+from app.services.repository import PostgresRepository
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Reprocess single matchup/fingerprint payload from live DB")
+    parser.add_argument("--matchup-id", default=None)
+    parser.add_argument("--poll-fingerprint", default=None)
+    parser.add_argument("--mode", choices=["dry-run", "apply"], default="dry-run")
+    parser.add_argument("--idempotency-check", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--output-dir", default="data/single_matchup_reprocess")
+    parser.add_argument("--tag", default=None)
+    parser.add_argument("--report", default=None)
+    return parser.parse_args()
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _json_default(value: Any) -> str:
+    if isinstance(value, (datetime, date)):
+        return value.isoformat()
+    return str(value)
+
+
+def _sanitize_tag(text: str) -> str:
+    return re.sub(r"[^a-zA-Z0-9_.-]+", "_", text).strip("_") or "run"
+
+
+def build_observation_where_clause(*, matchup_id: str | None, poll_fingerprint: str | None) -> tuple[str, tuple[Any, ...]]:
+    clauses: list[str] = []
+    params: list[Any] = []
+    if matchup_id:
+        clauses.append("o.matchup_id = %s")
+        params.append(matchup_id)
+    if poll_fingerprint:
+        clauses.append("o.poll_fingerprint = %s")
+        params.append(poll_fingerprint)
+    if not clauses:
+        raise ValueError("at least one of --matchup-id or --poll-fingerprint is required")
+    return " AND ".join(clauses), tuple(params)
+
+
+def fetch_target_observation(
+    conn,
+    *,
+    matchup_id: str | None,
+    poll_fingerprint: str | None,
+) -> dict[str, Any] | None:
+    where_sql, params = build_observation_where_clause(matchup_id=matchup_id, poll_fingerprint=poll_fingerprint)
+    with conn.cursor() as cur:
+        cur.execute(
+            f"""
+            SELECT
+                o.id AS observation_id,
+                o.article_id,
+                o.observation_key,
+                o.survey_name,
+                o.pollster,
+                o.survey_start_date,
+                o.survey_end_date,
+                o.confidence_level,
+                o.sample_size,
+                o.response_rate,
+                o.margin_of_error,
+                o.sponsor,
+                o.method,
+                o.region_code,
+                o.office_type,
+                o.matchup_id,
+                o.audience_scope,
+                o.audience_region_code,
+                o.sampling_population_text,
+                o.legal_completeness_score,
+                o.legal_filled_count,
+                o.legal_required_count,
+                o.date_resolution,
+                o.date_inference_mode,
+                o.date_inference_confidence,
+                o.poll_fingerprint,
+                o.source_channel,
+                o.source_channels,
+                o.official_release_at,
+                o.verified,
+                o.source_grade,
+                a.url AS article_url,
+                a.title AS article_title,
+                a.publisher AS article_publisher,
+                a.published_at AS article_published_at,
+                a.raw_text AS article_raw_text,
+                a.raw_hash AS article_raw_hash
+            FROM poll_observations o
+            JOIN articles a ON a.id = o.article_id
+            WHERE {where_sql}
+            ORDER BY o.survey_end_date DESC NULLS LAST, o.id DESC
+            LIMIT 1
+            """,
+            params,
+        )
+        return cur.fetchone()
+
+
+def fetch_poll_options(conn, *, observation_id: int) -> list[dict[str, Any]]:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT
+                option_type,
+                option_name,
+                candidate_id,
+                party_name,
+                scenario_key,
+                scenario_type,
+                scenario_title,
+                value_raw,
+                value_min,
+                value_max,
+                value_mid,
+                is_missing,
+                party_inferred,
+                party_inference_source,
+                party_inference_confidence,
+                candidate_verified,
+                candidate_verify_source,
+                candidate_verify_confidence,
+                needs_manual_review
+            FROM poll_options
+            WHERE observation_id = %s
+            ORDER BY id
+            """,
+            (observation_id,),
+        )
+        return cur.fetchall() or []
+
+
+def fetch_region_row(conn, *, region_code: str) -> dict[str, Any] | None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT region_code, sido_name, sigungu_name, admin_level, parent_region_code
+            FROM regions
+            WHERE region_code = %s
+            LIMIT 1
+            """,
+            (region_code,),
+        )
+        return cur.fetchone()
+
+
+def normalize_source_channels(value: Any) -> list[str] | None:
+    if not isinstance(value, (list, tuple)):
+        return None
+    channels: list[str] = []
+    for item in value:
+        if item in {"article", "nesdc"}:
+            channels.append(item)
+    return channels or None
+
+
+def build_ingest_payload_dict(
+    *,
+    source_row: dict[str, Any],
+    option_rows: list[dict[str, Any]],
+    region_row: dict[str, Any] | None,
+) -> dict[str, Any]:
+    source_channel = source_row.get("source_channel")
+    if source_channel not in {"article", "nesdc"}:
+        source_channel = "article"
+
+    observation = {
+        "observation_key": source_row["observation_key"],
+        "survey_name": source_row["survey_name"],
+        "pollster": source_row["pollster"],
+        "survey_start_date": source_row.get("survey_start_date"),
+        "survey_end_date": source_row.get("survey_end_date"),
+        "confidence_level": source_row.get("confidence_level"),
+        "sample_size": source_row.get("sample_size"),
+        "response_rate": source_row.get("response_rate"),
+        "margin_of_error": source_row.get("margin_of_error"),
+        "sponsor": source_row.get("sponsor"),
+        "method": source_row.get("method"),
+        "region_code": source_row["region_code"],
+        "office_type": source_row["office_type"],
+        "matchup_id": source_row["matchup_id"],
+        "audience_scope": source_row.get("audience_scope"),
+        "audience_region_code": source_row.get("audience_region_code"),
+        "sampling_population_text": source_row.get("sampling_population_text"),
+        "legal_completeness_score": source_row.get("legal_completeness_score"),
+        "legal_filled_count": source_row.get("legal_filled_count"),
+        "legal_required_count": source_row.get("legal_required_count"),
+        "date_resolution": source_row.get("date_resolution"),
+        "date_inference_mode": source_row.get("date_inference_mode"),
+        "date_inference_confidence": source_row.get("date_inference_confidence"),
+        "poll_fingerprint": source_row.get("poll_fingerprint"),
+        "source_channel": source_channel,
+        "source_channels": normalize_source_channels(source_row.get("source_channels")),
+        "official_release_at": source_row.get("official_release_at"),
+        "verified": bool(source_row.get("verified", False)),
+        "source_grade": source_row.get("source_grade") or "C",
+    }
+
+    options: list[dict[str, Any]] = []
+    for row in option_rows:
+        options.append(
+            {
+                "option_type": row["option_type"],
+                "option_name": row["option_name"],
+                "candidate_id": row.get("candidate_id"),
+                "party_name": row.get("party_name"),
+                "scenario_key": row.get("scenario_key"),
+                "scenario_type": row.get("scenario_type"),
+                "scenario_title": row.get("scenario_title"),
+                "value_raw": row.get("value_raw"),
+                "value_min": row.get("value_min"),
+                "value_max": row.get("value_max"),
+                "value_mid": row.get("value_mid"),
+                "is_missing": bool(row.get("is_missing", False)),
+                "party_inferred": bool(row.get("party_inferred", False)),
+                "party_inference_source": row.get("party_inference_source"),
+                "party_inference_confidence": row.get("party_inference_confidence"),
+                "candidate_verified": True if row.get("candidate_verified") is None else bool(row.get("candidate_verified")),
+                "candidate_verify_source": row.get("candidate_verify_source"),
+                "candidate_verify_confidence": row.get("candidate_verify_confidence"),
+                "needs_manual_review": bool(row.get("needs_manual_review", False)),
+            }
+        )
+
+    record: dict[str, Any] = {
+        "article": {
+            "url": source_row["article_url"],
+            "title": source_row["article_title"],
+            "publisher": source_row["article_publisher"],
+            "published_at": source_row.get("article_published_at"),
+            "raw_text": source_row.get("article_raw_text"),
+            "raw_hash": source_row.get("article_raw_hash"),
+        },
+        "observation": observation,
+        "options": options,
+    }
+    if region_row:
+        record["region"] = {
+            "region_code": region_row["region_code"],
+            "sido_name": region_row["sido_name"],
+            "sigungu_name": region_row["sigungu_name"],
+            "admin_level": region_row.get("admin_level") or "sigungu",
+            "parent_region_code": region_row.get("parent_region_code"),
+        }
+    return {
+        "run_type": "single_reprocess_cli_v1",
+        "extractor_version": "single-reprocess-cli-v1",
+        "records": [record],
+    }
+
+
+def collect_snapshot(conn, *, matchup_id: str | None, poll_fingerprint: str | None) -> dict[str, Any]:
+    where_sql, params = build_observation_where_clause(matchup_id=matchup_id, poll_fingerprint=poll_fingerprint)
+    with conn.cursor() as cur:
+        cur.execute(
+            f"""
+            SELECT
+                o.id,
+                o.observation_key,
+                o.poll_fingerprint,
+                o.matchup_id,
+                o.updated_at
+            FROM poll_observations o
+            WHERE {where_sql}
+            ORDER BY o.updated_at DESC NULLS LAST, o.id DESC
+            """,
+            params,
+        )
+        rows = cur.fetchall() or []
+
+        observation_ids = [int(row["id"]) for row in rows if row.get("id") is not None]
+        option_count = 0
+        if observation_ids:
+            cur.execute(
+                "SELECT COUNT(*)::int AS count FROM poll_options WHERE observation_id = ANY(%s)",
+                (observation_ids,),
+            )
+            option_count = int((cur.fetchone() or {}).get("count") or 0)
+
+    latest_row = rows[0] if rows else {}
+    distinct_obs_keys = len({str(row["observation_key"]) for row in rows if row.get("observation_key")})
+    distinct_fingerprints = len({str(row["poll_fingerprint"]) for row in rows if row.get("poll_fingerprint")})
+    distinct_matchups = len({str(row["matchup_id"]) for row in rows if row.get("matchup_id")})
+
+    return {
+        "observed_at": _utc_now(),
+        "filter": {"matchup_id": matchup_id, "poll_fingerprint": poll_fingerprint},
+        "observation_count": len(rows),
+        "distinct_observation_keys": distinct_obs_keys,
+        "distinct_poll_fingerprints": distinct_fingerprints,
+        "distinct_matchup_ids": distinct_matchups,
+        "option_count": option_count,
+        "latest_observation_id": latest_row.get("id"),
+        "latest_updated_at": latest_row.get("updated_at"),
+        "observation_ids": observation_ids,
+    }
+
+
+def snapshot_delta(before: dict[str, Any], after: dict[str, Any]) -> dict[str, int]:
+    keys = [
+        "observation_count",
+        "distinct_observation_keys",
+        "distinct_poll_fingerprints",
+        "distinct_matchup_ids",
+        "option_count",
+    ]
+    return {key: int(after.get(key, 0)) - int(before.get(key, 0)) for key in keys}
+
+
+def is_idempotent_counts(first: dict[str, Any], second: dict[str, Any]) -> bool:
+    return snapshot_delta(first, second) == {
+        "observation_count": 0,
+        "distinct_observation_keys": 0,
+        "distinct_poll_fingerprints": 0,
+        "distinct_matchup_ids": 0,
+        "option_count": 0,
+    }
+
+
+def build_idempotency_evidence(first: dict[str, Any], second: dict[str, Any]) -> dict[str, Any]:
+    first_ids = {int(x) for x in (first.get("observation_ids") or [])}
+    second_ids = {int(x) for x in (second.get("observation_ids") or [])}
+    return {
+        "new_observation_ids": sorted(second_ids - first_ids),
+        "removed_observation_ids": sorted(first_ids - second_ids),
+        "count_delta": snapshot_delta(first, second),
+    }
+
+
+def _serialize_apply_result(value: Any) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    if is_dataclass(value):
+        return asdict(value)
+    if isinstance(value, dict):
+        return value
+    if hasattr(value, "__dict__"):
+        return dict(value.__dict__)
+    return {"value": str(value)}
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2, default=_json_default) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    args = parse_args()
+    matchup_id = (args.matchup_id or "").strip() or None
+    poll_fingerprint = (args.poll_fingerprint or "").strip() or None
+    mode = args.mode
+
+    try:
+        build_observation_where_clause(matchup_id=matchup_id, poll_fingerprint=poll_fingerprint)
+    except ValueError as exc:
+        print(json.dumps({"status": "failed", "error": str(exc)}, ensure_ascii=False))
+        return 2
+
+    run_tag = args.tag or _utc_now().replace(":", "").replace("-", "").replace("+00:00", "Z")
+    run_name = _sanitize_tag(f"{run_tag}_{matchup_id or 'no_matchup'}_{(poll_fingerprint or 'no_fp')[:12]}")
+    output_dir = Path(args.output_dir) / run_name
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    with get_connection() as conn:
+        source = fetch_target_observation(conn, matchup_id=matchup_id, poll_fingerprint=poll_fingerprint)
+        if not source:
+            print(
+                json.dumps(
+                    {
+                        "status": "failed",
+                        "error": "target observation not found",
+                        "matchup_id": matchup_id,
+                        "poll_fingerprint": poll_fingerprint,
+                    },
+                    ensure_ascii=False,
+                )
+            )
+            return 1
+
+        options = fetch_poll_options(conn, observation_id=int(source["observation_id"]))
+        region = fetch_region_row(conn, region_code=source["region_code"])
+        payload_dict = build_ingest_payload_dict(source_row=source, option_rows=options, region_row=region)
+        payload = IngestPayload.model_validate(payload_dict)
+
+        before = collect_snapshot(conn, matchup_id=matchup_id, poll_fingerprint=poll_fingerprint)
+
+        first_result = None
+        second_result = None
+        after_first = before
+        after = before
+        idempotent_ok = None
+        idempotency_evidence = None
+
+        if mode == "apply":
+            repo = PostgresRepository(conn)
+            first_result = ingest_payload(payload, repo)
+            after_first = collect_snapshot(conn, matchup_id=matchup_id, poll_fingerprint=poll_fingerprint)
+            after = after_first
+            if args.idempotency_check:
+                second_result = ingest_payload(payload, repo)
+                after = collect_snapshot(conn, matchup_id=matchup_id, poll_fingerprint=poll_fingerprint)
+                idempotency_evidence = build_idempotency_evidence(after_first, after)
+                idempotent_ok = (
+                    is_idempotent_counts(after_first, after)
+                    and not idempotency_evidence["new_observation_ids"]
+                    and not idempotency_evidence["removed_observation_ids"]
+                )
+
+        delta_before_after = snapshot_delta(before, after)
+        delta_after_first_second = snapshot_delta(after_first, after) if mode == "apply" and args.idempotency_check else None
+
+        payload_path = output_dir / "payload.json"
+        before_path = output_dir / "before_snapshot.json"
+        after_path = output_dir / "after_snapshot.json"
+        after_first_path = output_dir / "after_first_apply_snapshot.json"
+        diff_path = output_dir / "diff.json"
+
+        _write_json(payload_path, payload.model_dump(mode="json"))
+        _write_json(before_path, before)
+        _write_json(after_path, after)
+        if mode == "apply":
+            _write_json(after_first_path, after_first)
+        _write_json(
+            diff_path,
+            {
+                "before_to_after": delta_before_after,
+                "after_first_to_after_second": delta_after_first_second,
+            },
+        )
+
+        report = {
+            "status": "success",
+            "mode": mode,
+            "idempotency_check": bool(args.idempotency_check) if mode == "apply" else False,
+            "idempotent_ok": idempotent_ok,
+            "target": {
+                "matchup_id": source["matchup_id"],
+                "poll_fingerprint": source.get("poll_fingerprint"),
+                "observation_id": source["observation_id"],
+                "observation_key": source["observation_key"],
+            },
+            "artifacts": {
+                "output_dir": str(output_dir),
+                "payload": str(payload_path),
+                "before_snapshot": str(before_path),
+                "after_snapshot": str(after_path),
+                "after_first_apply_snapshot": str(after_first_path) if mode == "apply" else None,
+                "diff": str(diff_path),
+            },
+            "before_snapshot": before,
+            "after_snapshot": after,
+            "delta_before_after": delta_before_after,
+            "delta_after_first_to_after_second": delta_after_first_second,
+            "idempotency_evidence": idempotency_evidence,
+            "apply_results": {
+                "first": _serialize_apply_result(first_result),
+                "second": _serialize_apply_result(second_result),
+            },
+            "generated_at": _utc_now(),
+        }
+
+        report_path = Path(args.report) if args.report else output_dir / "report.json"
+        _write_json(report_path, report)
+        report["report_path"] = str(report_path)
+
+    print(json.dumps(report, ensure_ascii=False, default=_json_default))
+    if mode == "apply" and args.idempotency_check and idempotent_ok is False:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_reprocess_single_matchup_script.py
+++ b/tests/test_reprocess_single_matchup_script.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import scripts.qa.reprocess_single_matchup as script
+
+
+def _source_row() -> dict:
+    return {
+        "observation_id": 11,
+        "article_id": 21,
+        "observation_key": "obs-11",
+        "survey_name": "테스트 조사",
+        "pollster": "테스트리서치",
+        "survey_start_date": "2026-02-20",
+        "survey_end_date": "2026-02-21",
+        "confidence_level": 95.0,
+        "sample_size": 1000,
+        "response_rate": 14.2,
+        "margin_of_error": 3.1,
+        "sponsor": "테스트",
+        "method": "전화면접",
+        "region_code": "11-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|11-000",
+        "audience_scope": "regional",
+        "audience_region_code": "11-000",
+        "sampling_population_text": "만18세 이상",
+        "legal_completeness_score": 1.0,
+        "legal_filled_count": 5,
+        "legal_required_count": 5,
+        "date_resolution": "exact",
+        "date_inference_mode": "none",
+        "date_inference_confidence": 1.0,
+        "poll_fingerprint": "f" * 64,
+        "source_channel": "article",
+        "source_channels": ["article"],
+        "official_release_at": None,
+        "verified": True,
+        "source_grade": "A",
+        "article_url": "https://example.com/a",
+        "article_title": "제목",
+        "article_publisher": "언론사",
+        "article_published_at": "2026-02-21T00:00:00+00:00",
+        "article_raw_text": "본문",
+        "article_raw_hash": "h" * 64,
+    }
+
+
+def _option_rows() -> list[dict]:
+    return [
+        {
+            "option_type": "candidate_matchup",
+            "option_name": "후보A",
+            "candidate_id": "cand-a",
+            "party_name": "정당A",
+            "scenario_key": "h2h-a-b",
+            "scenario_type": "head_to_head",
+            "scenario_title": "A vs B",
+            "value_raw": "53~55%",
+            "value_min": 53.0,
+            "value_max": 55.0,
+            "value_mid": 54.0,
+            "is_missing": False,
+            "party_inferred": False,
+            "party_inference_source": None,
+            "party_inference_confidence": None,
+            "candidate_verified": True,
+            "candidate_verify_source": "manual",
+            "candidate_verify_confidence": 1.0,
+            "needs_manual_review": False,
+        },
+        {
+            "option_type": "candidate_matchup",
+            "option_name": "후보B",
+            "candidate_id": "cand-b",
+            "party_name": "정당B",
+            "scenario_key": "h2h-a-b",
+            "scenario_type": "head_to_head",
+            "scenario_title": "A vs B",
+            "value_raw": "45%",
+            "value_min": 45.0,
+            "value_max": 45.0,
+            "value_mid": 45.0,
+            "is_missing": False,
+            "party_inferred": False,
+            "party_inference_source": None,
+            "party_inference_confidence": None,
+            "candidate_verified": True,
+            "candidate_verify_source": "manual",
+            "candidate_verify_confidence": 1.0,
+            "needs_manual_review": False,
+        },
+    ]
+
+
+def _snapshot() -> dict:
+    return {
+        "observation_count": 1,
+        "distinct_observation_keys": 1,
+        "distinct_poll_fingerprints": 1,
+        "distinct_matchup_ids": 1,
+        "option_count": 2,
+        "observation_ids": [11],
+    }
+
+
+def test_build_observation_where_clause_requires_filter() -> None:
+    try:
+        script.build_observation_where_clause(matchup_id=None, poll_fingerprint=None)
+        raise AssertionError("expected ValueError")
+    except ValueError:
+        pass
+
+
+def test_build_observation_where_clause_combines_filters() -> None:
+    where_sql, params = script.build_observation_where_clause(
+        matchup_id="m1",
+        poll_fingerprint="fp1",
+    )
+    assert where_sql == "o.matchup_id = %s AND o.poll_fingerprint = %s"
+    assert params == ("m1", "fp1")
+
+
+def test_build_idempotency_evidence_detects_new_ids() -> None:
+    evidence = script.build_idempotency_evidence(
+        {"observation_ids": [1, 2], "option_count": 2},
+        {"observation_ids": [1, 2, 3], "option_count": 3},
+    )
+    assert evidence["new_observation_ids"] == [3]
+    assert evidence["count_delta"]["option_count"] == 1
+
+
+def test_main_apply_generates_before_after_artifacts_and_idempotent_pass(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    args = SimpleNamespace(
+        matchup_id="20260603|광역자치단체장|11-000",
+        poll_fingerprint="f" * 64,
+        mode="apply",
+        idempotency_check=True,
+        output_dir=str(tmp_path / "out"),
+        tag="t",
+        report=str(tmp_path / "report.json"),
+    )
+    monkeypatch.setattr(script, "parse_args", lambda: args)
+
+    class _ConnCtx:
+        def __enter__(self):
+            return object()
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr(script, "get_connection", lambda: _ConnCtx())
+    monkeypatch.setattr(script, "fetch_target_observation", lambda conn, **kwargs: _source_row())
+    monkeypatch.setattr(script, "fetch_poll_options", lambda conn, observation_id: _option_rows())
+    monkeypatch.setattr(
+        script,
+        "fetch_region_row",
+        lambda conn, region_code: {
+            "region_code": region_code,
+            "sido_name": "서울",
+            "sigungu_name": "전체",
+            "admin_level": "sido",
+            "parent_region_code": None,
+        },
+    )
+
+    class _Payload:
+        def __init__(self, payload: dict) -> None:
+            self._payload = payload
+
+        def model_dump(self, mode: str = "json") -> dict:
+            return self._payload
+
+    monkeypatch.setattr(script.IngestPayload, "model_validate", lambda payload: _Payload(payload))
+
+    snapshots = [_snapshot(), _snapshot(), _snapshot()]
+    monkeypatch.setattr(script, "collect_snapshot", lambda conn, matchup_id, poll_fingerprint: snapshots.pop(0))
+    monkeypatch.setattr(
+        script,
+        "ingest_payload",
+        lambda payload, repo: SimpleNamespace(
+            run_id=1,
+            processed_count=1,
+            error_count=0,
+            status="success",
+        ),
+    )
+    monkeypatch.setattr(script, "PostgresRepository", lambda conn: object())
+
+    exit_code = script.main()
+    assert exit_code == 0
+
+    report = json.loads(Path(args.report).read_text(encoding="utf-8"))
+    assert report["status"] == "success"
+    assert report["mode"] == "apply"
+    assert report["idempotent_ok"] is True
+    assert report["idempotency_evidence"]["new_observation_ids"] == []
+    assert report["delta_after_first_to_after_second"]["observation_count"] == 0
+    assert Path(report["artifacts"]["before_snapshot"]).exists()
+    assert Path(report["artifacts"]["after_snapshot"]).exists()


### PR DESCRIPTION
Report-Path: develop_report/2026-02-26_issue367_single_matchup_reprocess_cli_report.md

## Summary
- add `scripts/qa/reprocess_single_matchup.py` for targeted reprocess by `matchup_id`/`poll_fingerprint`
- support `dry-run`/`apply`, before/after/diff artifacts, and idempotency check evidence
- add unit tests for CLI helpers and apply flow (`tests/test_reprocess_single_matchup_script.py`)
- document operation in runbook section `7.2`
- add develop report: `develop_report/2026-02-26_issue367_single_matchup_reprocess_cli_report.md`

## Validation
- `/Users/gimtaehun/election2026_codex/.venv/bin/python -m pytest -q tests/test_reprocess_single_matchup_script.py tests/test_ingest_dead_letter_reprocess.py tests/test_run_ingest_with_retry_script.py`
- `/Users/gimtaehun/election2026_codex/.venv/bin/python -m pytest -q tests/test_reprocess_single_matchup_script.py`

Closes #367
