### PR TITLE
[COLLECTOR] #339 targeted reingest PYTHONPATH hotfix

### DIFF
--- a/.github/workflows/collector-issue339-targeted-reingest.yml
+++ b/.github/workflows/collector-issue339-targeted-reingest.yml
@@ -66,7 +66,7 @@ jobs:
           print(json.dumps({"target_payload": str(dst), "record_count": len(targets)}, ensure_ascii=False))
           PY
 
-          .venv/bin/python scripts/qa/normalize_ingest_payload_for_schedule.py \
+          PYTHONPATH="." .venv/bin/python scripts/qa/normalize_ingest_payload_for_schedule.py \
             --input "$TARGET_PAYLOAD" \
             --output "$TARGET_PAYLOAD"
 


### PR DESCRIPTION
## Summary
- fix `collector-issue339-targeted-reingest.yml` normalization step to run with `PYTHONPATH=.`
- resolves `ModuleNotFoundError: No module named 'app'` on targeted payload path

## Evidence
- failed run before fix: https://github.com/iAmSomething/2026-/actions/runs/22468189004
- failed step: `Build issue339 targeted payload (single record)`

## Links
- Issue: #339

Report-Path: `/Users/gimtaehun/election2026_codex_issue339_fixsplit/Collector_reports/2026-02-27_issue339_runtime_timeout_update13_report.md`
