### PR TITLE
[COLLECTOR] #359 2026 데이터셋 시간 게이트 강화

### DIFF
--- a/Collector_reports/2026-02-27_issue359_time_gate_hardening_report.md
+++ b/Collector_reports/2026-02-27_issue359_time_gate_hardening_report.md
@@ -1,0 +1,58 @@
+# 2026-02-27 Issue #359 실행 보고서 (Collector)
+
+## 1) 작업 개요
+- 이슈: `#359` `[COLLECTOR][P1] 2026 지방선거 데이터셋 시간 게이트 강화(2025-12-01 이후)`
+- 목표: 2025-12-01 이전 사이클 데이터가 ingest/노출 경로에 섞이지 않도록 시간 게이트를 강제하고, map-latest 필터 통계에 `stale_cycle` 집계를 노출.
+
+## 2) 반영 내용
+- `app/services/cutoff_policy.py`
+  - `SURVEY_END_DATE_CUTOFF = 2025-12-01` 추가
+  - `parse_date_like`, `survey_end_date_cutoff_reason`, `is_survey_end_date_allowed` 추가
+- `app/services/ingest_service.py`
+  - ingest 시작 시 `survey_end_date` 컷오프 동시 검증 추가
+  - 기준 미달 시 `ingestion_error` + `STALE_CYCLE_BLOCK reason=SURVEY_END_DATE_BEFORE_CUTOFF`로 review_queue 기록 후 skip
+- `app/api/routes.py`
+  - `_is_cutoff_eligible_row`에 `survey_end_date` 컷오프 동시 적용
+  - summary/map-latest/big-matches/matchup 노출 경로에서 동일 게이트 적용
+  - map-latest `filter_stats.reason_counts`에서 컷오프 계열 사유를 `stale_cycle`로 통합 집계
+
+## 3) 테스트 반영
+- `tests/test_cutoff_policy.py`
+  - survey_end 컷오프 파싱/판정 케이스 추가
+- `tests/test_ingest_service.py`
+  - `survey_end_date < 2025-12-01` 레코드 ingest 차단 테스트 추가
+- `tests/test_api_routes.py`
+  - summary에서 survey_end 컷오프 필터 테스트 추가
+  - big-matches에서 survey_end 컷오프 필터 테스트 추가
+  - map-latest `reason_counts.stale_cycle` 집계 테스트 추가
+  - matchup survey_end 컷오프 시 404 테스트 추가
+
+## 4) 검증 결과
+- 실행 명령:
+  - `../election2026_codex/.venv/bin/python -m pytest tests/test_cutoff_policy.py tests/test_ingest_service.py tests/test_api_routes.py -q`
+  - `../election2026_codex/.venv/bin/python -m pytest tests/test_collector_map_latest_cleanup_v1_script.py -q`
+- 결과:
+  - `50 passed`
+  - `1 passed`
+
+## 5) 증적 파일
+- before/after 분포 캡처:
+  - `data/issue359_time_gate_before_after_distribution.json`
+- 재적재 1회 probe:
+  - `data/issue359_reingest_cutoff_probe.json`
+
+핵심 확인값:
+- summary: `before=3`, `after=1`, `excluded_stale_cycle=2`
+- map-latest: `reason_counts.stale_cycle=2`
+- big-matches: `before=3`, `after=1`, `excluded_stale_cycle=2`
+- reingest probe: `processed_count=1`, `error_count=1`, old-cycle는 `STALE_CYCLE_BLOCK`으로 차단
+
+## 6) 수용기준 대응
+- 운영 노출 경로(summary/map-latest/big-matches)에서 2025-12-01 이전 건 차단 로직 반영
+- map-latest `filter_stats.reason_counts`에 `stale_cycle` 집계 반영
+- 게이트 온/오프 경계 회귀 테스트 추가 및 PASS
+- 재적재 1회 증적 + before/after 분포 증적 제출 완료
+
+## 7) 의사결정 요청
+1. `stale_cycle` 상세 원인(`article_published_at_before_cutoff` vs `survey_end_date_before_cutoff`)을 API 응답에서 추가 노출할지 여부 결정 필요.
+2. 현재 cutoff 기준일 `2025-12-01`을 상수로 고정했습니다. 운영 전환 시 환경변수(`DATASET_CYCLE_CUTOFF`)로 외부화할지 결정 필요.

--- a/app/services/ingest_service.py
+++ b/app/services/ingest_service.py
@@ -6,9 +6,11 @@ from app.config import get_settings
 from app.models.schemas import IngestPayload, PollOptionInput
 from app.services.cutoff_policy import (
     ARTICLE_PUBLISHED_AT_CUTOFF_ISO,
+    SURVEY_END_DATE_CUTOFF,
     has_article_source,
     parse_datetime_like,
     published_at_cutoff_reason,
+    survey_end_date_cutoff_reason,
 )
 from app.services.data_go_candidate import DataGoCandidateConfig, DataGoCandidateService
 from app.services.errors import DuplicateConflictError
@@ -716,6 +718,25 @@ def ingest_payload(payload: IngestPayload, repo) -> IngestResult:
 
     for record in payload.records:
         try:
+            survey_end_cutoff_reason = survey_end_date_cutoff_reason(record.observation.survey_end_date)
+            if survey_end_cutoff_reason != "PASS":
+                error_count += 1
+                try:
+                    repo.insert_review_queue(
+                        entity_type="ingest_record",
+                        entity_id=record.observation.observation_key,
+                        issue_type="ingestion_error",
+                        review_note=(
+                            "STALE_CYCLE_BLOCK "
+                            f"reason={survey_end_cutoff_reason} "
+                            f"survey_end_date={record.observation.survey_end_date} "
+                            f"cutoff={SURVEY_END_DATE_CUTOFF.isoformat()}"
+                        ),
+                    )
+                except Exception:  # noqa: BLE001
+                    pass
+                continue
+
             article_source = has_article_source(
                 source_channel=record.observation.source_channel,
                 source_channels=record.observation.source_channels,

--- a/data/issue359_reingest_cutoff_probe.json
+++ b/data/issue359_reingest_cutoff_probe.json
@@ -1,0 +1,16 @@
+{
+  "run_result": {
+    "run_id": 1,
+    "status": "partial_success",
+    "processed_count": 1,
+    "error_count": 1
+  },
+  "review_queue": [
+    {
+      "entity_type": "ingest_record",
+      "entity_id": "obs-old",
+      "issue_type": "ingestion_error",
+      "review_note": "STALE_CYCLE_BLOCK reason=SURVEY_END_DATE_BEFORE_CUTOFF survey_end_date=2025-11-30 cutoff=2025-12-01"
+    }
+  ]
+}

--- a/data/issue359_time_gate_before_after_distribution.json
+++ b/data/issue359_time_gate_before_after_distribution.json
@@ -1,0 +1,30 @@
+{
+  "summary": {
+    "before_count": 3,
+    "after_count": 1,
+    "excluded_stale_cycle": 2,
+    "after_option_names": [
+      "최신조사"
+    ]
+  },
+  "map_latest": {
+    "before_count": 4,
+    "after_count": 1,
+    "excluded_count": 3,
+    "reason_counts": {
+      "stale_cycle": 2,
+      "invalid_candidate_option_name": 1
+    },
+    "after_option_names": [
+      "박형준"
+    ]
+  },
+  "big_matches": {
+    "before_count": 3,
+    "after_count": 1,
+    "excluded_stale_cycle": 2,
+    "after_matchup_ids": [
+      "20260603|기초자치단체장|11-020"
+    ]
+  }
+}

--- a/tests/test_cutoff_policy.py
+++ b/tests/test_cutoff_policy.py
@@ -2,10 +2,14 @@ from datetime import datetime, timezone
 
 from app.services.cutoff_policy import (
     ARTICLE_PUBLISHED_AT_CUTOFF_KST,
+    SURVEY_END_DATE_CUTOFF,
     has_article_source,
     is_article_published_at_allowed,
+    is_survey_end_date_allowed,
+    parse_date_like,
     parse_datetime_like,
     published_at_cutoff_reason,
+    survey_end_date_cutoff_reason,
 )
 
 
@@ -27,6 +31,14 @@ def test_cutoff_reason_and_allowance():
     assert published_at_cutoff_reason("2025-11-30T23:59:59+09:00") == "PUBLISHED_AT_BEFORE_CUTOFF"
     assert published_at_cutoff_reason("2025-12-01T00:00:00+09:00") == "PASS"
     assert is_article_published_at_allowed("2025-12-01T00:00:00+09:00") is True
+
+
+def test_survey_end_cutoff_reason_and_allowance():
+    assert parse_date_like("2025-12-01") == SURVEY_END_DATE_CUTOFF
+    assert survey_end_date_cutoff_reason(None) == "PASS"
+    assert survey_end_date_cutoff_reason("2025-11-30") == "SURVEY_END_DATE_BEFORE_CUTOFF"
+    assert survey_end_date_cutoff_reason("2025-12-01") == "PASS"
+    assert is_survey_end_date_allowed("2025-12-01") is True
 
 
 def test_has_article_source_defaults_to_true_without_source_fields():

--- a/tests/test_ingest_service.py
+++ b/tests/test_ingest_service.py
@@ -222,6 +222,24 @@ def test_article_source_record_before_cutoff_is_blocked():
     assert any("ARTICLE_PUBLISHED_AT_CUTOFF_BLOCK" in row[3] for row in repo.review)
 
 
+def test_record_with_survey_end_before_cutoff_is_blocked_even_if_article_is_new():
+    repo = FakeRepo()
+    payload_data = deepcopy(PAYLOAD)
+    payload_data["records"][0]["article"]["published_at"] = "2026-01-15T09:00:00+09:00"
+    payload_data["records"][0]["observation"]["survey_end_date"] = "2025-11-30"
+    payload = IngestPayload.model_validate(payload_data)
+
+    result = ingest_payload(payload, repo)
+
+    assert result.status == "partial_success"
+    assert result.processed_count == 0
+    assert result.error_count == 1
+    assert len(repo.articles) == 0
+    assert len(repo.observations) == 0
+    assert any("STALE_CYCLE_BLOCK" in row[3] for row in repo.review)
+    assert any("SURVEY_END_DATE_BEFORE_CUTOFF" in row[3] for row in repo.review)
+
+
 def test_nesdc_source_record_without_article_published_at_is_allowed():
     repo = FakeRepo()
     payload_data = deepcopy(PAYLOAD)


### PR DESCRIPTION
## Summary
- Report-Path: `Collector_reports/2026-02-27_issue359_time_gate_hardening_report.md`
- `survey_end_date >= 2025-12-01` 동시 게이트를 ingest/selection 경로에 반영
- map-latest `filter_stats.reason_counts`에 `stale_cycle` 집계 추가
- 재적재 1회 probe + before/after 분포 증적 추가

## Changes
- `app/services/cutoff_policy.py`
  - survey_end cutoff 정책/파서/판정 함수 추가
- `app/services/ingest_service.py`
  - survey_end cutoff 사전 차단(`STALE_CYCLE_BLOCK`) 추가
- `app/api/routes.py`
  - summary/map-latest/big-matches/matchup에 survey_end 동시 컷오프 적용
  - map-latest reason_counts cutoff 사유를 `stale_cycle`로 통합
- `tests/test_cutoff_policy.py`
- `tests/test_ingest_service.py`
- `tests/test_api_routes.py`
- `data/issue359_time_gate_before_after_distribution.json`
- `data/issue359_reingest_cutoff_probe.json`
- `Collector_reports/2026-02-27_issue359_time_gate_hardening_report.md`

## Validation
- `../election2026_codex/.venv/bin/python -m pytest tests/test_cutoff_policy.py tests/test_ingest_service.py tests/test_api_routes.py -q`
- `../election2026_codex/.venv/bin/python -m pytest tests/test_collector_map_latest_cleanup_v1_script.py -q`

Closes #359
