### PR TITLE
[DEVELOP][P2] Separate Vercel rate-limit from blocking quality gates (#491)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,3 +12,8 @@ Report-Path: <UIUX_reports|Collector_reports|develop_report>/YYYY-MM-DD_<topic>_
 - [ ] 테스트 또는 검증 로그 첨부
 - [ ] 보안 정보(key/secret) 미포함 확인
 - [ ] Report-Path 파일이 이번 PR에 포함됨
+
+## Deploy Verification (Vercel Rate-Limit Policy)
+- [ ] Vercel Preview 배포 성공 URL 증빙 (issue 코멘트/액션 로그)
+- [ ] 또는 `Deployment rate limited` 발생 시, 수동 `staging-smoke` 실행 증빙으로 대체
+  - [ ] staging smoke 실행 로그/아티팩트 링크 첨부

--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -80,6 +80,7 @@ jobs:
           DEPLOY_LOG=/tmp/vercel-preview-deploy.log
           # Deploy from repository root to avoid rootDirectory double-appending
           # when the Vercel project itself already has rootDirectory configured.
+          set +e
           npx vercel@latest deploy \
             --yes \
             --token "$VERCEL_TOKEN" \
@@ -90,6 +91,19 @@ jobs:
             --env API_BASE_URL="$WEB_API_BASE_URL" \
             --env NEXT_PUBLIC_API_BASE_URL="$WEB_API_BASE_URL" \
             2>&1 | tee "$DEPLOY_LOG"
+          deploy_exit=${PIPESTATUS[0]}
+          set -e
+
+          if [ "$deploy_exit" -ne 0 ]; then
+            if grep -Eiq "rate[ -]?limit|deployment rate limited|too many requests" "$DEPLOY_LOG"; then
+              echo "::warning::Vercel deployment was rate-limited. Treating as non-blocking signal."
+              echo "rate_limited=true" >> "$GITHUB_OUTPUT"
+              echo "preview_url=" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "::error::Vercel deploy failed (exit=${deploy_exit})"
+            exit "$deploy_exit"
+          fi
 
           PREVIEW_URL=$(grep -Eo 'https://[^ ]+' "$DEPLOY_LOG" | grep 'vercel.app' | tail -n 1)
           if [ -z "$PREVIEW_URL" ]; then
@@ -97,11 +111,19 @@ jobs:
             exit 1
           fi
 
+          echo "rate_limited=false" >> "$GITHUB_OUTPUT"
           echo "preview_url=$PREVIEW_URL" >> "$GITHUB_OUTPUT"
 
       - name: Verify preview URL accessibility
         id: verify
         run: |
+          if [ "${{ steps.deploy.outputs.rate_limited }}" = "true" ]; then
+            echo "verified=false" >> "$GITHUB_OUTPUT"
+            echo "access_mode=rate_limited" >> "$GITHUB_OUTPUT"
+            echo "status_code=none" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           PREVIEW_URL="${{ steps.deploy.outputs.preview_url }}"
           status_code=""
           for _ in $(seq 1 10); do
@@ -123,7 +145,7 @@ jobs:
           exit 1
 
       - name: Comment preview URL to issue
-        if: ${{ success() && env.ISSUE_NUMBER != '' }}
+        if: ${{ success() && env.ISSUE_NUMBER != '' && steps.deploy.outputs.rate_limited != 'true' }}
         uses: actions/github-script@v7
         with:
           script: |
@@ -147,6 +169,30 @@ jobs:
                 `- status_code: ${statusCode}`,
                 "",
                 "Access verification: curl status check"
+              ].join("\n")
+            });
+
+      - name: Comment rate-limit non-blocking note to issue
+        if: ${{ success() && env.ISSUE_NUMBER != '' && steps.deploy.outputs.rate_limited == 'true' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issueNumber = Number(process.env.ISSUE_NUMBER);
+            const rootDir = process.env.ROOT_DIR;
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              body: [
+                "[DEVELOP] Vercel preview deployment was rate-limited (non-blocking policy applied).",
+                "",
+                `- root_dir: ${rootDir}`,
+                `- action_run: ${runUrl}`,
+                "- deploy_status: rate_limited_non_blocking",
+                "- required_followup: attach manual staging smoke evidence for feature validation",
+                "",
+                "Operational policy: Vercel rate-limit is treated as deploy-signal only, not a functional gate."
               ].join("\n")
             });
 

--- a/develop_report/2026-02-27_vercel_rate_limit_operational_policy_report.md
+++ b/develop_report/2026-02-27_vercel_rate_limit_operational_policy_report.md
@@ -1,0 +1,36 @@
+# 2026-02-27 Vercel Rate-Limit Operational Policy Report
+
+## 1) Scope
+- Issue: #491
+- Goal: Separate Vercel rate-limit noise from functional quality signals so PR flow is not blocked by transient deploy throttling.
+
+## 2) Decision
+- `Deployment rate limited` (or equivalent rate-limit error) is treated as **non-blocking deploy signal**.
+- Functional gate remains **staging smoke evidence** (`staging-smoke`) rather than preview deploy success alone.
+
+## 3) Changes
+1. Workflow policy (`.github/workflows/vercel-preview.yml`)
+- Deploy step now distinguishes:
+  - hard failure (non-rate-limit): fail workflow
+  - rate-limit failure: warn + continue (non-blocking)
+- Verify step handles `rate_limited` mode without failing run.
+- Issue comment split:
+  - normal preview URL comment (success path)
+  - explicit `rate_limited_non_blocking` policy comment (rate-limit path)
+
+2. PR template separation (`.github/pull_request_template.md`)
+- Added `Deploy Verification` section with two evidence paths:
+  - Vercel preview URL proof
+  - or staging smoke proof when rate-limited
+
+3. Deployment docs update (`docs/04_DEPLOYMENT_AND_ENVIRONMENT.md`)
+- Added explicit non-blocking rate-limit policy and fallback evidence rule.
+
+## 4) Expected Effect
+- Reduce unnecessary PR waiting caused by Vercel throttling noise.
+- Keep feature validation quality signal anchored on staging smoke / API checks.
+
+## 5) Acceptance Mapping
+- [x] rate-limit 노이즈 비차단 정책 정의 및 워크플로 반영
+- [x] 기능 검증 기준(스모크)과 배포 신호(프리뷰) 분리
+- [x] PR/운영 문서에 증빙 규칙 반영

--- a/docs/04_DEPLOYMENT_AND_ENVIRONMENT.md
+++ b/docs/04_DEPLOYMENT_AND_ENVIRONMENT.md
@@ -186,6 +186,10 @@ scripts/qa/smoke_staging.sh --api-base "$API_BASE" --web-base "$WEB_BASE"
 - Preview URL 추출 후 `issue_number`에 코멘트 자동 작성
 - 접근 검증(`curl`) 로그와 배포 로그를 artifact로 업로드
 - Preview 접근정책은 `public` 고정이며 `401`이면 실패 처리한다.
+6. rate-limit 운영정책:
+- Vercel deploy 실패 원인이 `Deployment rate limited`/`rate limit`이면 non-blocking 신호로 처리한다.
+- 이 경우 워크플로는 실패로 종료하지 않고 issue 코멘트에 `rate_limited_non_blocking` 상태를 남긴다.
+- 기능 검증 게이트는 `staging-smoke` 증빙으로 대체한다(배포 성공 증빙과 분리 운영).
 
 ## 13. 웹 확인용 RC 고정값 (Issue #123)
 1. 공개 확인 URL(Production):


### PR DESCRIPTION
## What
- update `vercel-preview.yml` to treat `rate limit` deploy failures as non-blocking deploy signal
- keep hard failures blocking (non-rate-limit errors still fail workflow)
- add dedicated issue comment path for `rate_limited_non_blocking`
- separate deploy evidence in PR template (preview success vs staging-smoke fallback)
- document operational policy in deployment docs

## Report
- develop_report/2026-02-27_vercel_rate_limit_operational_policy_report.md

Closes #491
