### PR TITLE
[COLLECTOR] #339 in-review handoff report update16

### DIFF
--- a/Collector_reports/2026-02-27_issue339_handoff_inreview_update16_report.md
+++ b/Collector_reports/2026-02-27_issue339_handoff_inreview_update16_report.md
@@ -1,0 +1,38 @@
+# #339 collector handoff(in-review) 업데이트 v16 보고서
+
+- 작성일시(UTC): 2026-02-27T01:18:40Z
+- 담당: Collector
+- 관련 이슈: #339, #341
+- 상태: in-review (QA pass 대기)
+
+## 1) decision
+- collector 완료기준(runtime acceptance pass) 달성 후 #339 상태를 `status/in-review`로 전환했다.
+- 현재 단계는 QA 재게이트 및 `[QA PASS]` 코멘트 확인이다.
+
+## 2) next_status
+- `status/in-review`
+
+## 3) 반영 내역
+1. 이슈 상태 라벨 전환
+- issue: https://github.com/iAmSomething/2026-/issues/339
+- 변경: `status/in-progress` -> `status/in-review`
+
+2. collector 완료 근거(요약)
+- final run(success): https://github.com/iAmSomething/2026-/actions/runs/22468417899
+- acceptance report: `data/issue339_runtime_acceptance_update15.json`
+- 핵심 결과:
+  - `scenario_count=3`
+  - `scenario_keys=[h2h-전재수-박형준, h2h-전재수-김도읍, multi-전재수]`
+  - `default_removed=true`
+  - `acceptance_pass=true`
+
+## 4) evidence
+- prior final report: `Collector_reports/2026-02-27_issue339_targeted_reingest_acceptance_pass_update15_report.md`
+- final run status snapshot: `data/issue339_targeted_run_22468417899_status_snapshot.json`
+- final run log: `data/issue339_targeted_run_22468417899.log`
+- final runtime capture: `data/issue339_runtime_after_capture_targeted_update15.json`
+- final runtime acceptance: `data/issue339_runtime_acceptance_update15.json`
+
+## 5) 의사결정 요청
+1. QA에서 #339 `[QA PASS]` 코멘트 가능 여부 확인 요청
+2. `[QA PASS]` 확인 즉시 #339 `status/done` + close 진행 여부 확정 요청


### PR DESCRIPTION
## Summary
- add collector handoff report for #339 after acceptance PASS
- capture state transition intent (`status/in-review`, awaiting QA pass)

## Links
- Issue: #339
- QA gate issue: #341

Report-Path: `/Users/gimtaehun/election2026_codex_issue339_fixsplit/Collector_reports/2026-02-27_issue339_handoff_inreview_update16_report.md`
