### PR TITLE
[DEVELOP][P0] Add runtime guard for scope-title intent leak (#480)

### DIFF
--- a/develop_report/2026-02-27_scope_title_intent_leak_runtime_guard_report.md
+++ b/develop_report/2026-02-27_scope_title_intent_leak_runtime_guard_report.md
@@ -1,0 +1,34 @@
+# 2026-02-27 Scope Title Intent Leak Runtime Guard Report
+
+## 1) Scope
+- Issue: #480
+- Goal: Prevent local matchup/map responses from exposing mismatched metro-level article context.
+
+## 2) Implemented Guards
+- Matchup response guard (`GET /api/v1/matchups/{matchup_id}`)
+  - If `office_type/region_code` conflicts with `article_title` intent, `article_title` is masked to `null`.
+- Map latest guard (`GET /api/v1/dashboard/map-latest`)
+  - Added exclusion reason: `scope_title_intent_leak`.
+  - Rows with title intent mismatch are excluded from response items.
+  - `title` remains canonical-first via existing canonical normalization policy.
+
+## 3) Detection Rule
+- Intent keywords mapped to broad region prefixes (e.g. `서울시장`, `부산시장`, `인천시장`, `...도지사`).
+- Local office (`기초*`) with metro/provincial-intent keyword is treated as leak.
+- Non-local rows are treated as leak when title intent region prefix != row region prefix.
+
+## 4) Files Changed
+- `app/api/routes.py`
+- `tests/test_api_routes.py`
+- `docs/02_DATA_MODEL_AND_NORMALIZATION.md`
+
+## 5) Verification
+- Command:
+  - `/Users/gimtaehun/election2026_codex/.venv/bin/python -m pytest -q tests/test_api_routes.py -k "map_latest_excludes_scope_title_intent_leak_rows or matchup_masks_scope_title_intent_leak_for_local_matchup or map_latest_sanity_filter_drops_invalid_candidate_and_legacy_title_rows"`
+- Result:
+  - `3 passed`
+
+## 6) Acceptance Mapping
+- [x] `/api/v1/matchups/2026_local|기초자치단체장|26-710` leak title masked (`article_title=null`)
+- [x] `/api/v1/dashboard/map-latest` `region_code=28-450` leak row excluded (`scope_title_intent_leak`)
+- [x] scope/title intent leak blocked at API runtime layer

--- a/docs/02_DATA_MODEL_AND_NORMALIZATION.md
+++ b/docs/02_DATA_MODEL_AND_NORMALIZATION.md
@@ -120,6 +120,8 @@
 19. trends 포인트는 동일 `survey_end_date + option_name` 그룹에서 대표값 선택 trace(`source_trace.selected_source_tier`)를 포함한다.
 20. `GET /api/v1/dashboard/summary`는 응답 루트에 `selection_policy_version`을 노출한다.
 21. `GET /api/v1/dashboard/summary` 각 카드는 `selected_reason`(`official_preferred|latest_fallback`)를 포함한다.
+22. `GET /api/v1/matchups/{matchup_id}`는 `office_type/region_code`와 충돌하는 `article_title` 문맥을 비노출(`null`) 처리한다.
+23. `GET /api/v1/dashboard/map-latest`는 `scope_title_intent_leak` 행을 제외해 로컬/광역 제목 문맥 오염을 차단한다.
 
 ## 6.1 운영 품질 요약 규칙 (`GET /api/v1/dashboard/quality`)
 1. `freshness_p50_hours`, `freshness_p90_hours`는 검증 완료(`verified=true`) 관측치의 freshness 분포 백분위를 시간 단위로 노출한다.


### PR DESCRIPTION
## What
- add scope-title intent leak detector for matchup/map-latest
- mask leaked `article_title` in matchup responses
- exclude `scope_title_intent_leak` rows in map-latest
- add regression tests for 26-710 and 28-450 leak scenarios
- add develop report

## Validation
- `/Users/gimtaehun/election2026_codex/.venv/bin/python -m pytest -q tests/test_api_routes.py -k "map_latest_excludes_scope_title_intent_leak_rows or matchup_masks_scope_title_intent_leak_for_local_matchup or map_latest_sanity_filter_drops_invalid_candidate_and_legacy_title_rows"`
- pass: `3 passed`

## Report
- develop_report/2026-02-27_scope_title_intent_leak_runtime_guard_report.md

Closes #480
