### PR TITLE
[DEVELOP] #488 운영 후보 노이즈 토큰 즉시 차단 핫픽스

### DIFF
--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -306,6 +306,7 @@ class MatchupOut(BaseModel):
     date_inference_confidence: float | None = None
     nesdc_enriched: bool = False
     needs_manual_review: bool = False
+    candidate_noise_block_count: int = 0
     source_priority: Literal["official", "article", "mixed"] = Field(default="article", deprecated=True)
     official_release_at: datetime | None = Field(default=None, deprecated=True)
     article_published_at: datetime | None = Field(default=None, deprecated=True)

--- a/app/services/candidate_token_policy.py
+++ b/app/services/candidate_token_policy.py
@@ -50,6 +50,38 @@ _NOISE_EXACT_TOKENS = {
     "전라",
     "경상",
     "충청",
+    "최고치",
+    "접촉률",
+    "접촉률은",
+    "엔비디아",
+    "가격",
+    "조정",
+    "조정했는데도",
+    "보다",
+    "주전보다",
+    "지지율이",
+    "하위",
+    "주째",
+    "상승한",
+    "평가는",
+    "라인업에도",
+    "반영하면",
+    "각각",
+    "차의",
+    "구청장이",
+    "성동구청장이",
+    "시장이",
+    "의원이",
+    "시장",
+    "구청장",
+    "군수",
+    "도지사",
+    "의원",
+    "국회의원",
+    "시의원",
+    "도의원",
+    "위원",
+    "위원장",
 }
 
 _NOISE_SUBSTRING_TOKENS = {
@@ -83,6 +115,30 @@ _NOISE_SUBSTRING_TOKENS = {
     "전라",
     "경상",
     "충청",
+    "접촉률",
+    "엔비디아",
+    "주전보다",
+    "조정했는데도",
+    "최고치",
+    "지지율이",
+    "하위",
+    "주째",
+    "상승한",
+    "평가는",
+    "라인업",
+    "반영하면",
+    "각각",
+    "차의",
+    "구청장",
+    "성동구청장",
+    "시장",
+    "의원",
+    "시장",
+    "구청장",
+    "군수",
+    "도지사",
+    "의원",
+    "위원장",
 }
 
 _POSTPOSITION_SUFFIXES = (
@@ -135,6 +191,10 @@ def is_noise_candidate_token(
     substring_tokens = _NOISE_SUBSTRING_TOKENS | {normalize_candidate_token(x) for x in extra_substring_tokens}
     for v in variants:
         if any(part and part in v for part in substring_tokens):
+            return True
+        if len(v) >= 3 and v.endswith("보다"):
+            return True
+        if v.endswith("는데도"):
             return True
 
     if any(ch.isdigit() for ch in token):

--- a/app/services/repository.py
+++ b/app/services/repository.py
@@ -553,6 +553,33 @@ class PostgresRepository:
         self.conn.commit()
         self._invalidate_api_read_cache()
 
+    def ensure_review_queue_pending(self, entity_type: str, entity_id: str, issue_type: str, review_note: str) -> bool:
+        with self.conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT 1
+                FROM review_queue
+                WHERE entity_type = %s
+                  AND entity_id = %s
+                  AND issue_type = %s
+                  AND status IN ('pending', 'in_progress')
+                LIMIT 1
+                """,
+                (entity_type, entity_id, issue_type),
+            )
+            if cur.fetchone():
+                return False
+            cur.execute(
+                """
+                INSERT INTO review_queue (entity_type, entity_id, issue_type, status, review_note)
+                VALUES (%s, %s, %s, 'pending', %s)
+                """,
+                (entity_type, entity_id, issue_type, review_note),
+            )
+        self.conn.commit()
+        self._invalidate_api_read_cache()
+        return True
+
     def count_review_queue(self) -> int:
         with self.conn.cursor() as cur:
             cur.execute("SELECT COUNT(*)::int AS count FROM review_queue")
@@ -1876,7 +1903,7 @@ class PostgresRepository:
             return rows
 
     @staticmethod
-    def _normalize_options(options_payload) -> list[dict]:
+    def _normalize_options(options_payload, *, include_stats: bool = False) -> list[dict] | tuple[list[dict], dict]:
         options = options_payload
         if isinstance(options, str):
             try:
@@ -1888,6 +1915,7 @@ class PostgresRepository:
         if not isinstance(options, list):
             options = []
         normalized: list[dict] = []
+        candidate_noise_block_count = 0
         for option in options:
             if not isinstance(option, dict):
                 continue
@@ -1921,6 +1949,7 @@ class PostgresRepository:
             row["option_name"] = option_name
 
             if _is_noise_candidate_option(option_name, candidate_id):
+                candidate_noise_block_count += 1
                 continue
 
             if _is_low_quality_manual_candidate_option(row):
@@ -1932,6 +1961,10 @@ class PostgresRepository:
             row["party_name"] = party_name or "미확정(검수대기)"
 
             normalized.append(row)
+        if include_stats:
+            return normalized, {
+                "candidate_noise_block_count": candidate_noise_block_count,
+            }
         return normalized
 
     @staticmethod
@@ -2040,15 +2073,21 @@ class PostgresRepository:
         explicit_scenario_count = len([key for key in scenario_keys if key != "default"])
         return scenario_count, explicit_scenario_count
 
-    def _select_matchup_observation_bundle(self, observations: list[dict]) -> tuple[dict, list[dict], list[dict]]:
-        normalized_rows: list[tuple[dict, list[dict]]] = []
+    def _select_matchup_observation_bundle(self, observations: list[dict]) -> tuple[dict, list[dict], list[dict], int]:
+        normalized_rows: list[tuple[dict, list[dict], int]] = []
         selected_observation: dict | None = None
         selected_options: list[dict] = []
         selected_score: tuple[int, int, int, int] | None = None
+        fallback_noise_observation: dict | None = None
+        fallback_noise_block_count = 0
 
         for observation in observations:
-            normalized_options = self._normalize_options(observation.get("options"))
-            normalized_rows.append((observation, normalized_options))
+            normalized_options, stats = self._normalize_options(observation.get("options"), include_stats=True)
+            noise_block_count = int(stats.get("candidate_noise_block_count", 0) or 0)
+            normalized_rows.append((observation, normalized_options, noise_block_count))
+            if noise_block_count > fallback_noise_block_count:
+                fallback_noise_observation = observation
+                fallback_noise_block_count = noise_block_count
             if not normalized_options:
                 continue
             scenario_count, explicit_scenario_count = self._scenario_key_stats(normalized_options)
@@ -2064,15 +2103,19 @@ class PostgresRepository:
                 selected_options = normalized_options
 
         if selected_observation is None:
-            return observations[0], [], []
+            if fallback_noise_observation is not None:
+                return fallback_noise_observation, [], [], fallback_noise_block_count
+            return observations[0], [], [], 0
 
         bundle_key = self._observation_bundle_key(selected_observation)
         merged_options: list[dict] = []
         seen_option_keys: set[tuple] = set()
-        for observation, normalized_options in normalized_rows:
-            if not normalized_options:
-                continue
+        candidate_noise_block_count = 0
+        for observation, normalized_options, noise_block_count in normalized_rows:
             if self._observation_bundle_key(observation) != bundle_key:
+                continue
+            candidate_noise_block_count += noise_block_count
+            if not normalized_options:
                 continue
             for option in normalized_options:
                 option_key = self._matchup_option_identity(option)
@@ -2085,7 +2128,7 @@ class PostgresRepository:
             merged_options = [dict(row) for row in selected_options]
 
         scenarios, primary_options = self._build_matchup_scenarios(merged_options)
-        return selected_observation, scenarios, primary_options
+        return selected_observation, scenarios, primary_options, candidate_noise_block_count
 
     @staticmethod
     def _strip_region_suffix(name: str) -> str:
@@ -2213,6 +2256,7 @@ class PostgresRepository:
                 "article_published_at": None,
                 "nesdc_enriched": False,
                 "needs_manual_review": False,
+                "candidate_noise_block_count": 0,
                 "poll_fingerprint": None,
                 "source_channel": None,
                 "source_channels": [],
@@ -2225,7 +2269,26 @@ class PostgresRepository:
                 _api_read_cache_set(cache_key, result)
             return result
 
-        observation, scenarios, primary_options = self._select_matchup_observation_bundle(observations)
+        observation, scenarios, primary_options, candidate_noise_block_count = self._select_matchup_observation_bundle(
+            observations
+        )
+        needs_manual_review = bool(observation["needs_manual_review"])
+        if candidate_noise_block_count > 0 and not primary_options:
+            observation_key = str(observation.get("observation_key") or "").strip()
+            if observation_key:
+                try:
+                    self.ensure_review_queue_pending(
+                        entity_type="poll_observation",
+                        entity_id=observation_key,
+                        issue_type="mapping_error",
+                        review_note=(
+                            "runtime candidate noise guard removed all candidate options "
+                            f"(blocked={candidate_noise_block_count})"
+                        ),
+                    )
+                except Exception:
+                    pass
+            needs_manual_review = True
         observation_title = str(observation.get("title") or "").strip()
         if not canonical_title:
             canonical_title = observation_title or canonical_matchup_id
@@ -2261,7 +2324,8 @@ class PostgresRepository:
             "official_release_at": observation["official_release_at"],
             "article_published_at": observation["article_published_at"],
             "nesdc_enriched": observation["nesdc_enriched"],
-            "needs_manual_review": observation["needs_manual_review"],
+            "needs_manual_review": needs_manual_review,
+            "candidate_noise_block_count": candidate_noise_block_count,
             "poll_fingerprint": observation["poll_fingerprint"],
             "source_channel": observation["source_channel"],
             "source_channels": observation["source_channels"],

--- a/develop_report/2026-02-27_runtime_candidate_noise_denylist_hotfix_report.md
+++ b/develop_report/2026-02-27_runtime_candidate_noise_denylist_hotfix_report.md
@@ -1,0 +1,60 @@
+# 2026-02-27 Runtime Candidate Noise Denylist Hotfix Report
+
+## 1) 작업 개요
+- 대상 이슈: `#488` `[DEVELOP][P0][HOTFIX] 운영 API 후보 비인명 토큰 즉시 차단 가드`
+- 배경: 운영 `matchups` 응답에서 비인명 토큰(예: `최고치`, `접촉률은`, `엔비디아`, `가격`)이 후보 옵션으로 노출.
+- 목표: collector 재처리 전까지 API runtime에서 즉시 차단 + 후보 0건 시 fail-safe 동작.
+
+## 2) 구현 변경 사항
+1. 후보 토큰 차단 규칙 강화 (`/app/services/candidate_token_policy.py`)
+- 운영 실측 노이즈 토큰/패턴 denylist 확장.
+- 후처리 룰 추가:
+  - `...보다` / `...는데도` 형태 문장조각 차단.
+- `matchup`/`map-latest` 모두 동일 정책 함수 기반으로 차단 적용.
+
+2. matchup fail-safe 추가 (`/app/services/repository.py`)
+- `get_matchup()`에서 noise 필터 이후 후보가 0건일 때:
+  - `has_data=false`, `scenarios=[]`, `options=[]` 반환 유지
+  - `needs_manual_review=true`로 승격
+  - `review_queue`에 `mapping_error`를 pending으로 1회 등록(중복 pending/in_progress 방지)
+- `ensure_review_queue_pending()` 추가(중복 삽입 방지 헬퍼).
+
+3. 관측 메트릭 노출 (`/app/models/schemas.py`, `/app/services/repository.py`)
+- 응답 필드 `candidate_noise_block_count` 추가.
+- 해당 matchup 처리 중 runtime에서 차단된 후보 토큰 수를 노출.
+
+## 3) 테스트/검증
+1. 단위/통합 테스트
+- 실행:
+  - `pytest -q tests/test_candidate_token_policy_runtime_hotfix.py tests/test_repository_matchup_scenarios.py tests/test_map_latest_cleanup_policy.py tests/test_api_routes.py -k "matchup or map_latest or candidate_token_policy_runtime_hotfix"`
+- 결과: `18 passed`
+
+2. 실DB 코드 검증 (로컬 코드 + 운영 DB)
+- `PostgresRepository.get_matchup('20260603|광역자치단체장|11-000')`
+- 결과:
+  - `has_data=false`
+  - `needs_manual_review=true`
+  - `candidate_noise_block_count=7`
+  - `option_names=[]`
+
+3. map-latest 검증 (로컬 API 실행)
+- `/api/v1/dashboard/map-latest?limit=200`에서 `region_code=11-000`
+- 결과: 정상 인명 후보(`정원오`) 유지 확인.
+
+## 4) 수용 기준 매핑
+- [x] 운영 API에서 비인명 토큰 노출 0 (코드 기준 핫픽스 적용)
+- [x] 정상 인명 후보 유지
+- [x] 임시가드 적용 사실 보고서 제출
+
+## 5) 의사결정 필요 사항
+- 없음.
+
+## 6) 변경 파일
+- `/app/services/candidate_token_policy.py`
+- `/app/services/repository.py`
+- `/app/models/schemas.py`
+- `/tests/test_candidate_token_policy_runtime_hotfix.py`
+- `/tests/test_repository_matchup_scenarios.py`
+- `/tests/test_map_latest_cleanup_policy.py`
+- `/tests/test_api_routes.py`
+- `/develop_report/2026-02-27_runtime_candidate_noise_denylist_hotfix_report.md`

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -795,6 +795,7 @@ def test_api_contract_fields():
     assert matchup.json()["options"][0]["needs_manual_review"] is False
     assert matchup.json()["options"][1]["needs_manual_review"] is True
     assert matchup.json()["options"][1]["candidate_id"] == "cand-oh"
+    assert matchup.json()["candidate_noise_block_count"] == 0
     matchup_alias = client.get("/api/v1/matchups/m_2026_seoul_mayor")
     assert matchup_alias.status_code == 200
     assert matchup_alias.json()["matchup_id"] == "20260603|광역자치단체장|11-000"
@@ -804,6 +805,7 @@ def test_api_contract_fields():
     assert matchup_meta_only.json()["has_data"] is False
     assert matchup_meta_only.json()["scenarios"] == []
     assert matchup_meta_only.json()["options"] == []
+    assert matchup_meta_only.json()["candidate_noise_block_count"] == 0
 
     candidate = client.get("/api/v1/candidates/cand-jwo")
     assert candidate.status_code == 200

--- a/tests/test_candidate_token_policy_runtime_hotfix.py
+++ b/tests/test_candidate_token_policy_runtime_hotfix.py
@@ -1,0 +1,31 @@
+from app.services.candidate_token_policy import is_noise_candidate_token
+
+
+def test_runtime_noise_tokens_are_blocked_for_matchup_hotfix() -> None:
+    blocked = [
+        "최고치",
+        "접촉률은",
+        "엔비디아",
+        "가격",
+        "조정했는데도",
+        "보다",
+        "주전보다",
+        "지지율이",
+        "하위",
+        "주째",
+        "상승한",
+        "평가는",
+        "라인업에도",
+        "반영하면",
+        "구청장이",
+        "시장이",
+        "의원이",
+    ]
+    for token in blocked:
+        assert is_noise_candidate_token(token) is True
+
+
+def test_human_candidate_names_remain_allowed() -> None:
+    allowed = ["정원오", "오세훈", "김민주", "박형준", "전재수"]
+    for token in allowed:
+        assert is_noise_candidate_token(token) is False

--- a/tests/test_map_latest_cleanup_policy.py
+++ b/tests/test_map_latest_cleanup_policy.py
@@ -46,6 +46,10 @@ def test_map_latest_exclusion_reason_classifies_noise_and_legacy() -> None:
     context_noise["option_name"] = "대비"
     assert _map_latest_exclusion_reason(context_noise) == "invalid_candidate_option_name"
 
+    runtime_noise = dict(row)
+    runtime_noise["option_name"] = "엔비디아"
+    assert _map_latest_exclusion_reason(runtime_noise) == "invalid_candidate_option_name"
+
     legacy = dict(row)
     legacy["title"] = "[2022 지방선거] 서울시장 가상대결"
     assert _map_latest_exclusion_reason(legacy) == "legacy_matchup_title"


### PR DESCRIPTION
## Summary
- 운영 노이즈 토큰 재현(`11-000`) 기준으로 runtime 후보 토큰 denylist/패턴을 즉시 강화
- `matchup`에서 noise 필터 후 후보 0건이면 fail-safe로 `needs_manual_review=true` + `review_queue` pending 1회 등록(중복 방지)
- `candidate_noise_block_count` 응답 필드 추가로 차단 카운터 노출
- `map-latest`도 동일 정책 함수 기반으로 노이즈 차단 강화
- 회귀 테스트(정책/리포지토리/API/map-latest) 추가

## Linked Issue
- Closes #488

## Report-Path
Report-Path: develop_report/2026-02-27_runtime_candidate_noise_denylist_hotfix_report.md

## Checklist
- [x] docs 계약(필드/API/용어)과 일치
- [x] 테스트 또는 검증 로그 첨부
- [x] 보안 정보(key/secret) 미포함 확인
- [x] Report-Path 파일이 이번 PR에 포함됨
