### PR TITLE
[COLLECTOR] #339 default scenario cleanup + multi backfill

### DIFF
--- a/app/services/repository.py
+++ b/app/services/repository.py
@@ -456,6 +456,43 @@ class PostgresRepository:
             )
         self.conn.commit()
 
+    def delete_candidate_default_poll_options(self, observation_id: int) -> int:
+        with self.conn.cursor() as cur:
+            cur.execute(
+                """
+                DELETE FROM poll_options
+                WHERE observation_id = %s
+                  AND option_type = 'candidate_matchup'
+                  AND scenario_key = 'default'
+                """,
+                (observation_id,),
+            )
+            deleted = int(cur.rowcount or 0)
+        self.conn.commit()
+        return deleted
+
+    def fetch_candidate_default_poll_options(self, observation_id: int) -> list[dict]:
+        with self.conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT
+                    option_name,
+                    value_raw,
+                    value_min,
+                    value_max,
+                    value_mid,
+                    is_missing
+                FROM poll_options
+                WHERE observation_id = %s
+                  AND option_type = 'candidate_matchup'
+                  AND scenario_key = 'default'
+                ORDER BY option_name
+                """,
+                (observation_id,),
+            )
+            rows = cur.fetchall() or []
+        return [dict(row) for row in rows]
+
     def insert_review_queue(self, entity_type: str, entity_id: str, issue_type: str, review_note: str) -> None:
         with self.conn.cursor() as cur:
             cur.execute(


### PR DESCRIPTION
## Summary
- add repo helper to fetch and delete `candidate_matchup/default` rows by `observation_id`
- when ingesting explicit candidate scenarios, backfill missing `multi-*` candidates from stored default rows before cleanup
- cleanup stale default candidate rows for explicit scenario ingests
- add regression test covering two-pass ingest (`default` baseline -> explicit ingest) to verify:
  - default rows removed
  - multi block contains full candidate set

## Test
- `/Users/gimtaehun/election2026_codex/.venv/bin/python -m pytest tests/test_ingest_service.py`
- `/Users/gimtaehun/election2026_codex/.venv/bin/python -m pytest tests/test_collector_live_coverage_v2_pack_script.py`

## Links
- Issue: #339

Report-Path: `/Users/gimtaehun/election2026_codex_issue339_fixsplit/Collector_reports/2026-02-27_issue339_runtime_timeout_update13_report.md`
