### PR TITLE
[DEVELOP][P1] Add incumbent fallback for no-poll matchup payloads (#483)

### DIFF
--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -282,6 +282,15 @@ class MatchupScenarioOut(BaseModel):
     options: list[MatchupOptionOut]
 
 
+class IncumbentFallbackCandidateOut(BaseModel):
+    name: str
+    party: str | None = None
+    office: str | None = None
+    confidence: float = 0.0
+    reasons: list[str] = Field(default_factory=list)
+    candidate_id: str | None = None
+
+
 class MatchupOut(BaseModel):
     matchup_id: str
     region_code: str
@@ -290,6 +299,8 @@ class MatchupOut(BaseModel):
     canonical_title: str | None = None
     article_title: str | None = None
     has_data: bool = True
+    fallback_mode: Literal["none", "incumbent"] = "none"
+    incumbent_candidates: list[IncumbentFallbackCandidateOut] = Field(default_factory=list)
     pollster: str | None = None
     survey_start_date: date | None = None
     survey_end_date: date | None = None

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1099,6 +1099,32 @@ main {
   background: #f8fbff;
 }
 
+.fallback-panel {
+  border-style: solid;
+}
+
+.fallback-candidate-list {
+  list-style: none;
+  margin: 10px 0 0;
+  padding: 0;
+  display: grid;
+  gap: 10px;
+}
+
+.fallback-candidate-item {
+  border: 1px solid #dbe6f2;
+  border-radius: 12px;
+  padding: 10px 12px;
+  background: #fafcff;
+}
+
+.fallback-candidate-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
 .loading-callout {
   border: 1px solid #93c5fd;
   background: #eff6ff;

--- a/develop_report/2026-02-27_matchup_incumbent_fallback_ui_api_report.md
+++ b/develop_report/2026-02-27_matchup_incumbent_fallback_ui_api_report.md
@@ -1,0 +1,81 @@
+# 2026-02-27 Matchup Incumbent Fallback UI/API Report
+
+## 1) 작업 개요
+- 이슈: #483 `[DEVELOP][P1] 매치업 무데이터 시 현직자 fallback 노출(API/UI)`
+- 목적: `GET /api/v1/matchups/{matchup_id}`에서 poll scenario/option이 0건일 때만 현직자 fallback을 API/UI로 제공
+- 원칙: poll 데이터가 1건 이상이면 fallback 절대 비노출
+
+## 2) 구현 변경
+
+### 2.1 API 계약 확장
+- 파일: `app/models/schemas.py`
+- 추가:
+  - `IncumbentFallbackCandidateOut`
+    - `name`, `party`, `office`, `confidence`, `reasons`, `candidate_id`
+  - `MatchupOut.fallback_mode: none|incumbent` (default `none`)
+  - `MatchupOut.incumbent_candidates: []` (default empty)
+
+### 2.2 매치업 라우트 fallback 가드
+- 파일: `app/api/routes.py`
+- 추가:
+  - `_matchup_has_poll_payload(payload)`
+    - `options` + `scenarios[].options` 존재 여부로 poll 데이터 유무 판정
+- 정책 적용:
+  - poll payload 0건인 경우에만 `repo.fetch_incumbent_candidates(...)` 호출
+  - 후보가 존재하면 `fallback_mode='incumbent'`, `incumbent_candidates` 채움
+  - poll payload 1건 이상이면 `fallback_mode='none'`, `incumbent_candidates=[]`
+
+### 2.3 저장소 fallback 후보 추정
+- 파일: `app/services/repository.py`
+- 추가:
+  - `fetch_incumbent_candidates(region_code, office_type, limit=4)`
+  - 지역/직책 힌트 토큰 기반 점수화(`office_text_match`, `office_token_match`, `region_keyword_match`)
+  - 후보명 noise 토큰 필터 적용
+  - 매칭이 없을 때 placeholder 1건 반환:
+    - `name='현직자 정보 준비중'`
+    - `reasons=['incumbent_context_unavailable']`
+
+### 2.4 UI 전용 fallback 블록
+- 파일: `apps/web/app/matchups/[matchup_id]/page.js`
+- 변경:
+  - `isIncumbentFallback = (fallback_mode==='incumbent' && poll payload 0건)`
+  - 전용 섹션 렌더:
+    - 배지 `추정(현직 기반)`, `여론조사 아님`
+    - `incumbent_candidates` 목록 + 프로필 링크(candidate_id 있을 때만)
+  - 시나리오 영역은 fallback 상태에서 poll 카드 대신 안내 문구 노출
+
+- 파일: `apps/web/app/globals.css`
+- 추가:
+  - `.fallback-panel`, `.fallback-candidate-list`, `.fallback-candidate-item`, `.fallback-candidate-head`
+
+### 2.5 명세 문서 반영
+- 파일: `docs/02_DATA_MODEL_AND_NORMALIZATION.md`
+  - matchup fallback 규칙 2개 추가
+- 파일: `docs/03_UI_UX_SPEC.md`
+  - 매치업 상세 fallback UI 정책 추가
+  - 매치업 API 필수 필드에 `fallback_mode`, `incumbent_candidates[]` 추가
+
+## 3) 테스트/검증
+- 파일: `tests/test_api_routes.py`
+- 추가/보강:
+  - 기존 matchup 응답 기본값 검증:
+    - `fallback_mode == 'none'`
+    - `incumbent_candidates == []`
+  - 신규 회귀 테스트:
+    - poll=0 매치업 -> `fallback_mode='incumbent'`, 후보 목록 노출
+    - poll 존재 매치업 -> fallback 비노출 유지
+
+- 실행 명령:
+  - `.venv/bin/pytest -q tests/test_api_routes.py -k "matchup or fallback"`
+- 결과:
+  - `6 passed, 32 deselected, 0 failed`
+
+## 4) 수용 기준 체크
+- [x] poll=0 매치업에서만 fallback 노출
+- [x] poll 존재 매치업에서 fallback 노출 0건
+- [x] UI에 `여론조사 아님` 문구 상시 표기
+
+## 5) 의사결정 필요 사항
+1. `fallback 후보 0건`일 때 placeholder(`현직자 정보 준비중`)를 계속 노출할지, 아니면 빈 배열로 둘지 확정 필요
+2. `confidence` 표시 형식(정수 % vs 소수점 1자리 %)을 UI 공통 규칙으로 고정 필요
+3. fallback 후보 최대 노출 개수(현재 4개) 확정 필요

--- a/docs/02_DATA_MODEL_AND_NORMALIZATION.md
+++ b/docs/02_DATA_MODEL_AND_NORMALIZATION.md
@@ -122,6 +122,8 @@
 21. `GET /api/v1/dashboard/summary` 각 카드는 `selected_reason`(`official_preferred|latest_fallback`)를 포함한다.
 22. `GET /api/v1/matchups/{matchup_id}`는 `office_type/region_code`와 충돌하는 `article_title` 문맥을 비노출(`null`) 처리한다.
 23. `GET /api/v1/dashboard/map-latest`는 `scope_title_intent_leak` 행을 제외해 로컬/광역 제목 문맥 오염을 차단한다.
+24. `GET /api/v1/matchups/{matchup_id}`는 poll `scenario/option`이 0건일 때만 `fallback_mode='incumbent'`와 `incumbent_candidates[]`를 노출한다.
+25. poll `scenario/option`이 1건 이상이면 `fallback_mode='none'`, `incumbent_candidates=[]`로 고정한다.
 
 ## 6.1 운영 품질 요약 규칙 (`GET /api/v1/dashboard/quality`)
 1. `freshness_p50_hours`, `freshness_p90_hours`는 검증 완료(`verified=true`) 관측치의 freshness 분포 백분위를 시간 단위로 노출한다.

--- a/docs/03_UI_UX_SPEC.md
+++ b/docs/03_UI_UX_SPEC.md
@@ -48,6 +48,7 @@
 2. 최근 조사 카드(기관/표본/오차범위/조사기간)
 3. 출처 링크 및 검증 상태 배지
 4. 후보 클릭 시 후보자 상세 이동
+5. poll 데이터가 0건이면 전용 fallback 블록 노출(`추정(현직 기반)`, `여론조사 아님`), poll 카드/추세선 컴포넌트 재사용 금지
 
 ## 3.4 후보자 상세
 1. 후보 기본 정보(성명/정당/연령대/직업)
@@ -65,7 +66,7 @@
 | 추세선 카드(정당/직무평가/선거성격) | `GET /api/v1/trends/{metric}` | `poll_observations`, `poll_options` | `metric`, `scope`, `region_code`, `days`, `survey_end_date`, `option_name`, `value_mid`, `pollster`, `source_trace.selected_source_tier` |
 | 지역 검색 | `GET /api/v1/regions/search` (`q/query` optional, `has_data` optional) | `regions`, `elections` | `region_code`, `sido_name`, `sigungu_name`, `has_data`, `matchup_count` |
 | 지역별 선거 탭 | `GET /api/v1/regions/{region_code}/elections` | `matchups` | `region_code`, `office_type`, `is_active` |
-| 매치업 상세 | `GET /api/v1/matchups/{matchup_id}` | `matchups`, `poll_observations`, `poll_options`, `review_queue` | `matchup_id`, `canonical_title`, `article_title`, `title`(deprecated), `has_data`, `pollster`, `survey_start_date`, `survey_end_date`, `confidence_level`, `sample_size`, `response_rate`, `margin_of_error`, `date_inference_mode`, `date_inference_confidence`, `nesdc_enriched`, `needs_manual_review`, `source_trace`, `source_priority`, `official_release_at`, `article_published_at`, `freshness_hours`, `is_official_confirmed`, `source_channel`, `source_channels`, `source_grade`, `audience_scope`, `audience_region_code`, `legal_completeness_score`, `legal_filled_count`, `legal_required_count`, `poll_fingerprint`, `scenarios[]`, `scenarios[].scenario_key`, `scenarios[].scenario_type`, `scenarios[].scenario_title`, `scenarios[].options[]`, `options[]`, `options[].name_validity`, `options[].scenario_key`, `options[].scenario_type`, `options[].scenario_title`, `options[].value_mid`, `options[].value_raw`, `options[].party_inferred`, `options[].party_inference_source`, `options[].party_inference_confidence`, `options[].party_inference_evidence` |
+| 매치업 상세 | `GET /api/v1/matchups/{matchup_id}` | `matchups`, `poll_observations`, `poll_options`, `review_queue`, `candidates` | `matchup_id`, `canonical_title`, `article_title`, `title`(deprecated), `has_data`, `fallback_mode`, `incumbent_candidates[]`, `incumbent_candidates[].name`, `incumbent_candidates[].party`, `incumbent_candidates[].office`, `incumbent_candidates[].confidence`, `incumbent_candidates[].reasons`, `incumbent_candidates[].candidate_id`, `pollster`, `survey_start_date`, `survey_end_date`, `confidence_level`, `sample_size`, `response_rate`, `margin_of_error`, `date_inference_mode`, `date_inference_confidence`, `nesdc_enriched`, `needs_manual_review`, `source_trace`, `source_priority`, `official_release_at`, `article_published_at`, `freshness_hours`, `is_official_confirmed`, `source_channel`, `source_channels`, `source_grade`, `audience_scope`, `audience_region_code`, `legal_completeness_score`, `legal_filled_count`, `legal_required_count`, `poll_fingerprint`, `scenarios[]`, `scenarios[].scenario_key`, `scenarios[].scenario_type`, `scenarios[].scenario_title`, `scenarios[].options[]`, `options[]`, `options[].name_validity`, `options[].scenario_key`, `options[].scenario_type`, `options[].scenario_title`, `options[].value_mid`, `options[].value_raw`, `options[].party_inferred`, `options[].party_inference_source`, `options[].party_inference_confidence`, `options[].party_inference_evidence` |
 | 후보자 상세 | `GET /api/v1/candidates/{candidate_id}` | `candidates`, `candidate_profiles` | `candidate_id`, `name_ko`, `party_name`, `career_summary`, `election_history`, `profile_source`, `profile_completeness`, `profile_provenance`, `profile_source_type`, `profile_source_url`, `placeholder_name_applied` |
 
 ## 5. API-UI 필드명 일치 규칙
@@ -90,3 +91,5 @@
 19. 하위호환 필드(`title`, `source_priority`, `source_channel`, `source_channels`, `official_release_at`, `article_published_at`, `freshness_hours`, `is_official_confirmed`)는 deprecated 상태로 유지한다.
 20. `GET /api/v1/trends/{metric}`에서 `scope=regional|local` 요청은 `region_code` 필수다.
 21. trends 포인트는 동일 날짜/옵션 그룹 내 대표값 선택 trace(`source_trace.selected_source_tier`, `source_trace.selected_source_channel`)를 포함한다.
+22. 매치업 상세는 poll `scenario/option` 0건일 때만 `fallback_mode='incumbent'`와 `incumbent_candidates[]`를 노출한다.
+23. `fallback_mode='incumbent'` 상태에서는 UI에 `여론조사 아님` 문구를 상시 표시한다.


### PR DESCRIPTION
## What
- extend matchup API contract with `fallback_mode` and `incumbent_candidates[]`
- enable fallback only when poll payload is empty (`options/scenarios` both zero)
- add repository incumbent-candidate resolver with region/office token scoring and safe placeholder fallback
- render dedicated UI fallback block with `추정(현직 기반)` and `여론조사 아님` badges
- keep poll scenario cards disabled/replaced in fallback state to avoid component reuse
- update data/UI specs and API route tests

## Verification
- `.venv/bin/pytest -q tests/test_api_routes.py`
- `npm --prefix apps/web run -s build`

## Report
- Report-Path: develop_report/2026-02-27_matchup_incumbent_fallback_ui_api_report.md

Closes #483
