### PR TITLE
[COLLECTOR] #339 QA regate nudge report update18

### DIFF
--- a/Collector_reports/2026-02-27_issue339_qa_regate_nudge_update18_report.md
+++ b/Collector_reports/2026-02-27_issue339_qa_regate_nudge_update18_report.md
@@ -1,0 +1,30 @@
+# #339 QA regate nudge 업데이트 v18 보고서
+
+- 작성일시(UTC): 2026-02-27T01:26:00Z
+- 담당: Collector
+- 관련 이슈: #339, #341
+- 상태: in-review (QA 판정 대기)
+
+## 1) decision
+- #339은 collector acceptance 기준 충족 상태를 유지한다.
+- `[QA PASS]` 코멘트 부재로 close 전환은 보류하고, #341에 재게이트 우선순위 재평가를 요청한다.
+
+## 2) next_status
+- `status/in-review`
+
+## 3) 확인 사항
+1. #339 라벨/상태
+- `OPEN`, `status/in-review`
+- `[QA PASS]` 시작 코멘트: 없음
+
+2. collector 완료 근거(유지)
+- final run(success): https://github.com/iAmSomething/2026-/actions/runs/22468417899
+- acceptance pass: `data/issue339_runtime_acceptance_update15.json`
+
+## 4) evidence
+- prior follow-up report: `Collector_reports/2026-02-27_issue339_inreview_qa_followup_update17_report.md`
+- pass report: `Collector_reports/2026-02-27_issue339_targeted_reingest_acceptance_pass_update15_report.md`
+
+## 5) 요청사항
+1. #341에서 #339 판정 코멘트(`[QA PASS]` 또는 `[QA FAIL]`) 우선 반영 요청
+2. 판정 반영 즉시 #339 `status/done + close` 진행 여부 확정


### PR DESCRIPTION
## Summary
- add collector report update18 for #339 in-review hold
- document no `[QA PASS]` yet and request QA regate decision update

## Links
- Issue: #339
- QA gate: #341

Report-Path: `/Users/gimtaehun/election2026_codex_issue339_fixsplit/Collector_reports/2026-02-27_issue339_qa_regate_nudge_update18_report.md`
