### PR TITLE
[DEVELOP][P0] #507 Collector Live News timeout 병목 제거

### DIFF
--- a/.github/workflows/collector-live-news-schedule.yml
+++ b/.github/workflows/collector-live-news-schedule.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   collector-live-news-ingest:
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 35
     env:
       SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
       SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
@@ -62,19 +62,71 @@ jobs:
           exit 1
 
       - name: Run ingest with retry
-        timeout-minutes: 15
+        timeout-minutes: 22
         run: |
           .venv/bin/python scripts/qa/run_ingest_with_retry.py \
             --api-base "$API_BASE_URL" \
             --input data/collector_live_news_v1_payload.json \
-            --max-retries 2 \
+            --max-retries 1 \
             --backoff-seconds 1 \
             --timeout 180 \
             --timeout-scale-on-timeout 1.5 \
             --timeout-max 360 \
             --heartbeat-interval-seconds 20 \
+            --enable-timeout-chunk-downshift \
+            --chunk-target-records 80 \
+            --chunk-min-records 15 \
+            --chunk-downshift-factor 0.5 \
+            --max-chunk-splits 8 \
+            --max-total-chunks 20 \
             --classification-artifact data/collector_live_news_v1_failure_classification.json \
             --report data/collector_live_news_v1_ingest_runner_report.json
+
+      - name: Build latency profile artifact
+        if: always()
+        run: |
+          .venv/bin/python - <<'PY'
+          import json
+          from pathlib import Path
+
+          report_path = Path("data/collector_live_news_v1_ingest_runner_report.json")
+          out_path = Path("data/collector_live_news_v1_latency_profile.json")
+
+          if not report_path.exists():
+              out_path.write_text(
+                  json.dumps(
+                      {
+                          "status": "missing_report",
+                          "report_path": str(report_path),
+                      },
+                      ensure_ascii=False,
+                      indent=2,
+                  ) + "\\n",
+                  encoding="utf-8",
+              )
+              raise SystemExit(0)
+
+          report = json.loads(report_path.read_text(encoding="utf-8"))
+          payload = {
+              "status": "ok",
+              "success": report.get("effective_success", report.get("success")),
+              "raw_success": report.get("raw_success", report.get("success")),
+              "attempt_count": len(report.get("attempts") or []),
+              "latency_profile": report.get("latency_profile") or {},
+              "chunking": {
+                  "initial_record_count": (report.get("chunking") or {}).get("initial_record_count"),
+                  "initial_chunk_count": (report.get("chunking") or {}).get("initial_chunk_count"),
+                  "completed_chunk_count": (report.get("chunking") or {}).get("completed_chunk_count"),
+                  "split_count": (report.get("chunking") or {}).get("split_count"),
+                  "max_queue_depth": (report.get("chunking") or {}).get("max_queue_depth"),
+              },
+              "failure_class": report.get("failure_class"),
+              "cause_code": report.get("cause_code"),
+              "failure_reason": report.get("failure_reason"),
+          }
+          out_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\\n", encoding="utf-8")
+          print(json.dumps(payload, ensure_ascii=False))
+          PY
 
       - name: Capture API log snapshot
         if: always()
@@ -159,6 +211,7 @@ jobs:
             data/collector_live_news_v1_review_queue_candidates.json
             data/collector_live_news_v1_ingest_runner_report.json
             data/collector_live_news_v1_failure_classification.json
+            data/collector_live_news_v1_latency_profile.json
             data/collector_live_news_api.log
             data/dead_letter/*.json
           if-no-files-found: warn

--- a/develop_report/2026-03-01_issue507_collector_live_news_schedule_timeout_bottleneck_report.md
+++ b/develop_report/2026-03-01_issue507_collector_live_news_schedule_timeout_bottleneck_report.md
@@ -1,0 +1,89 @@
+# [DEVELOP] #507 Collector Live News Schedule timeout 병목 제거 보고서
+
+- 작성일: 2026-03-01
+- 담당: role/develop
+- 이슈: https://github.com/iAmSomething/2026-/issues/507
+- 브랜치: `codex/issue507-collector-live-timeout-bottleneck`
+
+## 1) 목표
+- `Collector Live News Schedule`의 timeout_request 재발 구간에서 실패율을 낮추고 자동 축소/분할 재시도로 회복성을 확보.
+- 실패 시 원인 분류 및 dead-letter 연계를 유지하면서, 평균/95p 실행시간을 아티팩트로 남기도록 표준화.
+
+## 2) 반영 변경
+1. timeout 기반 chunk downshift 실행기 추가
+- 파일: `scripts/qa/run_ingest_with_retry.py`
+- 반영:
+  - 신규 옵션
+    - `--enable-timeout-chunk-downshift`
+    - `--chunk-target-records`
+    - `--chunk-min-records`
+    - `--chunk-downshift-factor`
+    - `--max-chunk-splits`
+    - `--max-total-chunks`
+  - 신규 로직: `execute_ingest_with_adaptive_chunks(...)`
+    - timeout 계열(`failure_class=timeout` 또는 `cause_code=timeout_request`) 실패 청크만 분할 재시도
+    - 비-timeout 실패는 즉시 종결(불필요 재시도 방지)
+    - idempotent 전제를 유지한 상태로 청크 단위 재호출
+  - 결과 리포트 확장
+    - `raw_success`, `effective_success`
+    - `chunking`(initial/completed/split/max_queue_depth)
+    - `latency_profile`(attempt/chunk avg, p95, total)
+
+2. collector live schedule 워크플로 운영값 재설계
+- 파일: `.github/workflows/collector-live-news-schedule.yml`
+- 반영:
+  - job timeout: `35m`
+  - ingest step timeout: `22m`
+  - ingest 실행 파라미터 변경
+    - `--max-retries 1`
+    - `--timeout 180 --timeout-scale-on-timeout 1.5 --timeout-max 360`
+    - downshift 활성화: `target=80`, `min=15`, `factor=0.5`, `max_splits=8`, `max_total_chunks=20`
+  - `Build latency profile artifact` 단계 추가
+    - `data/collector_live_news_v1_ingest_runner_report.json`에서 핵심 지표 추출
+    - `data/collector_live_news_v1_latency_profile.json` 생성/업로드
+
+3. 단위 테스트 확장
+- 파일: `tests/test_run_ingest_with_retry_script.py`
+- 반영:
+  - timeout 청크 분할 성공 케이스 검증
+  - non-timeout 실패 즉시 종결 케이스 검증
+  - raw/effective success 분리 검증
+
+## 3) 검증 증빙
+### A. 테스트 증빙
+- 명령:
+  - `source .venv/bin/activate && pytest -q tests/test_run_ingest_with_retry_script.py tests/test_ingest_runner.py tests/test_ingest_dead_letter_reprocess.py`
+- 결과:
+  - `17 passed in 0.12s`
+
+### B. API 응답 증빙
+- 명령(로컬 임시 기동):
+  - `.venv/bin/uvicorn app.main:app --host 127.0.0.1 --port 8111`
+  - `curl -fsS http://127.0.0.1:8111/health`
+  - `curl -fsS http://127.0.0.1:8111/health/db`
+- 결과:
+  - `/health` -> `{"status":"ok"}`
+  - `/health/db` -> `{"status":"ok","db":"ok","ping":true,"bootstrap":{"enabled":false,"attempted":false,"ok":null,"detail":"disabled"}}`
+
+### C. 워크플로 정합성 검증
+- 명령:
+  - `bash scripts/qa/validate_workflow_yaml.sh`
+- 결과:
+  - `.github/workflows/*.yml` 파싱 성공
+
+## 4) 수용기준 매핑
+1. 스케줄 3회 연속 green
+- 코드/워크플로 반영 완료.
+- 최종 확인은 PR 반영 후 `collector-live-news-schedule` 3회 연속 성공 런으로 닫음.
+
+2. 평균/95p 실행시간 보고
+- `latency_profile`를 ingest 리포트 및 별도 아티팩트(`collector_live_news_v1_latency_profile.json`)로 표준화 완료.
+
+3. timeout_request 원인 분류 및 재발방지 문서화
+- timeout 전용 분할 재시도와 non-timeout 즉시 종결을 코드에 분리 반영.
+- failure classification artifact에 `chunking_summary`, `latency_profile` 포함.
+
+## 5) 의사결정 필요 사항
+1. 수용기준의 `3회 연속 green` 판정 기준 확정 필요
+- 제안: `main` 기준 `workflow_dispatch` 3회 연속 성공을 종료 기준으로 고정
+- 대안: `main` 2회 + 정시 스케줄 1회 성공도 동일 인정

--- a/scripts/qa/run_ingest_with_retry.py
+++ b/scripts/qa/run_ingest_with_retry.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import os
 import re
 import sys
@@ -10,12 +11,13 @@ import time
 from datetime import datetime, timezone
 from hashlib import sha256
 from pathlib import Path
+from typing import Any, Callable
 
 ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from app.jobs.ingest_runner import run_ingest_with_retry, write_runner_report
+from app.jobs.ingest_runner import IngestRunnerResult, run_ingest_with_retry, write_runner_report
 
 
 def parse_args() -> argparse.Namespace:
@@ -34,6 +36,13 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--dead-letter-dir", default="data/dead_letter")
     parser.add_argument("--disable-dead-letter", action="store_true")
     parser.add_argument("--allow-partial-success", action="store_true")
+
+    parser.add_argument("--enable-timeout-chunk-downshift", action="store_true")
+    parser.add_argument("--chunk-target-records", type=int, default=0)
+    parser.add_argument("--chunk-min-records", type=int, default=20)
+    parser.add_argument("--chunk-downshift-factor", type=float, default=0.5)
+    parser.add_argument("--max-chunk-splits", type=int, default=8)
+    parser.add_argument("--max-total-chunks", type=int, default=20)
     return parser.parse_args()
 
 
@@ -50,6 +59,65 @@ def _safe_filename_fragment(value: str | None) -> str:
 def _payload_digest(payload: dict) -> str:
     raw = json.dumps(payload, ensure_ascii=False, sort_keys=True)
     return sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _nearest_rank(values: list[float], percentile: float) -> float | None:
+    clean = sorted(v for v in values if isinstance(v, (int, float)) and math.isfinite(float(v)))
+    if not clean:
+        return None
+    rank = max(1, math.ceil(len(clean) * percentile))
+    return round(float(clean[rank - 1]), 3)
+
+
+def _build_latency_profile(*, attempt_durations: list[float], chunk_durations: list[float], total_elapsed_seconds: float) -> dict[str, float | None]:
+    clean_attempts = [float(v) for v in attempt_durations if isinstance(v, (int, float)) and math.isfinite(float(v))]
+    clean_chunks = [float(v) for v in chunk_durations if isinstance(v, (int, float)) and math.isfinite(float(v))]
+    return {
+        "attempt_count": len(clean_attempts),
+        "attempt_avg_seconds": round(sum(clean_attempts) / len(clean_attempts), 3) if clean_attempts else None,
+        "attempt_p95_seconds": _nearest_rank(clean_attempts, 0.95),
+        "chunk_count": len(clean_chunks),
+        "chunk_avg_seconds": round(sum(clean_chunks) / len(clean_chunks), 3) if clean_chunks else None,
+        "chunk_p95_seconds": _nearest_rank(clean_chunks, 0.95),
+        "total_elapsed_seconds": round(total_elapsed_seconds, 3),
+    }
+
+
+def _clone_payload_with_records(payload: dict[str, Any], records: list[Any]) -> dict[str, Any]:
+    chunk_payload = dict(payload)
+    chunk_payload["records"] = list(records)
+    return chunk_payload
+
+
+def _build_initial_chunks(records: list[Any], chunk_target_records: int) -> list[list[Any]]:
+    if chunk_target_records <= 0 or len(records) <= chunk_target_records:
+        return [list(records)]
+    chunks: list[list[Any]] = []
+    for idx in range(0, len(records), chunk_target_records):
+        chunks.append(list(records[idx : idx + chunk_target_records]))
+    return chunks or [list(records)]
+
+
+def _split_records_for_downshift(records: list[Any], factor: float, min_records: int) -> tuple[list[Any], list[Any]] | None:
+    if len(records) <= max(1, min_records):
+        return None
+    bounded_factor = min(max(factor, 0.1), 0.9)
+    split_at = int(len(records) * bounded_factor)
+    split_at = max(1, min(len(records) - 1, split_at))
+    left = records[:split_at]
+    right = records[split_at:]
+    if not left or not right:
+        return None
+    return left, right
+
+
+def _is_timeout_like_failure(result: IngestRunnerResult) -> bool:
+    if result.failure_class == "timeout" or result.cause_code == "timeout_request":
+        return True
+    if not result.attempts:
+        return False
+    last = result.attempts[-1]
+    return last.failure_class == "timeout" or last.cause_code == "timeout_request"
 
 
 def write_dead_letter_record(
@@ -87,6 +155,237 @@ def is_effective_success(result, *, allow_partial_success: bool) -> bool:
     return False
 
 
+def execute_ingest_with_adaptive_chunks(
+    *,
+    api_base: str,
+    token: str,
+    payload: dict[str, Any],
+    max_retries: int,
+    backoff_seconds: float,
+    timeout: float,
+    timeout_scale_on_timeout: float,
+    timeout_max: float,
+    heartbeat_interval_seconds: float,
+    allow_partial_success: bool,
+    enable_timeout_chunk_downshift: bool,
+    chunk_target_records: int,
+    chunk_min_records: int,
+    chunk_downshift_factor: float,
+    max_chunk_splits: int,
+    max_total_chunks: int,
+    runner_fn: Callable[..., IngestRunnerResult] = run_ingest_with_retry,
+    event_log_fn: Callable[[dict[str, Any]], None] | None = None,
+) -> tuple[IngestRunnerResult, bool, bool, dict[str, Any], dict[str, Any]]:
+    records = list(payload.get("records") or [])
+    if not records:
+        result = runner_fn(
+            api_base_url=api_base,
+            token=token,
+            payload=payload,
+            max_retries=max_retries,
+            backoff_seconds=backoff_seconds,
+            request_timeout=timeout,
+            timeout_scale_on_timeout=timeout_scale_on_timeout,
+            timeout_max=timeout_max,
+            heartbeat_interval_seconds=heartbeat_interval_seconds,
+            event_log_fn=event_log_fn,
+        )
+        effective = is_effective_success(result, allow_partial_success=allow_partial_success)
+        chunking_summary = {
+            "enabled": bool(enable_timeout_chunk_downshift),
+            "initial_record_count": 0,
+            "initial_chunk_count": 1,
+            "completed_chunk_count": 1,
+            "split_count": 0,
+            "max_queue_depth": 1,
+            "chunk_target_records": chunk_target_records,
+            "chunk_min_records": chunk_min_records,
+            "chunk_downshift_factor": chunk_downshift_factor,
+            "max_chunk_splits": max_chunk_splits,
+            "max_total_chunks": max_total_chunks,
+            "chunks": [
+                {
+                    "chunk_index": 1,
+                    "record_count": 0,
+                    "effective_success": effective,
+                    "raw_success": result.success,
+                    "failure_class": result.failure_class,
+                    "cause_code": result.cause_code,
+                    "attempt_count": len(result.attempts),
+                    "elapsed_seconds": result.elapsed_seconds,
+                    "timeout_attempts": sum(1 for item in result.attempts if item.failure_class == "timeout" or item.cause_code == "timeout_request"),
+                }
+            ],
+            "split_events": [],
+            "terminated_on_chunk": None if effective else 1,
+        }
+        profile = _build_latency_profile(
+            attempt_durations=[item.duration_seconds for item in result.attempts if item.duration_seconds is not None],
+            chunk_durations=[result.elapsed_seconds or 0.0],
+            total_elapsed_seconds=result.elapsed_seconds or 0.0,
+        )
+        return result, effective, result.success, chunking_summary, profile
+
+    started_monotonic = time.monotonic()
+    queue = _build_initial_chunks(records, chunk_target_records)
+    max_queue_depth = len(queue)
+    chunks: list[dict[str, Any]] = []
+    split_events: list[dict[str, Any]] = []
+    split_count = 0
+
+    aggregated_attempts = []
+    aggregated_run_ids: list[int] = []
+    chunk_elapsed: list[float] = []
+    raw_success_all = True
+    terminal_result: IngestRunnerResult | None = None
+    chunk_index = 0
+
+    while queue:
+        max_queue_depth = max(max_queue_depth, len(queue))
+        chunk_records = queue.pop(0)
+        chunk_index += 1
+
+        chunk_payload = _clone_payload_with_records(payload, chunk_records)
+        chunk_result = runner_fn(
+            api_base_url=api_base,
+            token=token,
+            payload=chunk_payload,
+            max_retries=max_retries,
+            backoff_seconds=backoff_seconds,
+            request_timeout=timeout,
+            timeout_scale_on_timeout=timeout_scale_on_timeout,
+            timeout_max=timeout_max,
+            heartbeat_interval_seconds=heartbeat_interval_seconds,
+            event_log_fn=event_log_fn,
+        )
+        chunk_effective_success = is_effective_success(chunk_result, allow_partial_success=allow_partial_success)
+        timeout_attempts = sum(
+            1
+            for item in chunk_result.attempts
+            if item.failure_class == "timeout" or item.cause_code == "timeout_request"
+        )
+
+        aggregated_attempts.extend(chunk_result.attempts)
+        aggregated_run_ids.extend(chunk_result.run_ids)
+        if chunk_result.elapsed_seconds is not None:
+            chunk_elapsed.append(chunk_result.elapsed_seconds)
+
+        chunk_meta = {
+            "chunk_index": chunk_index,
+            "record_count": len(chunk_records),
+            "effective_success": chunk_effective_success,
+            "raw_success": chunk_result.success,
+            "failure_class": chunk_result.failure_class,
+            "failure_type": chunk_result.failure_type,
+            "cause_code": chunk_result.cause_code,
+            "failure_reason": chunk_result.failure_reason,
+            "attempt_count": len(chunk_result.attempts),
+            "elapsed_seconds": chunk_result.elapsed_seconds,
+            "timeout_attempts": timeout_attempts,
+            "run_ids": chunk_result.run_ids,
+        }
+        chunks.append(chunk_meta)
+
+        if chunk_effective_success:
+            raw_success_all = raw_success_all and chunk_result.success
+            continue
+
+        can_split = (
+            enable_timeout_chunk_downshift
+            and _is_timeout_like_failure(chunk_result)
+            and len(chunk_records) > max(1, chunk_min_records)
+            and split_count < max(0, max_chunk_splits)
+            and (len(queue) + 2) <= max(1, max_total_chunks)
+        )
+
+        if can_split:
+            split_pair = _split_records_for_downshift(
+                chunk_records,
+                factor=chunk_downshift_factor,
+                min_records=chunk_min_records,
+            )
+            if split_pair is not None:
+                left, right = split_pair
+                queue = [left, right, *queue]
+                split_count += 1
+                split_events.append(
+                    {
+                        "chunk_index": chunk_index,
+                        "source_record_count": len(chunk_records),
+                        "left_record_count": len(left),
+                        "right_record_count": len(right),
+                        "reason": "timeout_request",
+                    }
+                )
+                continue
+
+        terminal_result = chunk_result
+        raw_success_all = False
+        break
+
+    elapsed_seconds = round(time.monotonic() - started_monotonic, 3)
+
+    if terminal_result is not None:
+        combined = IngestRunnerResult(
+            success=False,
+            attempts=aggregated_attempts,
+            run_ids=aggregated_run_ids,
+            started_at=aggregated_attempts[0].started_at if aggregated_attempts else datetime.now(timezone.utc).isoformat(),
+            finished_at=datetime.now(timezone.utc).isoformat(),
+            elapsed_seconds=elapsed_seconds,
+            failure_class=terminal_result.failure_class,
+            failure_type=terminal_result.failure_type,
+            cause_code=terminal_result.cause_code,
+            failure_reason=terminal_result.failure_reason,
+        )
+        effective_success = False
+    else:
+        if raw_success_all:
+            failure_class = None
+            failure_type = None
+            cause_code = None
+        else:
+            failure_class = "job_partial_success"
+            failure_type = "job_partial_success"
+            cause_code = "job_partial_success"
+        combined = IngestRunnerResult(
+            success=raw_success_all,
+            attempts=aggregated_attempts,
+            run_ids=aggregated_run_ids,
+            started_at=aggregated_attempts[0].started_at if aggregated_attempts else datetime.now(timezone.utc).isoformat(),
+            finished_at=datetime.now(timezone.utc).isoformat(),
+            elapsed_seconds=elapsed_seconds,
+            failure_class=failure_class,
+            failure_type=failure_type,
+            cause_code=cause_code,
+            failure_reason=None,
+        )
+        effective_success = is_effective_success(combined, allow_partial_success=allow_partial_success)
+
+    chunking_summary = {
+        "enabled": bool(enable_timeout_chunk_downshift),
+        "initial_record_count": len(records),
+        "initial_chunk_count": len(_build_initial_chunks(records, chunk_target_records)),
+        "completed_chunk_count": len(chunks),
+        "split_count": split_count,
+        "max_queue_depth": max_queue_depth,
+        "chunk_target_records": chunk_target_records,
+        "chunk_min_records": chunk_min_records,
+        "chunk_downshift_factor": chunk_downshift_factor,
+        "max_chunk_splits": max_chunk_splits,
+        "max_total_chunks": max_total_chunks,
+        "chunks": chunks,
+        "split_events": split_events,
+        "terminated_on_chunk": (chunks[-1]["chunk_index"] if terminal_result is not None and chunks else None),
+    }
+    latency_profile = _build_latency_profile(
+        attempt_durations=[item.duration_seconds for item in aggregated_attempts if item.duration_seconds is not None],
+        chunk_durations=chunk_elapsed,
+        total_elapsed_seconds=elapsed_seconds,
+    )
+    return combined, effective_success, raw_success_all, chunking_summary, latency_profile
+
+
 def write_failure_classification_artifact(
     *,
     path: str | Path,
@@ -96,6 +395,8 @@ def write_failure_classification_artifact(
     success: bool,
     raw_success: bool,
     dead_letter_path: str | None,
+    chunking_summary: dict[str, Any] | None = None,
+    latency_profile: dict[str, Any] | None = None,
 ) -> Path:
     target = Path(path)
     target.parent.mkdir(parents=True, exist_ok=True)
@@ -152,6 +453,10 @@ def write_failure_classification_artifact(
         "dead_letter_path": dead_letter_path,
         "attempt_timeline": attempt_timeline,
     }
+    if chunking_summary is not None:
+        artifact["chunking_summary"] = chunking_summary
+    if latency_profile is not None:
+        artifact["latency_profile"] = latency_profile
     target.write_text(json.dumps(artifact, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
     return target
 
@@ -205,6 +510,7 @@ def main() -> int:
         raise RuntimeError("INTERNAL_JOB_TOKEN is required")
 
     payload = json.loads(Path(args.input).read_text(encoding="utf-8"))
+
     def _emit_heartbeat(event: dict) -> None:
         print(
             json.dumps(
@@ -226,35 +532,58 @@ def main() -> int:
                 "ts": datetime.now(timezone.utc).isoformat(),
                 "source_input_path": args.input,
                 "report_path": args.report,
+                "record_count": len(payload.get("records") or []),
             },
             ensure_ascii=False,
         ),
         flush=True,
     )
 
-    result = run_ingest_with_retry(
-        api_base_url=args.api_base,
+    result, success, raw_success, chunking_summary, latency_profile = execute_ingest_with_adaptive_chunks(
+        api_base=args.api_base,
         token=token,
         payload=payload,
         max_retries=args.max_retries,
         backoff_seconds=args.backoff_seconds,
-        request_timeout=args.timeout,
+        timeout=args.timeout,
         timeout_scale_on_timeout=args.timeout_scale_on_timeout,
         timeout_max=args.timeout_max,
         heartbeat_interval_seconds=args.heartbeat_interval_seconds,
+        allow_partial_success=args.allow_partial_success,
+        enable_timeout_chunk_downshift=args.enable_timeout_chunk_downshift,
+        chunk_target_records=args.chunk_target_records,
+        chunk_min_records=args.chunk_min_records,
+        chunk_downshift_factor=args.chunk_downshift_factor,
+        max_chunk_splits=args.max_chunk_splits,
+        max_total_chunks=args.max_total_chunks,
         event_log_fn=_emit_heartbeat,
     )
+
     write_runner_report(args.report, result)
-    success = is_effective_success(result, allow_partial_success=args.allow_partial_success)
+    report_json = json.loads(Path(args.report).read_text(encoding="utf-8"))
+    report_json["raw_success"] = raw_success
+    report_json["effective_success"] = success
+    report_json["chunking"] = chunking_summary
+    report_json["latency_profile"] = latency_profile
+    Path(args.report).write_text(json.dumps(report_json, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
     output = {
         "success": success,
-        "raw_success": result.success,
+        "raw_success": raw_success,
         "report": args.report,
         "attempt_count": len(result.attempts),
         "failure_class": result.failure_class,
         "failure_type": result.failure_type,
         "cause_code": result.cause_code,
         "failure_reason": result.failure_reason,
+        "chunking": {
+            "initial_record_count": chunking_summary.get("initial_record_count"),
+            "initial_chunk_count": chunking_summary.get("initial_chunk_count"),
+            "completed_chunk_count": chunking_summary.get("completed_chunk_count"),
+            "split_count": chunking_summary.get("split_count"),
+            "max_queue_depth": chunking_summary.get("max_queue_depth"),
+        },
+        "latency_profile": latency_profile,
     }
     if result.attempts:
         last = result.attempts[-1]
@@ -266,7 +595,7 @@ def main() -> int:
             "error": last.error,
             "detail": last.detail,
         }
-    if success and not result.success:
+    if success and not raw_success:
         output["accepted_partial_success"] = True
 
     dead_letter_path: str | None = None
@@ -284,13 +613,15 @@ def main() -> int:
     if args.classification_artifact:
         artifact_path = str(
             write_failure_classification_artifact(
-            path=args.classification_artifact,
-            source_input_path=args.input,
-            payload=payload,
-            result=result,
-            success=success,
-            raw_success=result.success,
-            dead_letter_path=dead_letter_path,
+                path=args.classification_artifact,
+                source_input_path=args.input,
+                payload=payload,
+                result=result,
+                success=success,
+                raw_success=raw_success,
+                dead_letter_path=dead_letter_path,
+                chunking_summary=chunking_summary,
+                latency_profile=latency_profile,
             )
         )
         output["classification_artifact"] = artifact_path
@@ -303,6 +634,7 @@ def main() -> int:
             result=result,
         )
         output["comment_template_path"] = str(template_path)
+
     output["elapsed_seconds"] = round(time.monotonic() - started_monotonic, 3)
     print(json.dumps(output, ensure_ascii=False))
     return 0 if success else 1

--- a/tests/test_run_ingest_with_retry_script.py
+++ b/tests/test_run_ingest_with_retry_script.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from app.jobs.ingest_runner import AttemptLog, IngestRunnerResult
 from scripts.qa.run_ingest_with_retry import (
+    execute_ingest_with_adaptive_chunks,
     is_effective_success,
     write_failure_classification_artifact,
     write_failure_comment_template,
@@ -31,6 +32,41 @@ def _result(*, success: bool, failure_class: str | None) -> IngestRunnerResult:
         failure_class=failure_class,
         failure_type=failure_class,
         cause_code=failure_class,
+        failure_reason=None,
+    )
+
+
+def _result_with_records(
+    *,
+    success: bool,
+    failure_class: str | None,
+    cause_code: str | None = None,
+    elapsed_seconds: float = 1.0,
+) -> IngestRunnerResult:
+    return IngestRunnerResult(
+        success=success,
+        attempts=[
+            AttemptLog(
+                attempt=1,
+                http_status=200 if success else 503,
+                job_status="success" if success else "failed",
+                failure_class=failure_class,
+                failure_type=failure_class,
+                cause_code=cause_code,
+                retryable=False,
+                request_timeout_seconds=30.0,
+                duration_seconds=elapsed_seconds,
+                started_at="2026-02-24T00:00:00+00:00",
+                finished_at="2026-02-24T00:00:01+00:00",
+            )
+        ],
+        run_ids=[1] if success else [],
+        started_at="2026-02-24T00:00:00+00:00",
+        finished_at="2026-02-24T00:00:01+00:00",
+        elapsed_seconds=elapsed_seconds,
+        failure_class=failure_class,
+        failure_type=failure_class,
+        cause_code=cause_code,
         failure_reason=None,
     )
 
@@ -85,3 +121,85 @@ def test_write_failure_comment_template(tmp_path: Path) -> None:
     assert "[DEVELOP][INGEST FAILURE TEMPLATE]" in text
     assert "classification_artifact" in text
     assert "next_status: status/in-progress" in text
+
+
+def test_execute_ingest_with_adaptive_chunks_splits_timeout_chunk() -> None:
+    def runner_fn(**kwargs):  # noqa: ANN003
+        count = len(kwargs["payload"]["records"])
+        if count > 20:
+            return _result_with_records(
+                success=False,
+                failure_class="timeout",
+                cause_code="timeout_request",
+                elapsed_seconds=3.0,
+            )
+        return _result_with_records(success=True, failure_class=None, elapsed_seconds=1.2)
+
+    payload = {"run_type": "collector_live_news_v1", "records": list(range(40))}
+    result, effective_success, raw_success, chunking_summary, latency_profile = execute_ingest_with_adaptive_chunks(
+        api_base="http://127.0.0.1:8100",
+        token="token",
+        payload=payload,
+        max_retries=0,
+        backoff_seconds=1.0,
+        timeout=60.0,
+        timeout_scale_on_timeout=1.5,
+        timeout_max=180.0,
+        heartbeat_interval_seconds=0.0,
+        allow_partial_success=False,
+        enable_timeout_chunk_downshift=True,
+        chunk_target_records=0,
+        chunk_min_records=10,
+        chunk_downshift_factor=0.5,
+        max_chunk_splits=4,
+        max_total_chunks=10,
+        runner_fn=runner_fn,
+    )
+
+    assert effective_success is True
+    assert raw_success is True
+    assert result.success is True
+    assert result.failure_class is None
+    assert chunking_summary["split_count"] == 1
+    assert chunking_summary["completed_chunk_count"] == 3
+    assert latency_profile["attempt_count"] == 3
+    assert latency_profile["chunk_count"] == 3
+
+
+def test_execute_ingest_with_adaptive_chunks_keeps_non_timeout_failure() -> None:
+    def runner_fn(**kwargs):  # noqa: ANN003
+        _ = kwargs
+        return _result_with_records(
+            success=False,
+            failure_class="http_5xx",
+            cause_code="http_503",
+            elapsed_seconds=2.0,
+        )
+
+    payload = {"run_type": "collector_live_news_v1", "records": list(range(30))}
+    result, effective_success, raw_success, chunking_summary, latency_profile = execute_ingest_with_adaptive_chunks(
+        api_base="http://127.0.0.1:8100",
+        token="token",
+        payload=payload,
+        max_retries=0,
+        backoff_seconds=1.0,
+        timeout=60.0,
+        timeout_scale_on_timeout=1.5,
+        timeout_max=180.0,
+        heartbeat_interval_seconds=0.0,
+        allow_partial_success=False,
+        enable_timeout_chunk_downshift=True,
+        chunk_target_records=0,
+        chunk_min_records=10,
+        chunk_downshift_factor=0.5,
+        max_chunk_splits=4,
+        max_total_chunks=10,
+        runner_fn=runner_fn,
+    )
+
+    assert effective_success is False
+    assert raw_success is False
+    assert result.failure_class == "http_5xx"
+    assert chunking_summary["split_count"] == 0
+    assert chunking_summary["completed_chunk_count"] == 1
+    assert latency_profile["attempt_count"] == 1


### PR DESCRIPTION
## Summary
- collector live ingest 경로에 timeout 전용 chunk downshift(분할 재시도) 추가
- workflow timeout/retry/다운시프트 파라미터 재설계 및 latency profile 아티팩트 추가
- timeout/non-timeout 분기 회귀 테스트 보강

## Report-Path
Report-Path: develop_report/2026-03-01_issue507_collector_live_news_schedule_timeout_bottleneck_report.md

## Changes
- scripts/qa/run_ingest_with_retry.py
- .github/workflows/collector-live-news-schedule.yml
- tests/test_run_ingest_with_retry_script.py
- develop_report/2026-03-01_issue507_collector_live_news_schedule_timeout_bottleneck_report.md

## Validation
- pytest -q tests/test_run_ingest_with_retry_script.py tests/test_ingest_runner.py tests/test_ingest_dead_letter_reprocess.py
- bash scripts/qa/validate_workflow_yaml.sh
- local API health check (/health, /health/db)

## Issue
- Closes #507