### PR TITLE
[COLLECTOR] #339 close gate status report update20

### DIFF
--- a/Collector_reports/2026-02-27_issue339_close_gate_update20_report.md
+++ b/Collector_reports/2026-02-27_issue339_close_gate_update20_report.md
@@ -1,0 +1,37 @@
+# #339 close gate 상태 업데이트 v20 보고서
+
+- 작성일시(UTC): 2026-02-27T01:31:40Z
+- 담당: Collector
+- 관련 이슈: #339, #341
+- 상태: in-review (close gate 대기)
+
+## 1) decision
+- #339 collector acceptance는 PASS 상태이며 기술 작업은 완료됨.
+- #341이 `[QA PASS]`로 종료되었으나, #339 이슈 본문에는 `[QA PASS]` 코멘트가 아직 없어 close gate를 보류한다.
+
+## 2) next_status
+- `status/in-review`
+
+## 3) 확인 결과
+1. #341 QA 판정
+- issue: https://github.com/iAmSomething/2026-/issues/341
+- 상태: `CLOSED`, `status/done`
+- QA PASS 코멘트:
+  - https://github.com/iAmSomething/2026-/issues/341#issuecomment-3970189352
+
+2. #339 현황
+- issue: https://github.com/iAmSomething/2026-/issues/339
+- 상태: `OPEN`, `status/in-review`
+- `[QA PASS]` 시작 코멘트: 없음
+- 최신 collector PASS 증빙:
+  - run(success): https://github.com/iAmSomething/2026-/actions/runs/22468741905
+  - acceptance: `data/issue339_runtime_acceptance_update19.json`
+
+## 4) evidence
+- stability report: `Collector_reports/2026-02-27_issue339_stability_recheck_update19_report.md`
+- acceptance update19: `data/issue339_runtime_acceptance_update19.json`
+- qa final pass report(#341): `QA_reports/2026-02-27_qa_p0_user_regression_integrated_regate_final_pass_report.md`
+
+## 5) 요청사항
+1. #339 이슈에 `[QA PASS]` 코멘트 반영 요청
+2. 반영 즉시 #339 `status/done + close` 처리


### PR DESCRIPTION
## Summary
- add collector report update20 for #339 close gate status
- document that #341 is QA PASS + CLOSED while #339 still lacks direct `[QA PASS]` comment

## Links
- Issue: #339
- Related QA gate: #341

Report-Path: `/Users/gimtaehun/election2026_codex_issue339_fixsplit/Collector_reports/2026-02-27_issue339_close_gate_update20_report.md`
