### PR TITLE
[COLLECTOR] #339 QA follow-up report update17

### DIFF
--- a/Collector_reports/2026-02-27_issue339_inreview_qa_followup_update17_report.md
+++ b/Collector_reports/2026-02-27_issue339_inreview_qa_followup_update17_report.md
@@ -1,0 +1,32 @@
+# #339 in-review QA follow-up 업데이트 v17 보고서
+
+- 작성일시(UTC): 2026-02-27T01:21:40Z
+- 담당: Collector
+- 관련 이슈: #339, #341
+- 상태: in-review (QA PASS 대기)
+
+## 1) decision
+- #339은 collector acceptance 기준을 이미 충족했으며(`acceptance_pass=true`), 현재는 QA의 `[QA PASS]` 코멘트 대기 상태다.
+- collector는 추가 코드 변경 없이 QA 재게이트 요청/상태 고정 작업을 수행한다.
+
+## 2) next_status
+- `status/in-review`
+
+## 3) 확인 결과
+1. #339 상태
+- issue: https://github.com/iAmSomething/2026-/issues/339
+- labels: `role/collector`, `status/in-review`, `priority/p0`, `type/bug`
+- `[QA PASS]` 시작 코멘트: 없음
+
+2. collector 완료 근거(기존)
+- runtime acceptance pass: `data/issue339_runtime_acceptance_update15.json`
+- final run(success): https://github.com/iAmSomething/2026-/actions/runs/22468417899
+
+## 4) evidence
+- handoff report: `Collector_reports/2026-02-27_issue339_handoff_inreview_update16_report.md`
+- pass report: `Collector_reports/2026-02-27_issue339_targeted_reingest_acceptance_pass_update15_report.md`
+- acceptance json: `data/issue339_runtime_acceptance_update15.json`
+
+## 5) 요청사항
+1. QA(#341)에서 #339 재게이트 결과를 `[QA PASS]` 또는 `[QA FAIL]`로 코멘트 요청
+2. `[QA PASS]` 확인 시 #339 `status/done + close` 즉시 진행


### PR DESCRIPTION
## Summary
- add collector follow-up report for #339 in-review state
- document that collector acceptance is met and QA PASS comment is pending

## Links
- Issue: #339
- QA gate: #341

Report-Path: `/Users/gimtaehun/election2026_codex_issue339_fixsplit/Collector_reports/2026-02-27_issue339_inreview_qa_followup_update17_report.md`
