### PR TITLE
[DEVELOP][P0] #357 Add DB preflight and sharper connection diagnostics

### DIFF
--- a/.github/workflows/ingest-schedule.yml
+++ b/.github/workflows/ingest-schedule.yml
@@ -57,6 +57,17 @@ jobs:
           echo "::error::API server failed to start"
           exit 1
 
+      - name: DB preflight via health/db
+        run: |
+          DB_HEALTH_STATUS="$(curl -sS -o /tmp/ingest-schedule-health-db.json -w "%{http_code}" http://127.0.0.1:8100/health/db || true)"
+          echo "health_db_http_status=${DB_HEALTH_STATUS}"
+          echo "===== /tmp/ingest-schedule-health-db.json ====="
+          cat /tmp/ingest-schedule-health-db.json || true
+          if [ "${DB_HEALTH_STATUS}" != "200" ]; then
+            echo "::error::DB preflight failed (/health/db status=${DB_HEALTH_STATUS})"
+            exit 1
+          fi
+
       - name: Run scheduled ingest with retry
         run: |
           .venv/bin/python scripts/qa/run_ingest_with_retry.py \

--- a/develop_report/2026-02-26_issue357_db_preflight_diagnostics_update_report.md
+++ b/develop_report/2026-02-26_issue357_db_preflight_diagnostics_update_report.md
@@ -1,0 +1,44 @@
+# 2026-02-26 Issue #357 DB Preflight + Diagnostics Update Report
+
+## 1) 작업 목적
+- `Ingest Schedule`에서 `health`는 OK인데 `run-ingest`가 503으로 실패하는 케이스를 조기 분리.
+- `db_connection_unknown` 발생 시 원인 문자열 분류를 확장해 운영자가 바로 다음 조치를 판단할 수 있도록 개선.
+
+## 2) 변경 사항
+1. Ingest Schedule DB 프리플라이트 추가
+- 파일: `.github/workflows/ingest-schedule.yml`
+- 신규 단계: `DB preflight via health/db`
+- 동작: `GET /health/db`의 HTTP status와 body를 출력하고, 200이 아니면 fail-fast 처리.
+
+2. DB 연결 오류 분류 강화
+- 파일: `app/db.py`
+- `_classify_connection_error` 추가 패턴:
+  - `password authentication failed` -> `auth_failed`
+  - `authentication failed` -> `auth_error`
+  - `no pg_hba.conf entry` -> `auth_error`
+  - `server closed the connection unexpectedly` -> `network_error`
+  - `connection reset by peer` -> `network_error`
+- `DatabaseConnectionError` 메시지에 원본 예외 요약(최대 180자) 포함.
+  - 형식: `database connection failed (<reason>): <message>`
+
+3. 테스트 보강
+- 파일: `tests/test_db_url_normalization.py`
+- 위 신규 분류 케이스 파라미터 테스트 추가.
+
+## 3) 검증 결과
+```bash
+/Users/gimtaehun/election2026_codex/.venv/bin/python -m pytest -q \
+  tests/test_db_url_normalization.py tests/test_ingest_runner.py
+# 23 passed
+
+bash scripts/qa/validate_workflow_yaml.sh
+# all workflow files parsed successfully
+```
+
+## 4) 기대 효과
+- DB 비정상 시 `run-ingest` 재시도 이전에 `/health/db`에서 즉시 원인 출력 가능.
+- 기존 `db_connection_unknown`의 일부를 `auth_failed/auth_error/network_error`로 세분화.
+
+## 5) 현재 상태
+- 코드 레벨 진단/프리플라이트는 반영 완료.
+- 실제 `workflow_dispatch green` 달성 여부는 `main` 반영 후 재실행 결과로 판정 필요.

--- a/tests/test_db_url_normalization.py
+++ b/tests/test_db_url_normalization.py
@@ -40,8 +40,12 @@ class _FakePsycopgError(Exception):
     [
         (_FakePsycopgError("password authentication failed", "28P01"), "auth_failed"),
         (_FakePsycopgError("role is not permitted", "28000"), "auth_error"),
+        (_FakePsycopgError("password authentication failed for user \"postgres.ref\""), "auth_failed"),
+        (_FakePsycopgError("no pg_hba.conf entry for host \"1.2.3.4\""), "auth_error"),
         (_FakePsycopgError("could not translate host name \"bad\" to address"), "invalid_host_or_uri"),
         (_FakePsycopgError("connection refused"), "connection_refused"),
+        (_FakePsycopgError("server closed the connection unexpectedly"), "network_error"),
+        (_FakePsycopgError("connection reset by peer"), "network_error"),
         (_FakePsycopgError("timeout expired"), "network_timeout"),
         (_FakePsycopgError("sslmode value \"disable\" invalid when SSL required"), "ssl_required"),
         (_FakePsycopgError("some other message"), "unknown"),


### PR DESCRIPTION
Report-Path: develop_report/2026-02-26_issue357_db_preflight_diagnostics_update_report.md

## Summary
- add `DB preflight via health/db` step to `Ingest Schedule` (fail-fast with body dump)
- strengthen DB connection classification in `app/db.py` for auth/network edge cases
- include underlying DB exception message snippet in `DatabaseConnectionError` for faster root-cause triage
- add classification test cases in `tests/test_db_url_normalization.py`
- add report `develop_report/2026-02-26_issue357_db_preflight_diagnostics_update_report.md`

## Validation
- `/Users/gimtaehun/election2026_codex/.venv/bin/python -m pytest -q tests/test_db_url_normalization.py tests/test_ingest_runner.py`
- `bash scripts/qa/validate_workflow_yaml.sh`

## Notes
- This patch improves diagnosability and fail-fast behavior for #357.
- Final acceptance for #357 still requires a `workflow_dispatch` green run on `main`.

Refs: #357
