### PR TITLE
[W7][DEVELOP][P2] 후보 상세 API 결측/출처 계약 안정화

### DIFF
--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -33,6 +33,15 @@ class CandidateOut(BaseModel):
     job: str | None = None
     career_summary: str | None = None
     election_history: str | None = None
+    profile_source: Literal["data_go", "ingest", "mixed", "none"] = "none"
+    profile_completeness: Literal["complete", "partial", "empty"] = "empty"
+    profile_provenance: dict[
+        Literal["party_name", "gender", "birth_date", "job", "career_summary", "election_history"],
+        Literal["data_go", "ingest", "missing"],
+    ] = Field(default_factory=dict)
+    profile_source_type: str | None = None
+    profile_source_url: str | None = None
+    placeholder_name_applied: bool = False
 
 
 class SummaryPoint(BaseModel):

--- a/app/services/repository.py
+++ b/app/services/repository.py
@@ -1926,7 +1926,9 @@ class PostgresRepository:
                     ) AS needs_manual_review,
                     c.gender,
                     c.birth_date, c.job,
-                    cp.career_summary, cp.election_history
+                    cp.career_summary, cp.election_history,
+                    cp.source_type AS profile_source_type,
+                    cp.source_url AS profile_source_url
                 FROM candidates c
                 LEFT JOIN candidate_profiles cp ON cp.candidate_id = c.candidate_id
                 WHERE c.candidate_id = %s

--- a/develop_report/2026-02-27_issue390_candidate_detail_contract_stabilization_report.md
+++ b/develop_report/2026-02-27_issue390_candidate_detail_contract_stabilization_report.md
@@ -1,0 +1,59 @@
+# 2026-02-27 Issue #390 후보 상세 API 결측/출처 계약 안정화 보고서
+
+## 1) 이슈
+- #390 `[W7][DEVELOP][P2] 후보 상세 API 결측/출처 계약 안정화`
+
+## 2) 구현 내용
+1. `/api/v1/candidates/{candidate_id}` 응답 계약 보강
+- 신규 필드
+  - `profile_source`: `data_go|ingest|mixed|none`
+  - `profile_completeness`: `complete|partial|empty`
+  - `profile_provenance`: 프로필 필드별 출처(`data_go|ingest|missing`)
+  - `profile_source_type`, `profile_source_url`
+  - `placeholder_name_applied`
+
+2. 결측/placeholder 정책 표준화
+- 문자열 결측(`''`, 공백)은 `null`로 정규화
+- `name_ko` 결측 시 `candidate_id`로 fallback
+- fallback 적용 여부를 `placeholder_name_applied`로 명시
+
+3. provenance 계산 로직 추가
+- 기준 필드: `party_name`, `gender`, `birth_date`, `job`, `career_summary`, `election_history`
+- base(DB) vs enriched(data.go 반영 후) 비교로 필드별 출처 계산
+
+4. repository 매핑 보강
+- `get_candidate` 조회에 `candidate_profiles.source_type/source_url` 포함
+
+5. 문서 업데이트
+- `docs/02_DATA_MODEL_AND_NORMALIZATION.md`
+- `docs/03_UI_UX_SPEC.md`
+
+## 3) 테스트
+- 실행:
+```bash
+/Users/gimtaehun/election2026_codex/.venv/bin/python -m pytest -q \
+  tests/test_api_routes.py tests/test_data_go_candidate_service.py
+```
+- 결과: `38 passed`
+
+- 추가/강화 검증
+1. data.go 병합 시 provenance/source 집계 검증
+2. 결측 프로필에서 null 정규화 및 placeholder 플래그 검증
+3. 기존 후보 상세 계약/회귀 동작 유지
+
+## 4) 변경 파일
+- `app/api/routes.py`
+- `app/models/schemas.py`
+- `app/services/repository.py`
+- `tests/test_api_routes.py`
+- `docs/02_DATA_MODEL_AND_NORMALIZATION.md`
+- `docs/03_UI_UX_SPEC.md`
+- `develop_report/2026-02-27_issue390_candidate_detail_contract_stabilization_report.md`
+
+## 5) 수용기준 대응
+1. 후보 상세 API 4xx/5xx 회귀 0
+- 대상 테스트 PASS 및 기존 엔드포인트 회귀 없음
+2. 결측 표현 일관
+- 공백 문자열 null 정규화 + 이름 placeholder 정책 고정
+3. UI 연동 QA PASS
+- 출처/완결성/placeholder 계약 키를 응답에 명시해 분기 기준 단순화

--- a/docs/02_DATA_MODEL_AND_NORMALIZATION.md
+++ b/docs/02_DATA_MODEL_AND_NORMALIZATION.md
@@ -140,6 +140,13 @@
 4. 기존 레거시 데이터는 마이그레이션 시 `source_channels = [source_channel]`로 백필한다.
 5. API 파생 필드:
 - `source_priority`: `official|article|mixed`
+
+## 8.1 후보 상세 결측/출처 계약 (`GET /api/v1/candidates/{candidate_id}`)
+1. 문자열 결측값(`''`, 공백)은 API 응답에서 `null`로 정규화한다.
+2. `name_ko`가 결측이면 `candidate_id`를 placeholder로 사용하고 `placeholder_name_applied=true`를 노출한다.
+3. `profile_provenance`는 후보 프로필 필드별 출처(`data_go|ingest|missing`)를 노출한다.
+4. `profile_source`는 전체 출처 집계(`data_go|ingest|mixed|none`)를 노출한다.
+5. `profile_completeness`는 필수 프로필(`party_name`, `career_summary`, `election_history`) 기준으로 `complete|partial|empty`를 노출한다.
 - `is_official_confirmed`: `source_channels`에 `nesdc` 포함 시 `true`
 - `official_release_at`: 공식소스 포함 시 관측치 최신 갱신시각 기준
 - `article_published_at`: 연결 기사의 `published_at`

--- a/docs/03_UI_UX_SPEC.md
+++ b/docs/03_UI_UX_SPEC.md
@@ -65,7 +65,7 @@
 | 지역 검색 | `GET /api/v1/regions/search` (`q/query` optional, `has_data` optional) | `regions`, `elections` | `region_code`, `sido_name`, `sigungu_name`, `has_data`, `matchup_count` |
 | 지역별 선거 탭 | `GET /api/v1/regions/{region_code}/elections` | `matchups` | `region_code`, `office_type`, `is_active` |
 | 매치업 상세 | `GET /api/v1/matchups/{matchup_id}` | `matchups`, `poll_observations`, `poll_options`, `review_queue` | `matchup_id`, `has_data`, `pollster`, `survey_start_date`, `survey_end_date`, `confidence_level`, `sample_size`, `response_rate`, `margin_of_error`, `date_inference_mode`, `date_inference_confidence`, `nesdc_enriched`, `needs_manual_review`, `source_priority`, `official_release_at`, `article_published_at`, `freshness_hours`, `is_official_confirmed`, `value_mid`, `party_inferred`, `party_inference_source`, `party_inference_confidence`, `source_grade`, `audience_scope`, `audience_region_code`, `legal_completeness_score`, `legal_filled_count`, `legal_required_count`, `source_channel`, `source_channels`, `poll_fingerprint` |
-| 후보자 상세 | `GET /api/v1/candidates/{candidate_id}` | `candidates`, `candidate_profiles` | `candidate_id`, `name_ko`, `party_name`, `career_summary` |
+| 후보자 상세 | `GET /api/v1/candidates/{candidate_id}` | `candidates`, `candidate_profiles` | `candidate_id`, `name_ko`, `party_name`, `career_summary`, `election_history`, `profile_source`, `profile_completeness`, `profile_provenance`, `profile_source_type`, `profile_source_url`, `placeholder_name_applied` |
 
 ## 5. API-UI 필드명 일치 규칙
 1. UI에서 수치표시는 항상 `value_mid` 기준


### PR DESCRIPTION
Report-Path: develop_report/2026-02-27_issue390_candidate_detail_contract_stabilization_report.md

## Summary
- strengthen `/api/v1/candidates/{candidate_id}` contract for nullable/profile-source consistency
- add profile provenance fields and completeness/source aggregates
  - `profile_source`, `profile_completeness`, `profile_provenance`
  - `profile_source_type`, `profile_source_url`, `placeholder_name_applied`
- normalize candidate string-nullables to `null` and enforce deterministic name placeholder policy
- include `candidate_profiles.source_type/source_url` in repository mapping
- update docs and candidate endpoint tests for missing/merged scenarios

## Validation
- `/Users/gimtaehun/election2026_codex/.venv/bin/python -m pytest -q tests/test_api_routes.py tests/test_data_go_candidate_service.py`
  - result: `38 passed`

Closes #390
