### PR TITLE
[W6][DEVELOP][P1] 핵심 API 성능 튜닝(P95 개선)

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -22,6 +22,7 @@ class Settings(BaseSettings):
     data_go_candidate_cache_ttl_sec: int = 300
     data_go_candidate_requests_per_sec: float = 5.0
     data_go_candidate_num_of_rows: int = 300
+    api_read_cache_ttl_sec: int = 0
 
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
 

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -498,6 +498,12 @@ CREATE INDEX IF NOT EXISTS idx_poll_observations_matchup ON poll_observations (m
 CREATE INDEX IF NOT EXISTS idx_poll_observations_matchup_latest
     ON poll_observations (matchup_id, survey_end_date DESC, id DESC);
 CREATE INDEX IF NOT EXISTS idx_poll_observations_scope_date ON poll_observations (audience_scope, survey_end_date DESC);
+CREATE INDEX IF NOT EXISTS idx_poll_observations_verified_date
+    ON poll_observations (survey_end_date DESC, id DESC)
+    WHERE verified = TRUE;
+CREATE INDEX IF NOT EXISTS idx_poll_observations_verified_region_office_date
+    ON poll_observations (region_code, office_type, survey_end_date DESC, id DESC)
+    WHERE verified = TRUE;
 CREATE INDEX IF NOT EXISTS idx_poll_observations_fingerprint ON poll_observations (poll_fingerprint);
 CREATE INDEX IF NOT EXISTS idx_poll_observations_source_channels ON poll_observations USING GIN (source_channels);
 CREATE INDEX IF NOT EXISTS idx_candidates_source_channels ON candidates USING GIN (source_channels);
@@ -506,6 +512,12 @@ CREATE INDEX IF NOT EXISTS idx_elections_latest_matchup ON elections (latest_mat
 CREATE INDEX IF NOT EXISTS idx_poll_options_type ON poll_options (option_type);
 CREATE INDEX IF NOT EXISTS idx_poll_options_observation_value
     ON poll_options (observation_id, value_mid DESC, option_name);
+CREATE INDEX IF NOT EXISTS idx_poll_options_summary_type_observation
+    ON poll_options (option_type, observation_id, option_name)
+    WHERE option_type IN ('party_support', 'president_job_approval', 'election_frame', 'presidential_approval');
+CREATE INDEX IF NOT EXISTS idx_poll_options_candidate_matchup_observation_value
+    ON poll_options (observation_id, value_mid DESC, option_name)
+    WHERE option_type = 'candidate_matchup' AND value_mid IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_review_queue_status ON review_queue (status, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_review_queue_entity_status
     ON review_queue (entity_type, entity_id, status);

--- a/develop_report/2026-02-27_issue389_api_p95_tuning_report.md
+++ b/develop_report/2026-02-27_issue389_api_p95_tuning_report.md
@@ -1,0 +1,81 @@
+# 2026-02-27 Issue #389 핵심 API 성능 튜닝(P95) 보고서
+
+## 1. 작업 목표
+- 대상: 핵심 조회 API(`dashboard/summary`, `dashboard/map-latest`, `dashboard/big-matches`, `matchups/{id}`)
+- 목표: P95 지연 편차 완화
+- 제약: 데이터 신선도 훼손 없이 적용
+
+## 2. 적용한 개선
+
+### 2.1 Read Path TTL 캐시(짧은 TTL)
+- 파일: `app/services/repository.py`
+- 신규 구성:
+  - 모듈 전역 read cache (`_API_READ_CACHE`)
+  - TTL 기반 get/set (`_api_read_cache_get`, `_api_read_cache_set`)
+  - 캐시 키 표준화 (`_api_read_cache_key`)
+  - 수동 초기화 유틸 (`clear_api_read_cache`)
+- 캐시 적용 메서드:
+  - `fetch_dashboard_summary`
+  - `fetch_dashboard_map_latest`
+  - `fetch_dashboard_big_matches`
+  - `get_matchup`
+- 운영 설정:
+  - `API_READ_CACHE_TTL_SEC` (기본 `0`, 비활성)
+  - 활성화 권장값: `15~30`초
+
+### 2.2 쓰기 경로 캐시 무효화
+- 파일: `app/services/repository.py`
+- 데이터 변경 메서드 `commit` 직후 `self._invalidate_api_read_cache()` 적용
+- 목적: 짧은 TTL 캐시 사용 시에도 쓰기 직후 stale 응답 노출 최소화
+
+### 2.3 인덱스 튜닝
+- 파일: `db/schema.sql`
+- 추가 인덱스:
+  - `idx_poll_observations_verified_date`
+  - `idx_poll_observations_verified_region_office_date`
+  - `idx_poll_options_summary_type_observation`
+  - `idx_poll_options_candidate_matchup_observation_value`
+- 기대 효과:
+  - `verified=true` hot path 필터링 비용 감소
+  - summary/map/matchup에서 option+observation join/정렬 비용 감소
+
+### 2.4 환경 문서 반영
+- 파일: `docs/04_DEPLOYMENT_AND_ENVIRONMENT.md`
+- 추가:
+  - `API_READ_CACHE_TTL_SEC` 설명 (기본 `0`, 권장 `15~30`)
+
+## 3. 성능 근거(정량)
+
+### 3.1 캐시 hit 시 DB 쿼리 감소
+- 테스트: `tests/test_repository_read_cache.py`
+- 결과:
+  - 동일 summary 2회 호출
+  - 캐시 비활성(TTL=0): SQL 2회
+  - 캐시 활성(TTL=30): SQL 1회
+
+### 3.2 신선도 안전장치
+- 테스트: `tests/test_repository_read_cache.py::test_write_path_invalidates_dashboard_summary_cache`
+- 결과:
+  - 캐시 hit 후 write 발생 시 캐시 무효화
+  - 다음 read에서 SQL 재실행(신규 데이터 반영 경로 확보)
+
+## 4. 검증 실행
+- `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q tests/test_repository_read_cache.py tests/test_schema_read_performance_indexes.py`
+  - 결과: `4 passed`
+- `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q tests/test_repository_dashboard_summary_scope.py tests/test_repository_matchup_legal_metadata.py tests/test_repository_matchup_scenarios.py tests/test_repository_region_elections_master.py`
+  - 결과: `13 passed`
+- `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q tests/test_api_routes.py`
+  - 결과: `31 passed`
+
+## 5. 변경 파일
+- `app/config.py`
+- `app/services/repository.py`
+- `db/schema.sql`
+- `docs/04_DEPLOYMENT_AND_ENVIRONMENT.md`
+- `tests/test_repository_read_cache.py`
+- `tests/test_schema_read_performance_indexes.py`
+
+## 6. 운영 적용 권장
+1. `API_READ_CACHE_TTL_SEC=20`으로 먼저 적용
+2. QA/스테이징에서 API P95 비교 후(캐시 off vs on) 운영 반영
+3. 배치/수동 적재 직후 응답 신선도 체크(캐시 무효화 정상 동작 확인)

--- a/docs/04_DEPLOYMENT_AND_ENVIRONMENT.md
+++ b/docs/04_DEPLOYMENT_AND_ENVIRONMENT.md
@@ -116,6 +116,7 @@ PYTHONPATH=. .venv/bin/python scripts/sync_elections_master.py \
 - `INTERNAL_JOB_TOKEN`
 4. 선택 환경변수:
 - `RELATIVE_DATE_POLICY` (`strict_fail` 기본, `allow_estimated_timestamp` 선택)
+- `API_READ_CACHE_TTL_SEC` (초 단위, 기본 `0`=비활성, 권장 `15~30`)
 4. CI 부트스트랩 전략:
 - `DATABASE_URL` secret가 비어 있으면 workflow service postgres(`postgresql://postgres:postgres@127.0.0.1:5432/app`)로 자동 fallback
 - secret preflight는 fallback 반영 후 실행되어 DB URL 누락 원인을 즉시 표시

--- a/tests/test_repository_read_cache.py
+++ b/tests/test_repository_read_cache.py
@@ -1,0 +1,112 @@
+from datetime import date
+
+import app.services.repository as repository_module
+from app.services.repository import PostgresRepository, clear_api_read_cache
+
+
+class _FakeCursor:
+    def __init__(self, conn):
+        self.conn = conn
+        self._query = ""
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def execute(self, query, params=None):  # noqa: ARG002
+        self._query = query
+        if "WITH ranked_latest AS" in query:
+            self.conn.summary_query_count += 1
+        if "INSERT INTO review_queue" in query:
+            self.conn.review_insert_count += 1
+
+    def fetchall(self):
+        if "WITH ranked_latest AS" in self._query:
+            return [
+                {
+                    "option_type": "party_support",
+                    "option_name": "더불어민주당",
+                    "value_mid": 40.0,
+                    "pollster": "테스트",
+                    "survey_end_date": date(2026, 2, 27),
+                    "source_grade": "A",
+                    "audience_scope": "national",
+                    "audience_region_code": None,
+                    "observation_updated_at": "2026-02-27T00:00:00+00:00",
+                    "official_release_at": None,
+                    "article_published_at": "2026-02-27T00:00:00+00:00",
+                    "source_channel": "article",
+                    "source_channels": ["article"],
+                    "verified": True,
+                }
+            ]
+        return []
+
+
+class _FakeConn:
+    def __init__(self):
+        self.summary_query_count = 0
+        self.review_insert_count = 0
+        self.commit_count = 0
+
+    def cursor(self):
+        return _FakeCursor(self)
+
+    def commit(self):
+        self.commit_count += 1
+
+    def rollback(self):
+        return None
+
+
+def test_dashboard_summary_uses_ttl_cache(monkeypatch):
+    clear_api_read_cache()
+    monkeypatch.setattr(repository_module, "_api_read_cache_ttl_sec", lambda: 30.0)
+
+    conn = _FakeConn()
+    repo = PostgresRepository(conn)
+
+    first = repo.fetch_dashboard_summary(as_of=None)
+    second = repo.fetch_dashboard_summary(as_of=None)
+
+    assert conn.summary_query_count == 1
+    assert first == second
+
+
+def test_dashboard_summary_cache_disabled_when_ttl_zero(monkeypatch):
+    clear_api_read_cache()
+    monkeypatch.setattr(repository_module, "_api_read_cache_ttl_sec", lambda: 0.0)
+
+    conn = _FakeConn()
+    repo = PostgresRepository(conn)
+
+    repo.fetch_dashboard_summary(as_of=None)
+    repo.fetch_dashboard_summary(as_of=None)
+
+    assert conn.summary_query_count == 2
+
+
+def test_write_path_invalidates_dashboard_summary_cache(monkeypatch):
+    clear_api_read_cache()
+    monkeypatch.setattr(repository_module, "_api_read_cache_ttl_sec", lambda: 30.0)
+
+    conn = _FakeConn()
+    repo = PostgresRepository(conn)
+
+    repo.fetch_dashboard_summary(as_of=None)
+    repo.fetch_dashboard_summary(as_of=None)
+    assert conn.summary_query_count == 1
+
+    repo.insert_review_queue(
+        entity_type="ingest_record",
+        entity_id="obs-1",
+        issue_type="mapping_error",
+        review_note="need check",
+    )
+
+    repo.fetch_dashboard_summary(as_of=None)
+
+    assert conn.review_insert_count == 1
+    assert conn.summary_query_count == 2

--- a/tests/test_schema_read_performance_indexes.py
+++ b/tests/test_schema_read_performance_indexes.py
@@ -5,7 +5,11 @@ def test_schema_contains_read_performance_indexes() -> None:
     sql = Path("db/schema.sql").read_text(encoding="utf-8")
     assert "idx_poll_observations_matchup_latest" in sql
     assert "ON poll_observations (matchup_id, survey_end_date DESC, id DESC)" in sql
+    assert "idx_poll_observations_verified_region_office_date" in sql
+    assert "ON poll_observations (region_code, office_type, survey_end_date DESC, id DESC)" in sql
     assert "idx_poll_options_observation_value" in sql
     assert "ON poll_options (observation_id, value_mid DESC, option_name)" in sql
+    assert "idx_poll_options_summary_type_observation" in sql
+    assert "idx_poll_options_candidate_matchup_observation_value" in sql
     assert "idx_review_queue_entity_status" in sql
     assert "ON review_queue (entity_type, entity_id, status)" in sql


### PR DESCRIPTION
## Summary
- tune read hot path for `dashboard/summary`, `dashboard/map-latest`, `dashboard/big-matches`, `matchups/{id}`
- add TTL-based read cache in repository layer (config-driven)
- add write-path cache invalidation after commits
- add hot-path indexes for verified observation scans and summary/candidate option lookups
- add regression tests for cache behavior and index presence
- update deployment env doc and attach develop report

## Validation
- `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q tests/test_repository_read_cache.py tests/test_schema_read_performance_indexes.py`
- `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q tests/test_repository_dashboard_summary_scope.py tests/test_repository_matchup_legal_metadata.py tests/test_repository_matchup_scenarios.py tests/test_repository_region_elections_master.py`
- `/Users/gimtaehun/election2026_codex/.venv/bin/pytest -q tests/test_api_routes.py`

## Report
- `develop_report/2026-02-27_issue389_api_p95_tuning_report.md`

Closes #389
