### PR TITLE
[DEVELOP] #471 worktree/runtime 자동정리 가드 도입

### DIFF
--- a/.github/workflows/worktree-hygiene.yml
+++ b/.github/workflows/worktree-hygiene.yml
@@ -1,0 +1,73 @@
+name: Worktree Hygiene
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "Run mode"
+        required: false
+        default: "dry-run"
+        type: choice
+        options:
+          - dry-run
+          - apply
+      stale_hours:
+        description: "Stale threshold in hours"
+        required: false
+        default: "24"
+      base_dir:
+        description: "Scan base directory (empty = $HOME)"
+        required: false
+        default: ""
+  schedule:
+    - cron: "0 1 * * 1"
+
+jobs:
+  hygiene:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve params
+        id: params
+        shell: bash
+        run: |
+          mode="${{ github.event.inputs.mode }}"
+          hours="${{ github.event.inputs.stale_hours }}"
+          base_dir="${{ github.event.inputs.base_dir }}"
+
+          if [[ "${{ github.event_name }}" == "schedule" ]]; then
+            mode="dry-run"
+          fi
+          if [[ -z "${mode}" ]]; then
+            mode="dry-run"
+          fi
+          if [[ -z "${hours}" ]]; then
+            hours="24"
+          fi
+          if [[ -z "${base_dir}" ]]; then
+            base_dir="${HOME}"
+          fi
+
+          echo "mode=${mode}" >> "${GITHUB_OUTPUT}"
+          echo "hours=${hours}" >> "${GITHUB_OUTPUT}"
+          echo "base_dir=${base_dir}" >> "${GITHUB_OUTPUT}"
+
+      - name: Run worktree hygiene
+        id: hygiene
+        shell: bash
+        run: |
+          report_path="data/worktree_hygiene_report_${GITHUB_RUN_ID}.txt"
+          bash scripts/pm/worktree_hygiene.sh \
+            --mode "${{ steps.params.outputs.mode }}" \
+            --hours "${{ steps.params.outputs.hours }}" \
+            --base-dir "${{ steps.params.outputs.base_dir }}" \
+            --report "${report_path}"
+          echo "report_path=${report_path}" >> "${GITHUB_OUTPUT}"
+
+      - name: Upload report artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: worktree-hygiene-report-${{ github.run_id }}
+          path: ${{ steps.hygiene.outputs.report_path }}
+          if-no-files-found: error

--- a/develop_report/2026-02-27_worktree_hygiene_automation_report.md
+++ b/develop_report/2026-02-27_worktree_hygiene_automation_report.md
@@ -1,0 +1,71 @@
+# 2026-02-27 Worktree Hygiene Automation Report
+
+## 1) 작업 개요
+- 대상 이슈: `#471` `[DEVELOP][P1] worktree/runtime 임시폴더 자동정리 가드 도입`
+- 목표:
+  1. 24h 이상 미접근 임시 worktree/runtime 폴더 후보 탐지
+  2. 안전 제외(메인 레포/활성 worktree) 적용
+  3. `dry-run` / `apply` 모드 지원
+  4. 수동 + 주간 자동 리포트 워크플로 구축
+
+## 2) 구현 변경 사항
+1. 스크립트 추가: `/scripts/pm/worktree_hygiene.sh`
+- 지원 옵션:
+  - `--mode dry-run|apply`
+  - `--hours <stale_threshold>`
+  - `--base-dir <scan_base>`
+  - `--report <output_path>`
+- 탐지 패턴:
+  - `election2026_codex`
+  - `election2026_codex_issue*`
+  - `election2026_issue*`
+  - `election2026_runtime*`
+  - `election2026_codex_runtime*`
+- 안전 제외 정책:
+  - `election2026_codex` (protected root)
+  - `git worktree list --porcelain` 기반 활성 worktree 경로
+- 적용 시 가드:
+  - `base_dir` 하위 + 관리 패턴 경로만 삭제 허용
+- 산출 리포트:
+  - 후보/제외/삭제/오류 목록 + count 집계 기록
+
+2. 테스트 추가: `/tests/test_worktree_hygiene_script.py`
+- `dry-run`: stale 비활성 경로만 후보로 잡히는지 검증
+- `apply`: guarded candidate만 삭제되고 active worktree는 유지되는지 검증
+
+3. GitHub Action 추가: `/.github/workflows/worktree-hygiene.yml`
+- 트리거:
+  - `workflow_dispatch` (수동)
+  - `schedule` (주 1회, 월요일 01:00 UTC)
+- 동작:
+  - 스케줄 실행은 강제 `dry-run`
+  - 실행 결과 리포트를 artifact로 업로드
+
+4. 운영 문서 반영: `/docs/08_ROLE_BASED_GIT_WORK_SYSTEM_GUIDE.md`
+- Worktree/Runtime 위생 규칙, 로컬 실행 명령, 자동화 워크플로 명시
+
+## 3) 검증 결과
+1. 단위 테스트
+- 명령: `pytest tests/test_worktree_hygiene_script.py -q`
+- 결과: `2 passed`
+
+2. 스크립트 실증(demo)
+- 동일 입력 디렉터리에서 `dry-run` 후 `apply` 실행
+- dry-run 결과: `candidate_count=2`, `deleted_count=0`, `error_count=0`
+- apply 결과: `candidate_count=2`, `deleted_count=2`, `error_count=0`
+- active worktree 경로는 삭제되지 않고 유지됨
+
+## 4) 수용 기준 매핑
+- [x] dry-run 결과와 실제 정리 결과 일치
+- [x] 메인 레포/활성 worktree 오삭제 0건
+- [x] 보고서 제출 완료
+
+## 5) 의사결정 필요 사항
+- 없음.
+
+## 6) 변경 파일
+- `/.github/workflows/worktree-hygiene.yml`
+- `/scripts/pm/worktree_hygiene.sh`
+- `/tests/test_worktree_hygiene_script.py`
+- `/docs/08_ROLE_BASED_GIT_WORK_SYSTEM_GUIDE.md`
+- `/develop_report/2026-02-27_worktree_hygiene_automation_report.md`

--- a/docs/08_ROLE_BASED_GIT_WORK_SYSTEM_GUIDE.md
+++ b/docs/08_ROLE_BASED_GIT_WORK_SYSTEM_GUIDE.md
@@ -184,3 +184,26 @@ bash scripts/pm/set_pm_cycle_mode.sh --repo iAmSomething/2026- --lane online
 5. 주의:
 - 자동화는 이슈를 `in-progress`까지 전진시킨다.
 - 최종 완료(`status/done`)는 QA PASS 계약을 만족해야 한다.
+
+## 12. Worktree/Runtime 위생 규칙
+1. 정리 대상 패턴:
+- `$HOME/election2026_codex_issue*`
+- `$HOME/election2026_issue*`
+- `$HOME/election2026_runtime*`
+- `$HOME/election2026_codex_runtime*`
+
+2. 안전 제외:
+- 메인 레포(`election2026_codex`)
+- `git worktree list`에 잡히는 활성 worktree 경로
+
+3. 로컬 실행:
+```bash
+bash scripts/pm/worktree_hygiene.sh --mode dry-run --hours 24 --base-dir "$HOME" --report data/worktree_hygiene_report_local.txt
+bash scripts/pm/worktree_hygiene.sh --mode apply --hours 24 --base-dir "$HOME" --report data/worktree_hygiene_report_apply.txt
+```
+
+4. 자동화:
+- 워크플로: `.github/workflows/worktree-hygiene.yml`
+- 스케줄: 주 1회(`dry-run`)
+- 수동 실행: `workflow_dispatch`에서 `dry-run/apply` 선택 가능
+- 산출물: 정리 후보/제외/삭제 결과를 artifact로 업로드

--- a/scripts/pm/worktree_hygiene.sh
+++ b/scripts/pm/worktree_hygiene.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+MODE="dry-run"
+STALE_HOURS=24
+BASE_DIR="${WORKTREE_HYGIENE_BASE_DIR:-$HOME}"
+REPORT_PATH="${WORKTREE_HYGIENE_REPORT_PATH:-data/worktree_hygiene_report.txt}"
+GIT_BIN="${WORKTREE_HYGIENE_GIT:-git}"
+NOW_EPOCH="${WORKTREE_HYGIENE_NOW_EPOCH:-$(date +%s)}"
+WORKTREE_LIST_FILE="${WORKTREE_HYGIENE_WORKTREE_LIST_FILE:-}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd -P)"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/pm/worktree_hygiene.sh [--mode dry-run|apply] [--hours N] [--base-dir PATH] [--report PATH]
+
+Options:
+  --mode       dry-run (default) or apply
+  --hours      stale threshold in hours (default: 24)
+  --base-dir   directory to scan (default: $HOME)
+  --report     output report path (default: data/worktree_hygiene_report.txt)
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mode)
+      MODE="${2:-}"
+      shift 2
+      ;;
+    --hours)
+      STALE_HOURS="${2:-}"
+      shift 2
+      ;;
+    --base-dir)
+      BASE_DIR="${2:-}"
+      shift 2
+      ;;
+    --report)
+      REPORT_PATH="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown arg: $1"
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ "${MODE}" != "dry-run" && "${MODE}" != "apply" ]]; then
+  echo "Invalid --mode: ${MODE}. Use dry-run or apply."
+  exit 1
+fi
+
+if ! [[ "${STALE_HOURS}" =~ ^[0-9]+$ ]]; then
+  echo "Invalid --hours: ${STALE_HOURS}. Use non-negative integer."
+  exit 1
+fi
+
+if [[ ! -d "${BASE_DIR}" ]]; then
+  echo "Base directory not found: ${BASE_DIR}"
+  exit 1
+fi
+
+_canon() {
+  local path="$1"
+  (cd "$path" >/dev/null 2>&1 && pwd -P) || return 1
+}
+
+_mtime_epoch() {
+  local path="$1"
+  if stat -f %m "$path" >/dev/null 2>&1; then
+    stat -f %m "$path"
+  else
+    stat -c %Y "$path"
+  fi
+}
+
+if ! BASE_DIR="$(_canon "${BASE_DIR}")"; then
+  echo "Failed to resolve base directory: ${BASE_DIR}"
+  exit 1
+fi
+
+_is_managed_name() {
+  local name="$1"
+  [[ "$name" == election2026_codex_issue* ]] \
+    || [[ "$name" == election2026_issue* ]] \
+    || [[ "$name" == election2026_runtime* ]] \
+    || [[ "$name" == election2026_codex_runtime* ]]
+}
+
+_list_contains() {
+  local needle="$1"
+  shift
+  for item in "$@"; do
+    if [[ "$item" == "$needle" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+active_worktrees=()
+if [[ -n "${WORKTREE_LIST_FILE}" && -f "${WORKTREE_LIST_FILE}" ]]; then
+  while IFS= read -r line; do
+    [[ "$line" == worktree\ * ]] || continue
+    raw_path="${line#worktree }"
+    if abs_path="$(_canon "$raw_path")"; then
+      if ! _list_contains "${abs_path}" ${active_worktrees[@]+"${active_worktrees[@]}"}; then
+        active_worktrees+=("${abs_path}")
+      fi
+    fi
+  done < "${WORKTREE_LIST_FILE}"
+else
+  while IFS= read -r line; do
+    [[ "$line" == worktree\ * ]] || continue
+    raw_path="${line#worktree }"
+    if abs_path="$(_canon "$raw_path")"; then
+      if ! _list_contains "${abs_path}" ${active_worktrees[@]+"${active_worktrees[@]}"}; then
+        active_worktrees+=("${abs_path}")
+      fi
+    fi
+  done < <("${GIT_BIN}" -C "${REPO_ROOT}" worktree list --porcelain 2>/dev/null || true)
+fi
+
+seen_paths=()
+candidate_paths=()
+candidate_ages=()
+excluded_rows=()
+deleted_paths=()
+error_rows=()
+
+managed_patterns=(
+  "election2026_codex"
+  "election2026_codex_issue*"
+  "election2026_issue*"
+  "election2026_runtime*"
+  "election2026_codex_runtime*"
+)
+
+for pattern in "${managed_patterns[@]}"; do
+  for raw_path in "${BASE_DIR}"/${pattern}; do
+    [[ -e "${raw_path}" ]] || continue
+    [[ -d "${raw_path}" ]] || continue
+
+    if ! abs_path="$(_canon "${raw_path}")"; then
+      continue
+    fi
+    if _list_contains "${abs_path}" ${seen_paths[@]+"${seen_paths[@]}"}; then
+      continue
+    fi
+    seen_paths+=("${abs_path}")
+
+    base_name="$(basename "${abs_path}")"
+    if [[ "${abs_path}" == "${REPO_ROOT}" || "${base_name}" == "election2026_codex" ]]; then
+      excluded_rows+=("${abs_path}|protected_root")
+      continue
+    fi
+
+    if _list_contains "${abs_path}" ${active_worktrees[@]+"${active_worktrees[@]}"}; then
+      excluded_rows+=("${abs_path}|active_worktree")
+      continue
+    fi
+
+    modified_epoch="$(_mtime_epoch "${abs_path}")"
+    age_hours=$(( (NOW_EPOCH - modified_epoch) / 3600 ))
+    if (( age_hours >= STALE_HOURS )); then
+      candidate_paths+=("${abs_path}")
+      candidate_ages+=("${age_hours}")
+    else
+      excluded_rows+=("${abs_path}|fresh(${age_hours}h)")
+    fi
+  done
+done
+
+if [[ "${MODE}" == "apply" ]]; then
+  for idx in "${!candidate_paths[@]}"; do
+    path="${candidate_paths[$idx]}"
+    name="$(basename "${path}")"
+    if [[ "${path}" != "${BASE_DIR}"/* ]] || ! _is_managed_name "${name}"; then
+      error_rows+=("${path}|guard_rejected")
+      continue
+    fi
+    if rm -rf -- "${path}"; then
+      deleted_paths+=("${path}")
+    else
+      error_rows+=("${path}|delete_failed")
+    fi
+  done
+fi
+
+mkdir -p "$(dirname "${REPORT_PATH}")"
+{
+  echo "generated_at_epoch=${NOW_EPOCH}"
+  echo "mode=${MODE}"
+  echo "stale_hours=${STALE_HOURS}"
+  echo "base_dir=${BASE_DIR}"
+  echo "repo_root=${REPO_ROOT}"
+  echo "active_worktree_count=${#active_worktrees[@]}"
+  echo "candidate_count=${#candidate_paths[@]}"
+  echo "excluded_count=${#excluded_rows[@]}"
+  echo "deleted_count=${#deleted_paths[@]}"
+  echo "error_count=${#error_rows[@]}"
+  echo ""
+  echo "[candidates]"
+  for idx in "${!candidate_paths[@]}"; do
+    echo "${candidate_paths[$idx]}|age_hours=${candidate_ages[$idx]}"
+  done
+  echo ""
+  echo "[excluded]"
+  for row in "${excluded_rows[@]}"; do
+    echo "${row}"
+  done
+  echo ""
+  echo "[deleted]"
+  for row in "${deleted_paths[@]}"; do
+    echo "${row}"
+  done
+  echo ""
+  echo "[errors]"
+  for row in "${error_rows[@]}"; do
+    echo "${row}"
+  done
+} > "${REPORT_PATH}"
+
+echo "[worktree_hygiene] mode=${MODE} stale_hours=${STALE_HOURS} candidate_count=${#candidate_paths[@]} deleted_count=${#deleted_paths[@]} error_count=${#error_rows[@]}"
+echo "[worktree_hygiene] report=${REPORT_PATH}"

--- a/tests/test_worktree_hygiene_script.py
+++ b/tests/test_worktree_hygiene_script.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "pm" / "worktree_hygiene.sh"
+
+
+def _touch_with_age(path: Path, *, now_epoch: int, age_hours: int) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    epoch = now_epoch - (age_hours * 3600)
+    os.utime(path, (epoch, epoch))
+
+
+def _worktree_list_file(base_dir: Path, active_paths: list[Path]) -> Path:
+    file_path = base_dir / "worktree_list.txt"
+    lines: list[str] = []
+    for path in active_paths:
+        lines.append(f"worktree {path}")
+        lines.append("HEAD dummy")
+        lines.append("branch refs/heads/main")
+        lines.append("")
+    file_path.write_text("\n".join(lines), encoding="utf-8")
+    return file_path
+
+
+def _run_script(base_dir: Path, report_path: Path, worktree_list: Path, mode: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["WORKTREE_HYGIENE_NOW_EPOCH"] = "2000000000"
+    env["WORKTREE_HYGIENE_WORKTREE_LIST_FILE"] = str(worktree_list)
+    return subprocess.run(
+        [
+            "bash",
+            str(SCRIPT),
+            "--mode",
+            mode,
+            "--hours",
+            "24",
+            "--base-dir",
+            str(base_dir),
+            "--report",
+            str(report_path),
+        ],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_worktree_hygiene_dry_run_detects_only_stale_non_active_paths(tmp_path: Path) -> None:
+    now_epoch = 2_000_000_000
+    base_dir = tmp_path / "scan"
+    base_dir.mkdir(parents=True, exist_ok=True)
+
+    protected_main = base_dir / "election2026_codex"
+    stale_candidate = base_dir / "election2026_codex_issue_stale"
+    active_candidate = base_dir / "election2026_codex_issue_active"
+    stale_runtime = base_dir / "election2026_runtime_old"
+
+    _touch_with_age(protected_main, now_epoch=now_epoch, age_hours=72)
+    _touch_with_age(stale_candidate, now_epoch=now_epoch, age_hours=72)
+    _touch_with_age(active_candidate, now_epoch=now_epoch, age_hours=72)
+    _touch_with_age(stale_runtime, now_epoch=now_epoch, age_hours=72)
+
+    worktree_list = _worktree_list_file(base_dir, [protected_main, active_candidate])
+    report_path = base_dir / "report_dry_run.txt"
+    proc = _run_script(base_dir, report_path, worktree_list, "dry-run")
+
+    assert proc.returncode == 0
+    report = report_path.read_text(encoding="utf-8")
+    assert "candidate_count=2" in report
+    assert str(stale_candidate) in report
+    assert str(stale_runtime) in report
+    assert f"{active_candidate}|active_worktree" in report
+    assert f"{protected_main}|protected_root" in report
+
+
+def test_worktree_hygiene_apply_removes_only_guarded_candidates(tmp_path: Path) -> None:
+    now_epoch = 2_000_000_000
+    base_dir = tmp_path / "scan"
+    base_dir.mkdir(parents=True, exist_ok=True)
+
+    stale_candidate = base_dir / "election2026_codex_issue_remove_me"
+    active_candidate = base_dir / "election2026_codex_issue_keep_me"
+    stale_runtime = base_dir / "election2026_runtime_remove_me"
+
+    _touch_with_age(stale_candidate, now_epoch=now_epoch, age_hours=96)
+    _touch_with_age(active_candidate, now_epoch=now_epoch, age_hours=96)
+    _touch_with_age(stale_runtime, now_epoch=now_epoch, age_hours=96)
+
+    worktree_list = _worktree_list_file(base_dir, [active_candidate])
+    report_path = base_dir / "report_apply.txt"
+    proc = _run_script(base_dir, report_path, worktree_list, "apply")
+
+    assert proc.returncode == 0
+    assert not stale_candidate.exists()
+    assert not stale_runtime.exists()
+    assert active_candidate.exists()
+
+    report = report_path.read_text(encoding="utf-8")
+    assert "candidate_count=2" in report
+    assert "deleted_count=2" in report
+    assert "error_count=0" in report
+    assert str(active_candidate) not in report.split("[deleted]", 1)[1]


### PR DESCRIPTION
## Summary
- `scripts/pm/worktree_hygiene.sh` 추가: 24h stale 후보 탐지, safe exclude(메인/활성 worktree), `dry-run/apply` 지원
- 삭제 가드 강화: 관리 패턴 + base_dir 하위 경로만 apply 허용
- `.github/workflows/worktree-hygiene.yml` 추가: 수동 실행 + 주 1회 dry-run artifact 리포트
- 테스트 추가: `tests/test_worktree_hygiene_script.py` (dry-run/apply 안전성)
- 운영 보고서 추가: worktree hygiene 자동화 결과 문서화

## Linked Issue
- Closes #471

## Report-Path
Report-Path: develop_report/2026-02-27_worktree_hygiene_automation_report.md

## Checklist
- [x] docs 계약(필드/API/용어)과 일치
- [x] 테스트 또는 검증 로그 첨부
- [x] 보안 정보(key/secret) 미포함 확인
- [x] Report-Path 파일이 이번 PR에 포함됨
