### PR TITLE
[COLLECTOR] #503 poll_block 정규화 및 재처리 증빙

### DIFF
--- a/Collector_reports/2026-03-01_collector_issue503_poll_block_normalization_report.md
+++ b/Collector_reports/2026-03-01_collector_issue503_poll_block_normalization_report.md
@@ -1,0 +1,67 @@
+# 2026-03-01 Collector Issue #503 Poll Block Normalization Report
+
+## 1) 범위
+- 이슈: `#503 [COLLECTOR][P0] 기사 내 복수 조사블록 분리 정규화`
+- 목표:
+1. 추출 단계 `poll_block_id` 생성 및 관측/옵션 바인딩
+2. 기사 내 조사블록 간 시나리오/메타 cross-join 방지
+3. 재처리 증빙(`before/after`, dead-letter 유무) 산출
+
+## 2) 구현 요약
+- `src/pipeline/collector.py`
+1. 블록별 `poll_block_id` 생성 기준을 `기관+기간+표본+질문군` 중심으로 고정
+2. 멀티블록 처리 시 제목 기반 시나리오 분해를 차단(`survey_name=None`)해 블록 간 오염 방지
+3. observation/option 모두 `poll_block_id`를 일관되게 채움
+
+- `src/pipeline/contracts.py`, `src/pipeline/ingest_adapter.py`, `app/models/schemas.py`
+1. `poll_observation.poll_block_id`, `poll_option.poll_block_id` 계약/모델/어댑터 반영
+
+- `app/services/ingest_service.py`
+1. observation `poll_block_id` 누락 시 `observation_key` fallback
+2. option `poll_block_id` 누락 시 observation 값으로 보정
+3. option-observation `poll_block_id` 불일치 시 보정 + `metadata_cross_contamination` review_queue 적재
+
+- `app/services/repository.py`, `db/schema.sql`, `app/services/fingerprint.py`
+1. DB 저장/업서트 경로에 `poll_block_id` 반영(`poll_observations`, `poll_options`)
+2. 인덱스 추가(`idx_poll_observations_poll_block`, `idx_poll_options_poll_block`)
+3. fingerprint/merge 로직에 `poll_block_id` 포함(블록 단위 dedupe 안정화)
+
+## 3) 검증
+- 실행:
+```bash
+PYTHONPATH=. /Users/gimtaehun/election2026_codex/.venv/bin/python -m pytest \
+  tests/test_contracts.py \
+  tests/test_collector_extract.py \
+  tests/test_ingest_adapter.py \
+  tests/test_ingest_service.py \
+  tests/test_collector_live_news_v1_pack_script.py \
+  tests/test_issue503_poll_block_reprocess_script.py \
+  tests/test_repository_*.py -q
+```
+- 결과: `96 passed`
+
+## 4) 수용기준 증빙
+- 부산시장 혼합 시나리오(전재수-박형준 / 전재수-김도읍 / 다자) 분리 검증:
+1. 단위테스트: `tests/test_collector_extract.py::test_extract_multi_blocks_do_not_leak_title_scenario_into_other_poll_block`
+2. 재처리 synthetic 리포트: `data/issue503_poll_block_reprocess_synthetic_report.json`
+  - `scenario_split_present=true`
+  - `multi_poll_block_split_present=true`
+
+- 메타데이터 혼합 0건:
+1. `data/issue503_poll_block_reprocess_synthetic_report.json`
+  - `metadata_cross_contamination_count=0`
+  - `metadata_cross_contamination_zero=true`
+
+- 재처리 번들(26-000, 28-450, 26-710) 실행 로그/비교:
+1. 리포트: `data/issue503_poll_block_reprocess_report.json`
+2. before/after: `data/issue503_poll_block_before_after.json`
+3. 재적재 payload: `data/issue503_poll_block_reingest_payload.json`
+4. 입력 번들(재현용): `data/issue503_poll_block_synthetic_input.json`
+5. synthetic before/after: `data/issue503_poll_block_synthetic_before_after.json`
+6. synthetic 재적재 payload: `data/issue503_poll_block_synthetic_reingest_payload.json`
+
+## 5) 의사결정 필요 사항
+- `review_queue.issue_type` taxonomy에서 `metadata_cross_contamination` 유지 여부 최종 확정 필요.
+1. 현 구현은 오염 이슈를 명시적으로 추적하기 위해 `metadata_cross_contamination` 사용
+2. 만약 고정 taxonomy를 6종(`discover/fetch/classify/extract/mapping/ingestion`)으로 제한하면,
+   `issue_type=extract_error` + `error_code=POLL_BLOCK_ID_MISMATCH_IN_OBSERVATION`으로 전환 필요

--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -492,6 +492,7 @@ class CandidateInput(BaseModel):
 
 class PollObservationInput(BaseModel):
     observation_key: str
+    poll_block_id: str | None = None
     survey_name: str
     pollster: str
     survey_start_date: date | None = None
@@ -525,6 +526,7 @@ class PollObservationInput(BaseModel):
 class PollOptionInput(BaseModel):
     option_type: str
     option_name: str
+    poll_block_id: str | None = None
     candidate_id: str | None = None
     party_name: str | None = None
     scenario_key: str | None = None

--- a/app/services/fingerprint.py
+++ b/app/services/fingerprint.py
@@ -50,6 +50,7 @@ def build_poll_fingerprint(observation: dict) -> str:
         _norm_text(observation.get("region_code") or observation.get("region_text")),
         _norm_int(observation.get("sample_size")),
         _norm_text(observation.get("method")),
+        _norm_text(observation.get("poll_block_id")),
     ]
     base = "|".join(fields)
     return sha256(base.encode("utf-8")).hexdigest()
@@ -124,7 +125,7 @@ def merge_observation_by_priority(existing: dict, incoming: dict) -> dict:
     incoming_pri = SOURCE_PRIORITY.get(incoming_source, 1)
 
     core_conflicts: list[str] = []
-    for field in ("region_code", "office_type", "survey_start_date", "survey_end_date", "sample_size"):
+    for field in ("region_code", "office_type", "survey_start_date", "survey_end_date", "sample_size", "poll_block_id"):
         old = _normalize_core_field(field, existing.get(field))
         new = _normalize_core_field(field, incoming.get(field))
         if old is not None and new is not None and old != new:
@@ -147,6 +148,7 @@ def merge_observation_by_priority(existing: dict, incoming: dict) -> dict:
         "region_code",
         "office_type",
         "matchup_id",
+        "poll_block_id",
         "audience_scope",
         "audience_region_code",
         "sampling_population_text",

--- a/data/issue503_poll_block_before_after.json
+++ b/data/issue503_poll_block_before_after.json
@@ -1,0 +1,173 @@
+{
+  "issue": 503,
+  "input_payload_path": "data/collector_live_coverage_v2_payload.json",
+  "target_region_codes": [
+    "26-710",
+    "26-000",
+    "28-450"
+  ],
+  "items": [
+    {
+      "observation_key": "demo-30d-match-busan",
+      "region_code": "26-000",
+      "article_url": "https://demo.local/poll/match/busan",
+      "article_title": "부산시장 가상대결",
+      "before": {
+        "observation_poll_block_id": null,
+        "option_count": 2,
+        "option_scenario_keys": [
+          "default"
+        ]
+      },
+      "after": {
+        "observation_count": 1,
+        "candidate_option_count": 0,
+        "poll_block_count": 1,
+        "observations": [
+          {
+            "id": "obs_a818cd1a6eab15e4",
+            "poll_block_id": "pblk_08f6dff86f808f03",
+            "pollster": "미상조사기관",
+            "survey_start_date": null,
+            "survey_end_date": "2026-02-14",
+            "sample_size": null,
+            "scenario_keys": [],
+            "candidate_values": []
+          }
+        ]
+      },
+      "dead_letters": [
+        {
+          "id": "rvq_e4681896acc6174a",
+          "entity_type": "poll_observation",
+          "entity_id": "obs_a818cd1a6eab15e4",
+          "issue_type": "extract_error",
+          "stage": "extract",
+          "error_code": "NO_NUMERIC_SIGNAL",
+          "error_message": "no candidate/value pair extracted",
+          "source_url": "https://demo.local/poll/match/busan",
+          "payload": {
+            "article_id": "art_a0a6ab338d0e11ac",
+            "block_index": 0
+          },
+          "status": "pending",
+          "created_at": "2026-03-01T06:24:12.342513+00:00"
+        }
+      ]
+    },
+    {
+      "observation_key": "live30d-v2-12-obs_b61d10f49a5d5fdd",
+      "region_code": "26-710",
+      "article_url": "https://news.google.com/rss/articles/CBMibkFVX3lxTE9tU29Yc0dzaDhTR3BHUFNsaTdhb3h6N3Z2b3M4eEFxVHBtZzYwU3BrZV9DdEdNSWoxZV8wWk1lanEwRk4yLTJucFpwNnBZQ3hZdUNfNFNWOG1SVGdRc21qZjVVY3p0UFR2NHoycjRR0gFyQVVfeXFMUDc1RnNZaFhKeVE1NXMwbUtWSDJNMmYxWWJGY09Ea1Bxb191UlRiblBVWXhwRzNRT1JIWFRuME5DeF9YTjBjRHNOOE1WMFRWVWN5Nlo3U3d2OUVlX2ZzSVJ3bTRTQ3ZjWGRGdExlQTdnV2x3?live_cov_v2=12",
+      "article_title": "[2026지방선거] 부산시장, 전재수 43.4-박형준 32.3%, 전재수 43.8%-김도읍33.2%...다자대결 전재수26.8% 선두",
+      "before": {
+        "observation_poll_block_id": null,
+        "option_count": 5,
+        "option_scenario_keys": [
+          "h2h-전재수-김도읍",
+          "h2h-전재수-박형준",
+          "multi-전재수"
+        ]
+      },
+      "after": {
+        "observation_count": 1,
+        "candidate_option_count": 5,
+        "poll_block_count": 1,
+        "observations": [
+          {
+            "id": "obs_b9a64e99d8c97603",
+            "poll_block_id": "pblk_f6e034ff0b6d9f2e",
+            "pollster": "미상조사기관",
+            "survey_start_date": null,
+            "survey_end_date": "2026-02-10",
+            "sample_size": null,
+            "scenario_keys": [
+              "h2h-전재수-김도읍",
+              "h2h-전재수-박형준",
+              "multi-전재수"
+            ],
+            "candidate_values": [
+              {
+                "option_name": "박형준",
+                "scenario_key": "h2h-전재수-박형준",
+                "value_mid": 32.3,
+                "poll_block_id": "pblk_f6e034ff0b6d9f2e"
+              },
+              {
+                "option_name": "전재수",
+                "scenario_key": "h2h-전재수-김도읍",
+                "value_mid": 43.8,
+                "poll_block_id": "pblk_f6e034ff0b6d9f2e"
+              },
+              {
+                "option_name": "김도읍",
+                "scenario_key": "h2h-전재수-김도읍",
+                "value_mid": 33.2,
+                "poll_block_id": "pblk_f6e034ff0b6d9f2e"
+              },
+              {
+                "option_name": "전재수",
+                "scenario_key": "multi-전재수",
+                "value_mid": 26.8,
+                "poll_block_id": "pblk_f6e034ff0b6d9f2e"
+              },
+              {
+                "option_name": "전재수",
+                "scenario_key": "h2h-전재수-박형준",
+                "value_mid": 43.4,
+                "poll_block_id": "pblk_f6e034ff0b6d9f2e"
+              }
+            ]
+          }
+        ]
+      },
+      "dead_letters": []
+    },
+    {
+      "observation_key": "live30d-v2-18-obs_8dc5d149038ab97c",
+      "region_code": "28-450",
+      "article_url": "https://news.google.com/rss/articles/CBMicEFVX3lxTE9TYVNqLXN0aW1lemlIME05b25KX09HNFYydlg1Zk9iaUgyZ2kwcG12b0tTVHRtSEZNVTBoRm1xYS1zMlVCQzZaSnVYZjJlWjNZSkI2cUZlUVZ4TlY1M1BJUUFLd09UV2hiV0taaERtbi0?live_cov_v2=18",
+      "article_title": "[여론조사] 인천시장 양자대결 박찬대 51.2%, 유정복 37.1% 오차 밖 앞서",
+      "before": {
+        "observation_poll_block_id": null,
+        "option_count": 2,
+        "option_scenario_keys": [
+          "default"
+        ]
+      },
+      "after": {
+        "observation_count": 1,
+        "candidate_option_count": 2,
+        "poll_block_count": 1,
+        "observations": [
+          {
+            "id": "obs_1b52eaaa1ad7f4bf",
+            "poll_block_id": "pblk_9afe86107f0a0ec1",
+            "pollster": "미상조사기관",
+            "survey_start_date": null,
+            "survey_end_date": "2026-02-04",
+            "sample_size": null,
+            "scenario_keys": [
+              "default"
+            ],
+            "candidate_values": [
+              {
+                "option_name": "박찬대",
+                "scenario_key": "default",
+                "value_mid": 51.2,
+                "poll_block_id": "pblk_9afe86107f0a0ec1"
+              },
+              {
+                "option_name": "유정복",
+                "scenario_key": "default",
+                "value_mid": 37.1,
+                "poll_block_id": "pblk_9afe86107f0a0ec1"
+              }
+            ]
+          }
+        ]
+      },
+      "dead_letters": []
+    }
+  ]
+}

--- a/data/issue503_poll_block_reingest_payload.json
+++ b/data/issue503_poll_block_reingest_payload.json
@@ -1,0 +1,319 @@
+{
+  "run_type": "collector",
+  "extractor_version": "collector-v1",
+  "llm_model": null,
+  "records": [
+    {
+      "article": {
+        "url": "https://demo.local/poll/match/busan",
+        "title": "부산시장 가상대결",
+        "publisher": "데모뉴스",
+        "published_at": "2026-02-14T09:00:00+09:00",
+        "raw_text": "부산시장 가상대결",
+        "raw_hash": "hash-busan"
+      },
+      "region": {
+        "region_code": "26-000",
+        "sido_name": "부산광역시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [],
+      "observation": {
+        "observation_key": "obs_a818cd1a6eab15e4",
+        "poll_block_id": "pblk_08f6dff86f808f03",
+        "survey_name": "부산시장 가상대결",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": "2026-02-14",
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "26-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|26-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": null,
+        "legal_filled_count": null,
+        "legal_required_count": null,
+        "date_resolution": "exact",
+        "date_inference_mode": "published_at_exact",
+        "date_inference_confidence": 1.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": []
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMibkFVX3lxTE9tU29Yc0dzaDhTR3BHUFNsaTdhb3h6N3Z2b3M4eEFxVHBtZzYwU3BrZV9DdEdNSWoxZV8wWk1lanEwRk4yLTJucFpwNnBZQ3hZdUNfNFNWOG1SVGdRc21qZjVVY3p0UFR2NHoycjRR0gFyQVVfeXFMUDc1RnNZaFhKeVE1NXMwbUtWSDJNMmYxWWJGY09Ea1Bxb191UlRiblBVWXhwRzNRT1JIWFRuME5DeF9YTjBjRHNOOE1WMFRWVWN5Nlo3U3d2OUVlX2ZzSVJ3bTRTQ3ZjWGRGdExlQTdnV2x3?live_cov_v2=12",
+        "title": "[2026지방선거] 부산시장, 전재수 43.4-박형준 32.3%, 전재수 43.8%-김도읍33.2%...다자대결 전재수26.8% 선두",
+        "publisher": "폴리뉴스 Polinews",
+        "published_at": "2026-02-10T12:00:00+09:00",
+        "raw_text": "[2026지방선거] 부산시장, 전재수 43.4-박형준 32.3%, 전재수 43.8%-김도읍33.2%...다자대결 전재수26.8% 선두 - 폴리뉴스 Polinews [2026지방선거] 부산시장, 전재수 43.4-박형준 32.3%, 전재수 43.8%-김도읍33.2%...다자대결 전재수26.8% 선두 &nbsp;&nbsp; 폴리뉴스 Polinews 지방선거 부산 기장군수 여론조사",
+        "raw_hash": "raw_4cd6b2e755f5deb4"
+      },
+      "region": {
+        "region_code": "26-000",
+        "sido_name": "부산광역시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:박형준",
+          "name_ko": "박형준",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:전재수",
+          "name_ko": "전재수",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:김도읍",
+          "name_ko": "김도읍",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_b9a64e99d8c97603",
+        "poll_block_id": "pblk_f6e034ff0b6d9f2e",
+        "survey_name": "[2026지방선거] 부산시장, 전재수 43.4-박형준 32.3%, 전재수 43.8%-김도읍33.2%...다자대결 전재수26.8% 선두",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": "2026-02-10",
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "26-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|26-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": null,
+        "legal_filled_count": null,
+        "legal_required_count": null,
+        "date_resolution": "exact",
+        "date_inference_mode": "published_at_exact",
+        "date_inference_confidence": 1.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "박형준",
+          "poll_block_id": "pblk_f6e034ff0b6d9f2e",
+          "candidate_id": "cand:박형준",
+          "party_name": null,
+          "scenario_key": "h2h-전재수-박형준",
+          "scenario_type": "head_to_head",
+          "scenario_title": "전재수 vs 박형준",
+          "value_raw": "32.3%",
+          "value_min": 32.3,
+          "value_max": 32.3,
+          "value_mid": 32.3,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "전재수",
+          "poll_block_id": "pblk_f6e034ff0b6d9f2e",
+          "candidate_id": "cand:전재수",
+          "party_name": null,
+          "scenario_key": "h2h-전재수-김도읍",
+          "scenario_type": "head_to_head",
+          "scenario_title": "전재수 vs 김도읍",
+          "value_raw": "43.8%",
+          "value_min": 43.8,
+          "value_max": 43.8,
+          "value_mid": 43.8,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "김도읍",
+          "poll_block_id": "pblk_f6e034ff0b6d9f2e",
+          "candidate_id": "cand:김도읍",
+          "party_name": null,
+          "scenario_key": "h2h-전재수-김도읍",
+          "scenario_type": "head_to_head",
+          "scenario_title": "전재수 vs 김도읍",
+          "value_raw": "33.2%",
+          "value_min": 33.2,
+          "value_max": 33.2,
+          "value_mid": 33.2,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "전재수",
+          "poll_block_id": "pblk_f6e034ff0b6d9f2e",
+          "candidate_id": "cand:전재수",
+          "party_name": null,
+          "scenario_key": "multi-전재수",
+          "scenario_type": "multi_candidate",
+          "scenario_title": "다자대결",
+          "value_raw": "26.8%",
+          "value_min": 26.8,
+          "value_max": 26.8,
+          "value_mid": 26.8,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "전재수",
+          "poll_block_id": "pblk_f6e034ff0b6d9f2e",
+          "candidate_id": "cand:전재수",
+          "party_name": null,
+          "scenario_key": "h2h-전재수-박형준",
+          "scenario_type": "head_to_head",
+          "scenario_title": "전재수 vs 박형준",
+          "value_raw": "43.4%",
+          "value_min": 43.4,
+          "value_max": 43.4,
+          "value_mid": 43.4,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://news.google.com/rss/articles/CBMicEFVX3lxTE9TYVNqLXN0aW1lemlIME05b25KX09HNFYydlg1Zk9iaUgyZ2kwcG12b0tTVHRtSEZNVTBoRm1xYS1zMlVCQzZaSnVYZjJlWjNZSkI2cUZlUVZ4TlY1M1BJUUFLd09UV2hiV0taaERtbi0?live_cov_v2=18",
+        "title": "[여론조사] 인천시장 양자대결 박찬대 51.2%, 유정복 37.1% 오차 밖 앞서",
+        "publisher": "인천투데이",
+        "published_at": "2026-02-04T12:00:00+09:00",
+        "raw_text": "[여론조사] 인천시장 양자대결 박찬대 51.2%, 유정복 37.1% 오차 밖 앞서 - 인천투데이 [여론조사] 인천시장 양자대결 박찬대 51.2%, 유정복 37.1% 오차 밖 앞서 &nbsp;&nbsp; 인천투데이 지방선거 인천 연수구청장 여론조사",
+        "raw_hash": "raw_b0e1a45d89cbf8ad"
+      },
+      "region": {
+        "region_code": "28-000",
+        "sido_name": "인천광역시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:박찬대",
+          "name_ko": "박찬대",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:유정복",
+          "name_ko": "유정복",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_1b52eaaa1ad7f4bf",
+        "poll_block_id": "pblk_9afe86107f0a0ec1",
+        "survey_name": "[여론조사] 인천시장 양자대결 박찬대 51.2%, 유정복 37.1% 오차 밖 앞서",
+        "pollster": "미상조사기관",
+        "survey_start_date": null,
+        "survey_end_date": "2026-02-04",
+        "sample_size": null,
+        "response_rate": null,
+        "margin_of_error": null,
+        "sponsor": null,
+        "method": null,
+        "region_code": "28-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|28-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": null,
+        "legal_filled_count": null,
+        "legal_required_count": null,
+        "date_resolution": "exact",
+        "date_inference_mode": "published_at_exact",
+        "date_inference_confidence": 1.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "박찬대",
+          "poll_block_id": "pblk_9afe86107f0a0ec1",
+          "candidate_id": "cand:박찬대",
+          "party_name": null,
+          "scenario_key": "default",
+          "scenario_type": null,
+          "scenario_title": null,
+          "value_raw": "51.2%",
+          "value_min": 51.2,
+          "value_max": 51.2,
+          "value_mid": 51.2,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "유정복",
+          "poll_block_id": "pblk_9afe86107f0a0ec1",
+          "candidate_id": "cand:유정복",
+          "party_name": null,
+          "scenario_key": "default",
+          "scenario_type": null,
+          "scenario_title": null,
+          "value_raw": "37.1%",
+          "value_min": 37.1,
+          "value_max": 37.1,
+          "value_mid": 37.1,
+          "is_missing": false
+        }
+      ]
+    }
+  ]
+}

--- a/data/issue503_poll_block_reprocess_report.json
+++ b/data/issue503_poll_block_reprocess_report.json
@@ -1,0 +1,22 @@
+{
+  "issue": 503,
+  "input_payload_path": "data/collector_live_coverage_v2_payload.json",
+  "before_after_output_path": "data/issue503_poll_block_before_after.json",
+  "reingest_output_path": "data/issue503_poll_block_reingest_payload.json",
+  "reingest_record_count": 3,
+  "target_region_codes": [
+    "26-710",
+    "26-000",
+    "28-450"
+  ],
+  "matched_record_count": 3,
+  "dead_letter_count": 1,
+  "metadata_cross_contamination_count": 0,
+  "acceptance_checks": {
+    "matched_records_present": true,
+    "multi_poll_block_split_present": false,
+    "scenario_split_present": true,
+    "all_options_bound_to_poll_block": true,
+    "metadata_cross_contamination_zero": true
+  }
+}

--- a/data/issue503_poll_block_reprocess_synthetic_report.json
+++ b/data/issue503_poll_block_reprocess_synthetic_report.json
@@ -1,0 +1,22 @@
+{
+  "issue": 503,
+  "input_payload_path": "data/issue503_poll_block_synthetic_input.json",
+  "before_after_output_path": "data/issue503_poll_block_synthetic_before_after.json",
+  "reingest_output_path": "data/issue503_poll_block_synthetic_reingest_payload.json",
+  "reingest_record_count": 2,
+  "target_region_codes": [
+    "26-000",
+    "28-450",
+    "26-710"
+  ],
+  "matched_record_count": 1,
+  "dead_letter_count": 0,
+  "metadata_cross_contamination_count": 0,
+  "acceptance_checks": {
+    "matched_records_present": true,
+    "multi_poll_block_split_present": true,
+    "scenario_split_present": true,
+    "all_options_bound_to_poll_block": true,
+    "metadata_cross_contamination_zero": true
+  }
+}

--- a/data/issue503_poll_block_synthetic_before_after.json
+++ b/data/issue503_poll_block_synthetic_before_after.json
@@ -1,0 +1,122 @@
+{
+  "issue": 503,
+  "input_payload_path": "data/issue503_poll_block_synthetic_input.json",
+  "target_region_codes": [
+    "26-000",
+    "28-450",
+    "26-710"
+  ],
+  "items": [
+    {
+      "observation_key": "obs-issue503-synthetic-1",
+      "region_code": "26-000",
+      "article_url": "https://example.com/issue503-busan-multi",
+      "article_title": "[부산시장] 전재수 43.4%-박형준 32.3%, 전재수 43.8%-김도읍 33.2%, 다자대결 전재수 26.8%",
+      "before": {
+        "observation_poll_block_id": "legacy-single-block",
+        "option_count": 2,
+        "option_scenario_keys": [
+          "default"
+        ]
+      },
+      "after": {
+        "observation_count": 2,
+        "candidate_option_count": 10,
+        "poll_block_count": 2,
+        "observations": [
+          {
+            "id": "obs_612216a78d501c73",
+            "poll_block_id": "pblk_d3edf877e867aadc",
+            "pollster": "KSOI",
+            "survey_start_date": "2026-02-03",
+            "survey_end_date": "2026-02-04",
+            "sample_size": 1000,
+            "scenario_keys": [
+              "h2h-전재수-김도읍",
+              "h2h-전재수-박형준",
+              "multi-전재수"
+            ],
+            "candidate_values": [
+              {
+                "option_name": "전재수",
+                "scenario_key": "h2h-전재수-박형준",
+                "value_mid": 43.4,
+                "poll_block_id": "pblk_d3edf877e867aadc"
+              },
+              {
+                "option_name": "박형준",
+                "scenario_key": "h2h-전재수-박형준",
+                "value_mid": 32.3,
+                "poll_block_id": "pblk_d3edf877e867aadc"
+              },
+              {
+                "option_name": "전재수",
+                "scenario_key": "h2h-전재수-김도읍",
+                "value_mid": 43.8,
+                "poll_block_id": "pblk_d3edf877e867aadc"
+              },
+              {
+                "option_name": "김도읍",
+                "scenario_key": "h2h-전재수-김도읍",
+                "value_mid": 33.2,
+                "poll_block_id": "pblk_d3edf877e867aadc"
+              },
+              {
+                "option_name": "전재수",
+                "scenario_key": "multi-전재수",
+                "value_mid": 26.8,
+                "poll_block_id": "pblk_d3edf877e867aadc"
+              }
+            ]
+          },
+          {
+            "id": "obs_c3c340beaf01fb22",
+            "poll_block_id": "pblk_4de0219f635d06e2",
+            "pollster": "리얼미터",
+            "survey_start_date": "2026-02-05",
+            "survey_end_date": "2026-02-06",
+            "sample_size": 800,
+            "scenario_keys": [
+              "h2h-전재수-김도읍",
+              "h2h-전재수-박형준",
+              "multi-전재수"
+            ],
+            "candidate_values": [
+              {
+                "option_name": "전재수",
+                "scenario_key": "h2h-전재수-박형준",
+                "value_mid": 41.0,
+                "poll_block_id": "pblk_4de0219f635d06e2"
+              },
+              {
+                "option_name": "박형준",
+                "scenario_key": "h2h-전재수-박형준",
+                "value_mid": 34.0,
+                "poll_block_id": "pblk_4de0219f635d06e2"
+              },
+              {
+                "option_name": "전재수",
+                "scenario_key": "h2h-전재수-김도읍",
+                "value_mid": 40.2,
+                "poll_block_id": "pblk_4de0219f635d06e2"
+              },
+              {
+                "option_name": "김도읍",
+                "scenario_key": "h2h-전재수-김도읍",
+                "value_mid": 30.1,
+                "poll_block_id": "pblk_4de0219f635d06e2"
+              },
+              {
+                "option_name": "전재수",
+                "scenario_key": "multi-전재수",
+                "value_mid": 24.4,
+                "poll_block_id": "pblk_4de0219f635d06e2"
+              }
+            ]
+          }
+        ]
+      },
+      "dead_letters": []
+    }
+  ]
+}

--- a/data/issue503_poll_block_synthetic_input.json
+++ b/data/issue503_poll_block_synthetic_input.json
@@ -1,0 +1,30 @@
+{
+  "records": [
+    {
+      "article": {
+        "url": "https://example.com/issue503-busan-multi",
+        "title": "[부산시장] 전재수 43.4%-박형준 32.3%, 전재수 43.8%-김도읍 33.2%, 다자대결 전재수 26.8%",
+        "publisher": "테스트",
+        "published_at": "2026-02-07T00:00:00+09:00",
+        "raw_text": "KSOI는 2월 3~4일 조사, 표본 1000명, 응답률 10.1%, 표본오차 ±3.1%, 전재수 43.4%-박형준 32.3%, 전재수 43.8%-김도읍 33.2%, 다자대결 전재수 26.8%를 발표했다. 리얼미터는 2월 5~6일 조사, 표본 800명, 응답률 8.5%, 표본오차 ±3.5%, 전재수 41.0%-박형준 34.0%, 전재수 40.2%-김도읍 30.1%, 다자대결 전재수 24.4%를 발표했다."
+      },
+      "observation": {
+        "observation_key": "obs-issue503-synthetic-1",
+        "region_code": "26-000",
+        "poll_block_id": "legacy-single-block"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "전재수",
+          "value_raw": "43.4%"
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "박형준",
+          "value_raw": "32.3%"
+        }
+      ]
+    }
+  ]
+}

--- a/data/issue503_poll_block_synthetic_reingest_payload.json
+++ b/data/issue503_poll_block_synthetic_reingest_payload.json
@@ -1,0 +1,323 @@
+{
+  "run_type": "collector",
+  "extractor_version": "collector-v1",
+  "llm_model": null,
+  "records": [
+    {
+      "article": {
+        "url": "https://example.com/issue503-busan-multi",
+        "title": "[부산시장] 전재수 43.4%-박형준 32.3%, 전재수 43.8%-김도읍 33.2%, 다자대결 전재수 26.8%",
+        "publisher": "테스트",
+        "published_at": "2026-02-07T00:00:00+09:00",
+        "raw_text": "KSOI는 2월 3~4일 조사, 표본 1000명, 응답률 10.1%, 표본오차 ±3.1%, 전재수 43.4%-박형준 32.3%, 전재수 43.8%-김도읍 33.2%, 다자대결 전재수 26.8%를 발표했다. 리얼미터는 2월 5~6일 조사, 표본 800명, 응답률 8.5%, 표본오차 ±3.5%, 전재수 41.0%-박형준 34.0%, 전재수 40.2%-김도읍 30.1%, 다자대결 전재수 24.4%를 발표했다.",
+        "raw_hash": "hash_5766caaad6eb088e"
+      },
+      "region": {
+        "region_code": "26-000",
+        "sido_name": "부산광역시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:전재수",
+          "name_ko": "전재수",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:박형준",
+          "name_ko": "박형준",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:김도읍",
+          "name_ko": "김도읍",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_612216a78d501c73",
+        "poll_block_id": "pblk_d3edf877e867aadc",
+        "survey_name": "[부산시장] 전재수 43.4%-박형준 32.3%, 전재수 43.8%-김도읍 33.2%, 다자대결 전재수 26.8%",
+        "pollster": "KSOI",
+        "survey_start_date": "2026-02-03",
+        "survey_end_date": "2026-02-04",
+        "sample_size": 1000,
+        "response_rate": 10.1,
+        "margin_of_error": 3.1,
+        "sponsor": null,
+        "method": null,
+        "region_code": "26-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|26-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": null,
+        "legal_filled_count": null,
+        "legal_required_count": null,
+        "date_resolution": "exact",
+        "date_inference_mode": "published_at_exact",
+        "date_inference_confidence": 1.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "전재수",
+          "poll_block_id": "pblk_d3edf877e867aadc",
+          "candidate_id": "cand:전재수",
+          "party_name": null,
+          "scenario_key": "h2h-전재수-박형준",
+          "scenario_type": "head_to_head",
+          "scenario_title": "전재수 vs 박형준",
+          "value_raw": "43.4%",
+          "value_min": 43.4,
+          "value_max": 43.4,
+          "value_mid": 43.4,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "박형준",
+          "poll_block_id": "pblk_d3edf877e867aadc",
+          "candidate_id": "cand:박형준",
+          "party_name": null,
+          "scenario_key": "h2h-전재수-박형준",
+          "scenario_type": "head_to_head",
+          "scenario_title": "전재수 vs 박형준",
+          "value_raw": "32.3%",
+          "value_min": 32.3,
+          "value_max": 32.3,
+          "value_mid": 32.3,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "전재수",
+          "poll_block_id": "pblk_d3edf877e867aadc",
+          "candidate_id": "cand:전재수",
+          "party_name": null,
+          "scenario_key": "h2h-전재수-김도읍",
+          "scenario_type": "head_to_head",
+          "scenario_title": "전재수 vs 김도읍",
+          "value_raw": "43.8%",
+          "value_min": 43.8,
+          "value_max": 43.8,
+          "value_mid": 43.8,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "김도읍",
+          "poll_block_id": "pblk_d3edf877e867aadc",
+          "candidate_id": "cand:김도읍",
+          "party_name": null,
+          "scenario_key": "h2h-전재수-김도읍",
+          "scenario_type": "head_to_head",
+          "scenario_title": "전재수 vs 김도읍",
+          "value_raw": "33.2%",
+          "value_min": 33.2,
+          "value_max": 33.2,
+          "value_mid": 33.2,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "전재수",
+          "poll_block_id": "pblk_d3edf877e867aadc",
+          "candidate_id": "cand:전재수",
+          "party_name": null,
+          "scenario_key": "multi-전재수",
+          "scenario_type": "multi_candidate",
+          "scenario_title": "다자대결",
+          "value_raw": "26.8%",
+          "value_min": 26.8,
+          "value_max": 26.8,
+          "value_mid": 26.8,
+          "is_missing": false
+        }
+      ]
+    },
+    {
+      "article": {
+        "url": "https://example.com/issue503-busan-multi",
+        "title": "[부산시장] 전재수 43.4%-박형준 32.3%, 전재수 43.8%-김도읍 33.2%, 다자대결 전재수 26.8%",
+        "publisher": "테스트",
+        "published_at": "2026-02-07T00:00:00+09:00",
+        "raw_text": "KSOI는 2월 3~4일 조사, 표본 1000명, 응답률 10.1%, 표본오차 ±3.1%, 전재수 43.4%-박형준 32.3%, 전재수 43.8%-김도읍 33.2%, 다자대결 전재수 26.8%를 발표했다. 리얼미터는 2월 5~6일 조사, 표본 800명, 응답률 8.5%, 표본오차 ±3.5%, 전재수 41.0%-박형준 34.0%, 전재수 40.2%-김도읍 30.1%, 다자대결 전재수 24.4%를 발표했다.",
+        "raw_hash": "hash_5766caaad6eb088e"
+      },
+      "region": {
+        "region_code": "26-000",
+        "sido_name": "부산광역시",
+        "sigungu_name": "전체",
+        "admin_level": "sido",
+        "parent_region_code": null
+      },
+      "candidates": [
+        {
+          "candidate_id": "cand:전재수",
+          "name_ko": "전재수",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:박형준",
+          "name_ko": "박형준",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        },
+        {
+          "candidate_id": "cand:김도읍",
+          "name_ko": "김도읍",
+          "party_name": null,
+          "gender": null,
+          "birth_date": null,
+          "job": null,
+          "career_summary": null,
+          "election_history": null
+        }
+      ],
+      "observation": {
+        "observation_key": "obs_c3c340beaf01fb22",
+        "poll_block_id": "pblk_4de0219f635d06e2",
+        "survey_name": "[부산시장] 전재수 43.4%-박형준 32.3%, 전재수 43.8%-김도읍 33.2%, 다자대결 전재수 26.8%",
+        "pollster": "리얼미터",
+        "survey_start_date": "2026-02-05",
+        "survey_end_date": "2026-02-06",
+        "sample_size": 800,
+        "response_rate": 8.5,
+        "margin_of_error": 3.5,
+        "sponsor": null,
+        "method": null,
+        "region_code": "26-000",
+        "office_type": "광역자치단체장",
+        "matchup_id": "20260603|광역자치단체장|26-000",
+        "audience_scope": null,
+        "audience_region_code": null,
+        "sampling_population_text": null,
+        "legal_completeness_score": null,
+        "legal_filled_count": null,
+        "legal_required_count": null,
+        "date_resolution": "exact",
+        "date_inference_mode": "published_at_exact",
+        "date_inference_confidence": 1.0,
+        "poll_fingerprint": null,
+        "source_channel": "article",
+        "source_channels": [
+          "article"
+        ],
+        "verified": false,
+        "source_grade": "C"
+      },
+      "options": [
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "전재수",
+          "poll_block_id": "pblk_4de0219f635d06e2",
+          "candidate_id": "cand:전재수",
+          "party_name": null,
+          "scenario_key": "h2h-전재수-박형준",
+          "scenario_type": "head_to_head",
+          "scenario_title": "전재수 vs 박형준",
+          "value_raw": "41.0%",
+          "value_min": 41.0,
+          "value_max": 41.0,
+          "value_mid": 41.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "박형준",
+          "poll_block_id": "pblk_4de0219f635d06e2",
+          "candidate_id": "cand:박형준",
+          "party_name": null,
+          "scenario_key": "h2h-전재수-박형준",
+          "scenario_type": "head_to_head",
+          "scenario_title": "전재수 vs 박형준",
+          "value_raw": "34.0%",
+          "value_min": 34.0,
+          "value_max": 34.0,
+          "value_mid": 34.0,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "전재수",
+          "poll_block_id": "pblk_4de0219f635d06e2",
+          "candidate_id": "cand:전재수",
+          "party_name": null,
+          "scenario_key": "h2h-전재수-김도읍",
+          "scenario_type": "head_to_head",
+          "scenario_title": "전재수 vs 김도읍",
+          "value_raw": "40.2%",
+          "value_min": 40.2,
+          "value_max": 40.2,
+          "value_mid": 40.2,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "김도읍",
+          "poll_block_id": "pblk_4de0219f635d06e2",
+          "candidate_id": "cand:김도읍",
+          "party_name": null,
+          "scenario_key": "h2h-전재수-김도읍",
+          "scenario_type": "head_to_head",
+          "scenario_title": "전재수 vs 김도읍",
+          "value_raw": "30.1%",
+          "value_min": 30.1,
+          "value_max": 30.1,
+          "value_mid": 30.1,
+          "is_missing": false
+        },
+        {
+          "option_type": "candidate_matchup",
+          "option_name": "전재수",
+          "poll_block_id": "pblk_4de0219f635d06e2",
+          "candidate_id": "cand:전재수",
+          "party_name": null,
+          "scenario_key": "multi-전재수",
+          "scenario_type": "multi_candidate",
+          "scenario_title": "다자대결",
+          "value_raw": "24.4%",
+          "value_min": 24.4,
+          "value_max": 24.4,
+          "value_mid": 24.4,
+          "is_missing": false
+        }
+      ]
+    }
+  ]
+}

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -217,6 +217,7 @@ CREATE TABLE IF NOT EXISTS poll_observations (
     article_id BIGINT NOT NULL REFERENCES articles(id) ON DELETE CASCADE,
     survey_name TEXT NOT NULL,
     pollster TEXT NOT NULL,
+    poll_block_id TEXT NULL,
     survey_start_date DATE NULL,
     survey_end_date DATE NULL,
     confidence_level FLOAT NULL,
@@ -252,6 +253,7 @@ ALTER TABLE poll_observations
     ADD COLUMN IF NOT EXISTS confidence_level FLOAT NULL,
     ADD COLUMN IF NOT EXISTS sponsor TEXT NULL,
     ADD COLUMN IF NOT EXISTS method TEXT NULL,
+    ADD COLUMN IF NOT EXISTS poll_block_id TEXT NULL,
     ADD COLUMN IF NOT EXISTS audience_scope TEXT NULL,
     ADD COLUMN IF NOT EXISTS audience_region_code TEXT NULL,
     ADD COLUMN IF NOT EXISTS sampling_population_text TEXT NULL,
@@ -369,6 +371,7 @@ $$;
 CREATE TABLE IF NOT EXISTS poll_options (
     id BIGSERIAL PRIMARY KEY,
     observation_id BIGINT NOT NULL REFERENCES poll_observations(id) ON DELETE CASCADE,
+    poll_block_id TEXT NULL,
     option_type TEXT NOT NULL,
     option_name TEXT NOT NULL,
     candidate_id TEXT NULL,
@@ -397,6 +400,7 @@ CREATE TABLE IF NOT EXISTS poll_options (
 );
 
 ALTER TABLE poll_options
+    ADD COLUMN IF NOT EXISTS poll_block_id TEXT NULL,
     ADD COLUMN IF NOT EXISTS candidate_id TEXT NULL,
     ADD COLUMN IF NOT EXISTS party_name TEXT NULL,
     ADD COLUMN IF NOT EXISTS scenario_key TEXT NOT NULL DEFAULT 'default',
@@ -523,11 +527,13 @@ CREATE INDEX IF NOT EXISTS idx_poll_observations_verified_region_office_date
     ON poll_observations (region_code, office_type, survey_end_date DESC, id DESC)
     WHERE verified = TRUE;
 CREATE INDEX IF NOT EXISTS idx_poll_observations_fingerprint ON poll_observations (poll_fingerprint);
+CREATE INDEX IF NOT EXISTS idx_poll_observations_poll_block ON poll_observations (poll_block_id);
 CREATE INDEX IF NOT EXISTS idx_poll_observations_source_channels ON poll_observations USING GIN (source_channels);
 CREATE INDEX IF NOT EXISTS idx_candidates_source_channels ON candidates USING GIN (source_channels);
 CREATE INDEX IF NOT EXISTS idx_elections_region_active ON elections (region_code, is_active, office_type);
 CREATE INDEX IF NOT EXISTS idx_elections_latest_matchup ON elections (latest_matchup_id);
 CREATE INDEX IF NOT EXISTS idx_poll_options_type ON poll_options (option_type);
+CREATE INDEX IF NOT EXISTS idx_poll_options_poll_block ON poll_options (poll_block_id);
 CREATE INDEX IF NOT EXISTS idx_poll_options_observation_value
     ON poll_options (observation_id, value_mid DESC, option_name);
 CREATE INDEX IF NOT EXISTS idx_poll_options_summary_type_observation

--- a/docs/06_COLLECTOR_CONTRACTS.md
+++ b/docs/06_COLLECTOR_CONTRACTS.md
@@ -17,6 +17,12 @@
 - `src/pipeline/contracts.py`의 `POLL_OPTION_SCHEMA`
 - 통합 레지스트리: `INPUT_CONTRACT_SCHEMAS`
 
+`poll_block_id` 최소 계약:
+1. `poll_observation.poll_block_id` 필수
+2. `poll_option.poll_block_id` 필수
+3. 생성 기준: 조사기관+조사기간+표본수+질문군(후보/시나리오 문맥) 조합
+4. 같은 관측(observation) 내 option은 observation의 `poll_block_id`와 동일해야 함
+
 ## 2. 식별자 계약
 아래 식별자는 최소 필수 계약입니다.
 
@@ -24,6 +30,7 @@
 2. `office_type`: 기획 표준 enum
 3. `matchup_id`: `election_id|office_type|region_code` 조합 키
 4. `candidate_id`: 후보 식별자 (`cand:<normalized_name>`)
+5. `poll_block_id`: 기사 내 조사단위 식별자 (`pblk_...`)
 
 `office_type` 허용값:
 1. `광역자치단체장`

--- a/scripts/run_issue503_poll_block_reprocess.py
+++ b/scripts/run_issue503_poll_block_reprocess.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from src.pipeline.collector import CollectorOutput, PollCollector
+from src.pipeline.contracts import Article, stable_id, utc_now_iso
+from src.pipeline.ingest_adapter import collector_output_to_ingest_payload
+
+DEFAULT_INPUT = "data/collector_live_coverage_v2_payload.json"
+DEFAULT_REPORT_OUTPUT = "data/issue503_poll_block_reprocess_report.json"
+DEFAULT_BEFORE_AFTER_OUTPUT = "data/issue503_poll_block_before_after.json"
+DEFAULT_REINGEST_OUTPUT = "data/issue503_poll_block_reingest_payload.json"
+DEFAULT_TARGET_REGION_CODES = ("26-000", "28-450", "26-710")
+
+
+def _record_observation_key(record: dict[str, Any]) -> str:
+    return str((record.get("observation") or {}).get("observation_key") or "").strip()
+
+
+def _record_region_code(record: dict[str, Any]) -> str:
+    observation = record.get("observation") or {}
+    return str(observation.get("region_code") or "").strip()
+
+
+def _to_article(record: dict[str, Any]) -> Article:
+    article = record.get("article") or {}
+    raw_text = str(article.get("raw_text") or article.get("title") or "")
+    url = str(article.get("url") or "")
+    title = str(article.get("title") or "").strip() or "untitled"
+    raw_hash = str(article.get("raw_hash") or "").strip() or stable_id("hash", raw_text)
+    return Article(
+        id=stable_id("art", url or title, raw_hash),
+        url=url,
+        title=title,
+        publisher=str(article.get("publisher") or "unknown"),
+        published_at=article.get("published_at"),
+        snippet=raw_text[:220],
+        collected_at=str(article.get("collected_at") or utc_now_iso()),
+        raw_hash=raw_hash,
+        raw_text=raw_text,
+    )
+
+
+def _candidate_options_by_observation(options: list[Any]) -> dict[str, list[Any]]:
+    grouped: dict[str, list[Any]] = {}
+    for row in options:
+        if getattr(row, "option_type", "") != "candidate":
+            continue
+        grouped.setdefault(str(getattr(row, "observation_id", "")), []).append(row)
+    return grouped
+
+
+def run_reprocess(
+    *,
+    input_payload_path: Path,
+    report_output_path: Path,
+    before_after_output_path: Path,
+    reingest_output_path: Path | None = None,
+    target_region_codes: tuple[str, ...] = DEFAULT_TARGET_REGION_CODES,
+    election_id: str = "2026_local",
+) -> dict[str, Any]:
+    payload = json.loads(input_payload_path.read_text(encoding="utf-8"))
+    records = payload.get("records") or []
+    target_set = {str(code).strip() for code in target_region_codes if str(code).strip()}
+
+    matched_records = [row for row in records if _record_region_code(row) in target_set]
+    if not matched_records:
+        matched_records = records[: min(5, len(records))]
+
+    collector = PollCollector(election_id=election_id)
+    reingest_output = CollectorOutput()
+    before_after_items: list[dict[str, Any]] = []
+    dead_letter_count = 0
+    metadata_cross_contamination_count = 0
+    all_options_bound_to_poll_block = True
+    scenario_split_present = False
+
+    for record in matched_records:
+        before_observation = record.get("observation") or {}
+        before_options = record.get("options") or []
+
+        article = _to_article(record)
+        observations, options, errors = collector.extract(article)
+        reingest_output.articles.append(article)
+        reingest_output.poll_observations.extend(observations)
+        reingest_output.poll_options.extend(options)
+        reingest_output.review_queue.extend(errors)
+        options_by_observation = _candidate_options_by_observation(options)
+
+        observation_rows: list[dict[str, Any]] = []
+        for row in observations:
+            row_options = options_by_observation.get(row.id, [])
+            option_poll_block_ids = sorted({str(getattr(opt, "poll_block_id", "") or "") for opt in row_options})
+            if any(value != row.poll_block_id for value in option_poll_block_ids):
+                all_options_bound_to_poll_block = False
+            observation_rows.append(
+                {
+                    "id": row.id,
+                    "poll_block_id": row.poll_block_id,
+                    "pollster": row.pollster,
+                    "survey_start_date": row.survey_start_date,
+                    "survey_end_date": row.survey_end_date,
+                    "sample_size": row.sample_size,
+                    "scenario_keys": sorted({str(getattr(opt, "scenario_key", "") or "") for opt in row_options}),
+                    "candidate_values": [
+                        {
+                            "option_name": opt.option_name,
+                            "scenario_key": opt.scenario_key,
+                            "value_mid": opt.value_mid,
+                            "poll_block_id": opt.poll_block_id,
+                        }
+                        for opt in row_options
+                    ],
+                }
+            )
+
+        dead_letters = [item.to_dict() for item in errors]
+        dead_letter_count += len(dead_letters)
+        metadata_cross_contamination_count += sum(
+            1 for item in dead_letters if str(item.get("issue_type") or "") == "metadata_cross_contamination"
+        )
+        scenario_keys = {
+            key
+            for obs in observation_rows
+            for key in (obs.get("scenario_keys") or [])
+            if isinstance(key, str) and key
+        }
+        if {
+            "h2h-전재수-박형준",
+            "h2h-전재수-김도읍",
+            "multi-전재수",
+        }.issubset(scenario_keys):
+            scenario_split_present = True
+
+        before_after_items.append(
+            {
+                "observation_key": _record_observation_key(record),
+                "region_code": _record_region_code(record),
+                "article_url": article.url,
+                "article_title": article.title,
+                "before": {
+                    "observation_poll_block_id": before_observation.get("poll_block_id"),
+                    "option_count": len(before_options),
+                    "option_scenario_keys": sorted(
+                        {
+                            str((row.get("scenario_key") if isinstance(row, dict) else None) or "default")
+                            for row in before_options
+                        }
+                    ),
+                },
+                "after": {
+                    "observation_count": len(observations),
+                    "candidate_option_count": sum(len(rows) for rows in options_by_observation.values()),
+                    "poll_block_count": len({row.poll_block_id for row in observations}),
+                    "observations": observation_rows,
+                },
+                "dead_letters": dead_letters,
+            }
+        )
+
+    before_after = {
+        "issue": 503,
+        "input_payload_path": str(input_payload_path),
+        "target_region_codes": list(target_set),
+        "items": before_after_items,
+    }
+    before_after_output_path.write_text(json.dumps(before_after, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    reingest_record_count = 0
+    if reingest_output_path is not None:
+        ingest_payload = collector_output_to_ingest_payload(reingest_output)
+        reingest_record_count = len(ingest_payload.get("records") or [])
+        reingest_output_path.write_text(json.dumps(ingest_payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    report = {
+        "issue": 503,
+        "input_payload_path": str(input_payload_path),
+        "before_after_output_path": str(before_after_output_path),
+        "reingest_output_path": str(reingest_output_path) if reingest_output_path is not None else None,
+        "reingest_record_count": reingest_record_count,
+        "target_region_codes": list(target_set),
+        "matched_record_count": len(matched_records),
+        "dead_letter_count": dead_letter_count,
+        "metadata_cross_contamination_count": metadata_cross_contamination_count,
+        "acceptance_checks": {
+            "matched_records_present": len(matched_records) > 0,
+            "multi_poll_block_split_present": any(
+                item.get("after", {}).get("poll_block_count", 0) >= 2 for item in before_after_items
+            ),
+            "scenario_split_present": scenario_split_present,
+            "all_options_bound_to_poll_block": all_options_bound_to_poll_block,
+            "metadata_cross_contamination_zero": metadata_cross_contamination_count == 0,
+        },
+    }
+    report_output_path.write_text(json.dumps(report, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Issue #503 poll-block normalization reprocess helper")
+    parser.add_argument("--input", default=DEFAULT_INPUT)
+    parser.add_argument("--report-output", default=DEFAULT_REPORT_OUTPUT)
+    parser.add_argument("--before-after-output", default=DEFAULT_BEFORE_AFTER_OUTPUT)
+    parser.add_argument("--reingest-output", default=DEFAULT_REINGEST_OUTPUT)
+    parser.add_argument("--target-region-codes", default=",".join(DEFAULT_TARGET_REGION_CODES))
+    parser.add_argument("--election-id", default="2026_local")
+    args = parser.parse_args()
+
+    target_codes = tuple(part.strip() for part in str(args.target_region_codes).split(",") if part.strip())
+    report = run_reprocess(
+        input_payload_path=Path(args.input),
+        report_output_path=Path(args.report_output),
+        before_after_output_path=Path(args.before_after_output),
+        reingest_output_path=Path(args.reingest_output),
+        target_region_codes=target_codes,
+        election_id=args.election_id,
+    )
+    print(f"written: {args.report_output}")
+    print(f"written: {args.before_after_output}")
+    print(f"written: {args.reingest_output}")
+    print(f"matched_record_count={report['matched_record_count']}")
+    print(f"dead_letter_count={report['dead_letter_count']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/pipeline/contracts.py
+++ b/src/pipeline/contracts.py
@@ -60,6 +60,7 @@ POLL_OBSERVATION_SCHEMA: dict[str, Any] = {
     "required": [
         "id",
         "article_id",
+        "poll_block_id",
         "region_code",
         "office_type",
         "matchup_id",
@@ -70,6 +71,7 @@ POLL_OBSERVATION_SCHEMA: dict[str, Any] = {
         "article_id": {"type": "string"},
         "survey_name": {"type": ["string", "null"]},
         "pollster": {"type": ["string", "null"]},
+        "poll_block_id": {"type": "string"},
         "survey_start_date": {"type": ["string", "null"], "format": "date"},
         "survey_end_date": {"type": ["string", "null"], "format": "date"},
         "sample_size": {"type": ["integer", "null"]},
@@ -110,6 +112,7 @@ POLL_OPTION_SCHEMA: dict[str, Any] = {
     "required": [
         "id",
         "observation_id",
+        "poll_block_id",
         "option_type",
         "option_name",
         "candidate_id",
@@ -123,6 +126,7 @@ POLL_OPTION_SCHEMA: dict[str, Any] = {
     "properties": {
         "id": {"type": "string"},
         "observation_id": {"type": "string"},
+        "poll_block_id": {"type": "string"},
         "option_type": {"type": "string"},
         "option_name": {"type": "string"},
         "candidate_id": {"type": "string"},
@@ -198,6 +202,7 @@ class Article:
 class PollObservation:
     id: str
     article_id: str
+    poll_block_id: str
     survey_name: str | None
     pollster: str | None
     survey_start_date: str | None
@@ -236,6 +241,7 @@ class PollObservation:
 class PollOption:
     id: str
     observation_id: str
+    poll_block_id: str
     option_type: str
     option_name: str
     candidate_id: str

--- a/src/pipeline/ingest_adapter.py
+++ b/src/pipeline/ingest_adapter.py
@@ -78,6 +78,7 @@ def collector_output_to_ingest_payload(
                 "candidates": candidates,
                 "observation": {
                     "observation_key": observation.id,
+                    "poll_block_id": observation.poll_block_id,
                     "survey_name": observation.survey_name or article.title,
                     "pollster": observation.pollster or "미상조사기관",
                     "survey_start_date": observation.survey_start_date,
@@ -109,6 +110,7 @@ def collector_output_to_ingest_payload(
                     {
                         "option_type": _option_type_for_ingest(option["option_type"]),
                         "option_name": option["option_name"],
+                        "poll_block_id": option.get("poll_block_id") or observation.poll_block_id,
                         "candidate_id": option.get("candidate_id"),
                         "party_name": option.get("party_name"),
                         "scenario_key": option.get("scenario_key"),

--- a/tests/test_collector_live_news_v1_pack_script.py
+++ b/tests/test_collector_live_news_v1_pack_script.py
@@ -59,6 +59,7 @@ class FakeCollector:
         obs = PollObservation(
             id=stable_id("obs", article.id),
             article_id=article.id,
+            poll_block_id=stable_id("pblk", article.id, "한국갤럽", "2026-02-24", "서울시장"),
             survey_name=article.title,
             pollster="한국갤럽",
             survey_start_date=None,
@@ -80,6 +81,7 @@ class FakeCollector:
         opt = PollOption(
             id=stable_id("opt", article.id),
             observation_id=obs.id,
+            poll_block_id=obs.poll_block_id,
             option_type="candidate",
             option_name="정원오",
             candidate_id="cand:jungwonoh",

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -34,6 +34,8 @@ class ContractTest(unittest.TestCase):
         self.assertIn("scenario_key", POLL_OPTION_SCHEMA["properties"])
         self.assertIn("scenario_type", POLL_OPTION_SCHEMA["properties"])
         self.assertIn("scenario_title", POLL_OPTION_SCHEMA["properties"])
+        self.assertIn("poll_block_id", POLL_OBSERVATION_SCHEMA["required"])
+        self.assertIn("poll_block_id", POLL_OPTION_SCHEMA["required"])
 
     def test_normalization_contract_single(self) -> None:
         out = normalize_value("38%")

--- a/tests/test_ingest_adapter.py
+++ b/tests/test_ingest_adapter.py
@@ -48,4 +48,6 @@ def test_collector_output_converts_to_ingest_payload():
     assert parsed.records[0].observation.source_channel == "article"
     assert parsed.records[0].observation.source_channels == ["article"]
     assert parsed.records[0].observation.date_inference_mode == "relative_published_at"
+    assert parsed.records[0].observation.poll_block_id
+    assert parsed.records[0].options[0].poll_block_id == parsed.records[0].observation.poll_block_id
     assert parsed.records[0].options[0].candidate_id is not None

--- a/tests/test_issue503_poll_block_reprocess_script.py
+++ b/tests/test_issue503_poll_block_reprocess_script.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.run_issue503_poll_block_reprocess import run_reprocess
+
+
+def test_issue503_reprocess_generates_before_after_and_poll_block_checks(tmp_path: Path) -> None:
+    payload_path = tmp_path / "input.json"
+    report_path = tmp_path / "report.json"
+    before_after_path = tmp_path / "before_after.json"
+    reingest_path = tmp_path / "reingest.json"
+
+    article_title = "[부산시장] 복수조사: KSOI/리얼미터"
+    article_text = (
+        "KSOI는 2월 3~4일 조사, 표본 1000명, 응답률 10.1%, 표본오차 ±3.1%, "
+        "전재수 43.4%-박형준 32.3%, 전재수 43.8%-김도읍 33.2%, 다자대결 전재수 26.8%를 발표했다. "
+        "리얼미터는 2월 5~6일 조사, 표본 800명, 응답률 8.5%, 표본오차 ±3.5%, "
+        "전재수 41.0%-박형준 34.0%, 전재수 40.2%-김도읍 30.1%, 다자대결 전재수 24.4%를 발표했다."
+    )
+    payload = {
+        "records": [
+            {
+                "article": {
+                    "url": "https://example.com/issue503-busan",
+                    "title": article_title,
+                    "publisher": "테스트",
+                    "published_at": "2026-02-07T00:00:00+09:00",
+                    "raw_text": article_text,
+                },
+                "observation": {
+                    "observation_key": "obs-issue503-1",
+                    "region_code": "26-000",
+                    "poll_block_id": "legacy-single-block",
+                },
+                "options": [
+                    {"option_type": "candidate_matchup", "option_name": "전재수", "value_raw": "43.4%"},
+                    {"option_type": "candidate_matchup", "option_name": "박형준", "value_raw": "32.3%"},
+                ],
+            }
+        ]
+    }
+    payload_path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+
+    report = run_reprocess(
+        input_payload_path=payload_path,
+        report_output_path=report_path,
+        before_after_output_path=before_after_path,
+        reingest_output_path=reingest_path,
+        target_region_codes=("26-000", "28-450", "26-710"),
+        election_id="20260603",
+    )
+
+    assert report["matched_record_count"] == 1
+    assert report["reingest_record_count"] >= 1
+    assert report["dead_letter_count"] == 0
+    assert report["acceptance_checks"]["multi_poll_block_split_present"] is True
+    assert report["acceptance_checks"]["scenario_split_present"] is True
+    assert report["acceptance_checks"]["all_options_bound_to_poll_block"] is True
+    assert report["acceptance_checks"]["metadata_cross_contamination_zero"] is True
+
+    before_after = json.loads(before_after_path.read_text(encoding="utf-8"))
+    reingest = json.loads(reingest_path.read_text(encoding="utf-8"))
+    assert len(reingest.get("records") or []) >= 1
+    assert before_after["items"][0]["after"]["poll_block_count"] >= 2
+    observations = before_after["items"][0]["after"]["observations"]
+    assert len(observations) >= 2
+    for row in observations:
+        for opt in row["candidate_values"]:
+            assert opt["poll_block_id"] == row["poll_block_id"]


### PR DESCRIPTION
## Summary\n- poll_block_id를 observation/option 계약, 추출, ingest adapter, DB 저장 경로까지 일관 반영\n- 멀티블록 기사에서 제목 기반 시나리오 오염(cross-join) 방지 가드 추가\n- issue #503 재처리 스크립트/테스트/증빙(before_after, reingest payload, dead-letter) 추가\n\n## Linked Issue\n- Closes #503\n\n## Validation\n- PYTHONPATH=. /Users/gimtaehun/election2026_codex/.venv/bin/python -m pytest tests/test_contracts.py tests/test_collector_extract.py tests/test_ingest_adapter.py tests/test_ingest_service.py tests/test_collector_live_news_v1_pack_script.py tests/test_issue503_poll_block_reprocess_script.py tests/test_repository_*.py -q\n- 96 passed\n\n## Report\n- Collector_reports/2026-03-01_collector_issue503_poll_block_normalization_report.md\n