### PR TITLE
[COLLECTOR][W6] 상대시점 날짜해석 엔진 고도화(게시일 anchor) (#385)

### DIFF
--- a/Collector_reports/2026-02-27_issue385_relative_date_anchor_engine_report.md
+++ b/Collector_reports/2026-02-27_issue385_relative_date_anchor_engine_report.md
@@ -1,0 +1,62 @@
+# 2026-02-27 Issue #385 실행 보고서 (Collector)
+
+## 1) 작업 개요
+- 이슈: `#385` `[W6][COLLECTOR][P1] 기사 상대시점 날짜해석 엔진 고도화(게시일 anchor)`
+- 목표:
+  - 게시일 anchor 기준 상대시점 해석 정확도 개선
+  - timezone/자정 경계 오차 축소
+  - date inference 근거 payload 확장
+
+## 2) 반영 내용
+- `src/pipeline/collector.py`
+  - 상대시점 룰셋 확장
+    - 고정 신호: `그저께/그제/어제/오늘/지난주/이번주/최근`
+    - 수치 신호: `N일 전`, `N주 전`, `N개월 전`, `지난 N일`, `지난달`
+  - 게시일 anchor 해석 개선
+    - `published_at`/`collected_at` 파싱 시 `Asia/Seoul` 기준 날짜 변환
+    - UTC->KST 자정 경계(전일/당일 뒤틀림) 보정
+  - 월 단위 이동 보강
+    - `지난달`, `N개월 전`에서 월말 clamp 처리(예: 3/31 -> 2/28)
+  - 증거 payload 확장
+    - 상대시점 관련 review_queue payload에 아래 필드 추가:
+      - `relative_signal`, `relative_offset_days`
+      - `anchor_source`, `anchor_date`, `inferred_survey_end_date`
+      - `published_at`, `collected_at`, `timezone`
+
+- `tests/test_collector_extract.py`
+  - 상대시점 경계/월단위/수치 표현 테스트 추가
+  - strict_fail payload 확장 필드 검증 추가
+
+## 3) 테스트 결과
+- 실행 명령:
+  - `../election2026_codex/.venv/bin/python -m pytest tests/test_collector_extract.py tests/test_contracts.py tests/test_collector_contract_freeze.py tests/test_ingest_adapter.py -q`
+  - `../election2026_codex/.venv/bin/python -m pytest tests/test_collector_live_news_v1_pack_script.py tests/test_collector_live_coverage_v2_pack_script.py -q`
+- 결과:
+  - `31 passed`
+  - `10 passed`
+
+## 4) 증적 파일
+- `data/issue385_relative_date_inference_evidence.json`
+
+핵심 확인값:
+- 총 7개 시나리오 검증, `passed_cases=7`
+- KST 자정 경계 보정 케이스:
+  - `published_at=2026-02-17T16:30:00+00:00` + `어제`
+  - 결과 `survey_end_date=2026-02-17` (KST anchor 기준)
+- 월말 clamp 케이스:
+  - `published_at=2026-03-31T10:00:00+09:00` + `지난달`
+  - 결과 `survey_end_date=2026-02-28`
+
+## 5) 수용기준 대응
+1. 상대시점 해석 정확도 개선
+- 단순 키워드 기반에서 수치/월단위 패턴까지 확장했고, 7개 대표 시나리오 정확 매칭.
+
+2. `date_inference_mode/confidence` 일관 저장
+- 기존 모드 체계(`relative_published_at/estimated_timestamp/strict_fail_blocked`) 유지하면서 signal별 confidence를 일관 계산.
+
+3. QA 날짜검증 PASS 준비
+- 경계/패턴 케이스 테스트와 증빙 JSON 제출 완료. QA 측 재검증 입력으로 사용 가능.
+
+## 6) 의사결정 요청
+1. `이번주/최근` 신호의 confidence(현재 0.58/0.45)를 운영 임계치(0.8) 하회로 유지할지, 도메인별로 상향 조정할지 결정이 필요합니다.
+2. 상대시점 해석 시 timezone을 `Asia/Seoul` 고정으로 두었는데, 해외 매체 확장 시 소스 timezone 우선 전략으로 전환할지 정책 결정이 필요합니다.

--- a/data/issue385_relative_date_inference_evidence.json
+++ b/data/issue385_relative_date_inference_evidence.json
@@ -1,0 +1,224 @@
+{
+  "issue": 385,
+  "generated_at_kst": "2026-02-27T11:44:44+09:00",
+  "scenario": "relative_date_inference_anchor_v2",
+  "summary": {
+    "total_cases": 7,
+    "passed_cases": 7,
+    "failed_cases": 0
+  },
+  "results": [
+    {
+      "case_id": "yesterday_published_anchor",
+      "policy": "strict_fail",
+      "input": {
+        "published_at": "2026-02-20T08:00:00+09:00",
+        "collected_at": "2026-02-20T00:00:00+00:00",
+        "raw_text": "어제 발표된 서울시장 여론조사에서 정원오 44% vs 오세훈 31%"
+      },
+      "expected": {
+        "survey_end_date": "2026-02-19",
+        "date_inference_mode": "relative_published_at"
+      },
+      "observed": {
+        "survey_end_date": "2026-02-19",
+        "date_inference_mode": "relative_published_at",
+        "date_inference_confidence": 0.95,
+        "date_resolution": "relative_day",
+        "error_codes": [],
+        "error_payloads": [],
+        "option_count": 2
+      },
+      "passed": true
+    },
+    {
+      "case_id": "three_days_ago",
+      "policy": "strict_fail",
+      "input": {
+        "published_at": "2026-02-20T08:00:00+09:00",
+        "collected_at": "2026-02-20T00:00:00+00:00",
+        "raw_text": "3일 전 발표된 서울시장 여론조사에서 정원오 44% vs 오세훈 31%"
+      },
+      "expected": {
+        "survey_end_date": "2026-02-17",
+        "date_inference_mode": "relative_published_at"
+      },
+      "observed": {
+        "survey_end_date": "2026-02-17",
+        "date_inference_mode": "relative_published_at",
+        "date_inference_confidence": 0.9,
+        "date_resolution": "relative_day",
+        "error_codes": [],
+        "error_payloads": [],
+        "option_count": 2
+      },
+      "passed": true
+    },
+    {
+      "case_id": "last_month_day_clamp",
+      "policy": "strict_fail",
+      "input": {
+        "published_at": "2026-03-31T10:00:00+09:00",
+        "collected_at": "2026-04-01T00:00:00+00:00",
+        "raw_text": "지난달 실시된 서울시장 여론조사에서 정원오 44% vs 오세훈 31%"
+      },
+      "expected": {
+        "survey_end_date": "2026-02-28",
+        "date_inference_mode": "relative_published_at"
+      },
+      "observed": {
+        "survey_end_date": "2026-02-28",
+        "date_inference_mode": "relative_published_at",
+        "date_inference_confidence": 0.86,
+        "date_resolution": "relative_month",
+        "error_codes": [],
+        "error_payloads": [],
+        "option_count": 2
+      },
+      "passed": true
+    },
+    {
+      "case_id": "kst_midnight_boundary",
+      "policy": "strict_fail",
+      "input": {
+        "published_at": "2026-02-17T16:30:00+00:00",
+        "collected_at": "2026-02-19T00:00:00+00:00",
+        "raw_text": "어제 발표된 서울시장 여론조사에서 정원오 44% vs 오세훈 31%"
+      },
+      "expected": {
+        "survey_end_date": "2026-02-17",
+        "date_inference_mode": "relative_published_at"
+      },
+      "observed": {
+        "survey_end_date": "2026-02-17",
+        "date_inference_mode": "relative_published_at",
+        "date_inference_confidence": 0.95,
+        "date_resolution": "relative_day",
+        "error_codes": [],
+        "error_payloads": [],
+        "option_count": 2
+      },
+      "passed": true
+    },
+    {
+      "case_id": "strict_fail_when_published_missing",
+      "policy": "strict_fail",
+      "input": {
+        "published_at": null,
+        "collected_at": "2026-02-19T00:00:00+00:00",
+        "raw_text": "어제 발표된 서울시장 여론조사에서 정원오 44% vs 오세훈 31%"
+      },
+      "expected": {
+        "survey_end_date": null,
+        "date_inference_mode": "strict_fail_blocked",
+        "error_code": "RELATIVE_DATE_STRICT_FAIL"
+      },
+      "observed": {
+        "survey_end_date": null,
+        "date_inference_mode": "strict_fail_blocked",
+        "date_inference_confidence": 0.0,
+        "date_resolution": "failed",
+        "error_codes": [
+          "RELATIVE_DATE_STRICT_FAIL"
+        ],
+        "error_payloads": [
+          {
+            "date_inference_mode": "strict_fail_blocked",
+            "date_inference_confidence": 0.0,
+            "relative_date_policy": "strict_fail",
+            "relative_signal": "어제",
+            "relative_offset_days": -1,
+            "anchor_source": "none",
+            "anchor_date": null,
+            "inferred_survey_end_date": null,
+            "published_at": null,
+            "collected_at": "2026-02-19T00:00:00+00:00",
+            "timezone": "Asia/Seoul"
+          }
+        ],
+        "option_count": 2
+      },
+      "passed": true
+    },
+    {
+      "case_id": "allow_estimated_when_published_missing",
+      "policy": "allow_estimated_timestamp",
+      "input": {
+        "published_at": null,
+        "collected_at": "2026-02-19T00:00:00+00:00",
+        "raw_text": "어제 발표된 서울시장 여론조사에서 정원오 44% vs 오세훈 31%"
+      },
+      "expected": {
+        "survey_end_date": "2026-02-18",
+        "date_inference_mode": "estimated_timestamp",
+        "error_code": "RELATIVE_DATE_ESTIMATED"
+      },
+      "observed": {
+        "survey_end_date": "2026-02-18",
+        "date_inference_mode": "estimated_timestamp",
+        "date_inference_confidence": 0.7,
+        "date_resolution": "estimated",
+        "error_codes": [
+          "RELATIVE_DATE_ESTIMATED"
+        ],
+        "error_payloads": [
+          {
+            "date_inference_mode": "estimated_timestamp",
+            "date_inference_confidence": 0.7,
+            "relative_date_policy": "allow_estimated_timestamp",
+            "relative_signal": "어제",
+            "relative_offset_days": -1,
+            "anchor_source": "collected_at",
+            "anchor_date": "2026-02-19",
+            "inferred_survey_end_date": "2026-02-18",
+            "published_at": null,
+            "collected_at": "2026-02-19T00:00:00+00:00",
+            "timezone": "Asia/Seoul"
+          }
+        ],
+        "option_count": 2
+      },
+      "passed": true
+    },
+    {
+      "case_id": "low_confidence_recent",
+      "policy": "strict_fail",
+      "input": {
+        "published_at": "2026-02-18T00:00:00+09:00",
+        "collected_at": "2026-02-19T00:00:00+00:00",
+        "raw_text": "최근 서울시장 여론조사에서 정원오 44% vs 오세훈 31%"
+      },
+      "expected": {
+        "survey_end_date": "2026-02-18",
+        "date_inference_mode": "relative_published_at",
+        "error_code": "RELATIVE_DATE_UNCERTAIN"
+      },
+      "observed": {
+        "survey_end_date": "2026-02-18",
+        "date_inference_mode": "relative_published_at",
+        "date_inference_confidence": 0.45,
+        "date_resolution": "relative_recent",
+        "error_codes": [
+          "RELATIVE_DATE_UNCERTAIN"
+        ],
+        "error_payloads": [
+          {
+            "date_inference_mode": "relative_published_at",
+            "date_inference_confidence": 0.45,
+            "relative_date_policy": "strict_fail",
+            "relative_signal": "최근",
+            "relative_offset_days": 0,
+            "anchor_source": "published_at",
+            "anchor_date": "2026-02-18",
+            "inferred_survey_end_date": "2026-02-18",
+            "published_at": "2026-02-18T00:00:00+09:00",
+            "collected_at": "2026-02-19T00:00:00+00:00",
+            "timezone": "Asia/Seoul"
+          }
+        ],
+        "option_count": 2
+      },
+      "passed": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- improve relative date resolver with published-at anchor and KST boundary handling
- expand relative expressions: fixed + numeric (`N일 전`, `N주 전`, `N개월 전`, `지난 N일`, `지난달`)
- add inference evidence payload fields for relative-date review queue records
- add regression tests and issue evidence/report artifacts

## Changes
- `src/pipeline/collector.py`
- `tests/test_collector_extract.py`
- `data/issue385_relative_date_inference_evidence.json`
- `Collector_reports/2026-02-27_issue385_relative_date_anchor_engine_report.md`

## Validation
- `../election2026_codex/.venv/bin/python -m pytest tests/test_collector_extract.py tests/test_contracts.py tests/test_collector_contract_freeze.py tests/test_ingest_adapter.py -q`
- `../election2026_codex/.venv/bin/python -m pytest tests/test_collector_live_news_v1_pack_script.py tests/test_collector_live_coverage_v2_pack_script.py -q`
- result: `31 passed`, `10 passed`

## Evidence
- `data/issue385_relative_date_inference_evidence.json` (`7/7` scenarios passed)

## Report-Path
Report-Path: Collector_reports/2026-02-27_issue385_relative_date_anchor_engine_report.md

Closes #385
